### PR TITLE
New `CARDANO_CLI_VISIBILITY_LEVEL` environment variable

### DIFF
--- a/cardano-cli/app/cardano-cli.hs
+++ b/cardano-cli/app/cardano-cli.hs
@@ -6,7 +6,7 @@
 #endif
 
 import           Cardano.Api
-import           Cardano.CLI.Environment (getEnvCli)
+import           Cardano.CLI.Environment (getCliVisibilityLevel, getEnvCli)
 import           Cardano.CLI.Option (opts, pref)
 import           Cardano.CLI.Run (renderClientCommandError, runClientCommand)
 import           Cardano.CLI.TopHandler
@@ -26,10 +26,12 @@ main = toplevelExceptionHandler $ do
 
   envCli <- getEnvCli
 
+  visibility <- getCliVisibilityLevel
+
   GHC.mkTextEncoding "UTF-8" >>= GHC.setLocaleEncoding
 #ifdef UNIX
   _ <- setFileCreationMask (otherModes `unionFileModes` groupModes)
 #endif
-  co <- Opt.customExecParser pref (opts envCli)
+  co <- Opt.customExecParser pref (opts visibility envCli)
 
   orDie (docToText . renderClientCommandError) $ runClientCommand co

--- a/cardano-cli/src/Cardano/CLI/Byron/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parser.hs
@@ -70,7 +70,13 @@ backwardsCompatibilityCommands envCli =
   asum hiddenCmds
  where
   convertToByronCommand :: Mod CommandFields ByronCommand -> Parser ClientCommand
-  convertToByronCommand p = ByronCommand <$> Opt.subparser (p <> Opt.internal)
+  convertToByronCommand p =
+    fmap ByronCommand $
+      Opt.subparser $
+        mconcat
+          [ p
+          , Opt.internal
+          ]
 
   hiddenCmds :: [Parser ClientCommand]
   hiddenCmds =
@@ -119,7 +125,12 @@ parseByronCommands envCli =
   subParser' name pInfo = Opt.subparser $ commandWithMetavar name pInfo
 
 pNodeCmdBackwardCompatible :: EnvCli -> Parser NodeCmds
-pNodeCmdBackwardCompatible envCli = Opt.subparser $ pNodeCmds envCli <> Opt.internal
+pNodeCmdBackwardCompatible envCli =
+  Opt.subparser $
+    mconcat
+      [ pNodeCmds envCli
+      , Opt.internal
+      ]
 
 parseCBORObject :: Parser CBORObject
 parseCBORObject =

--- a/cardano-cli/src/Cardano/CLI/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/Command.hs
@@ -17,7 +17,7 @@ import Cardano.CLI.EraIndependent.Node.Command
 import Cardano.CLI.EraIndependent.Ping.Command (PingCmd)
 import Cardano.CLI.Legacy.Command
 
-import Options.Applicative.Types (ParserInfo (..), ParserPrefs (..))
+import Options.Applicative.Types (OptVisibility (..), ParserInfo (..), ParserPrefs (..))
 
 -- | Sub-commands of 'cardano-cli'.
 data ClientCommand
@@ -39,5 +39,5 @@ data ClientCommand
     LegacyCmds LegacyCmds
   | CliPingCommand PingCmd
   | CliDebugCmds DebugCmds
-  | forall a. Help ParserPrefs (ParserInfo a)
+  | forall a. Help OptVisibility ParserPrefs (ParserInfo a)
   | DisplayVersion

--- a/cardano-cli/src/Cardano/CLI/Environment.hs
+++ b/cardano-cli/src/Cardano/CLI/Environment.hs
@@ -8,6 +8,7 @@ module Cardano.CLI.Environment
   , getEnvCli
   , getEnvNetworkId
   , getEnvSocketPath
+  , getCliVisibilityLevel
   )
 where
 
@@ -21,8 +22,10 @@ import Cardano.Api
   , forEraInEonMaybe
   )
 
+import Data.Char (toLower)
 import Data.Typeable
 import Data.Word (Word32)
+import Options.Applicative.Types (OptVisibility (..))
 import System.Environment qualified as IO
 import System.IO qualified as IO
 import Text.Read (readMaybe)
@@ -72,6 +75,19 @@ getEnvNetworkId = do
                   , " It should be either 'mainnet' or a number."
                   ]
               pure Nothing
+
+getCliVisibilityLevel :: IO OptVisibility
+getCliVisibilityLevel = do
+  mVisibillityString <- IO.lookupEnv "CARDANO_CLI_VISIBILITY_LEVEL"
+
+  pure $ case mVisibillityString of
+    Nothing -> Visible
+    Just visibilityString ->
+      case fmap toLower visibilityString of
+        "internal" -> Internal
+        "hidden" -> Hidden
+        "visible" -> Visible
+        _ -> Visible
 
 -- | If the environment variable @CARDANO_NODE_SOCKET_PATH@ is set, then return the set value.
 -- Otherwise, return 'Nothing'.

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -320,11 +320,16 @@ pScriptFor name Nothing help' =
   fmap File $ parseFilePath name help'
 pScriptFor name (Just deprecated) help' =
   pScriptFor name Nothing help'
-    <|> File
-    <$> Opt.strOption
-      ( Opt.long deprecated
-          <> Opt.internal
-      )
+    <|> pScriptFile deprecated
+
+pScriptFile :: String -> Parser (File content direction)
+pScriptFile deprecated =
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long deprecated
+        , Opt.internal
+        ]
 
 -- | The first argument is the optional prefix.
 pStakeVerificationKey :: Maybe String -> Parser (VerificationKey StakeKey)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
@@ -128,7 +128,10 @@ calcMinValueInfo era' =
 pCalculateMinRequiredUtxoBackwardCompatible :: ShelleyBasedEra era -> Parser (TransactionCmds era)
 pCalculateMinRequiredUtxoBackwardCompatible era' =
   Opt.subparser $
-    Opt.command "calculate-min-value" (calcMinValueInfo era') <> Opt.internal
+    mconcat
+      [ Opt.command "calculate-min-value" (calcMinValueInfo era')
+      , Opt.internal
+      ]
 
 assembleInfo :: ParserInfo (TransactionCmds era)
 assembleInfo =
@@ -138,7 +141,10 @@ assembleInfo =
 pSignWitnessBackwardCompatible :: Parser (TransactionCmds era)
 pSignWitnessBackwardCompatible =
   Opt.subparser $
-    Opt.command "sign-witness" assembleInfo <> Opt.internal
+    mconcat
+      [ Opt.command "sign-witness" assembleInfo
+      , Opt.internal
+      ]
 
 pScriptValidity :: Parser ScriptValidity
 pScriptValidity =

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
@@ -3,7 +3,9 @@
 {- HLINT ignore "Redundant id" -}
 
 module Test.Golden.Help
-  ( hprop_golden_HelpAll
+  ( hprop_golden_HelpAllVisible
+  , hprop_golden_HelpAllHidden
+  , hprop_golden_HelpAllInternal
   , hprop_golden_HelpCmds
   )
 where
@@ -50,16 +52,52 @@ extractCmd =
       (c : _) -> Char.isAlpha c
       [] -> False
 
--- | Test that converting a @cardano-address@ Byron signing key yields the
--- expected result.
-hprop_golden_HelpAll :: Property
-hprop_golden_HelpAll =
+hprop_golden_HelpAllVisible :: Property
+hprop_golden_HelpAllVisible =
   propertyOnce . H.moduleWorkspace "help" $ \_ -> do
     -- These tests are not run on Windows because the cardano-cli usage
     -- output is slightly different on Windows.  For example it uses
     -- "cardano-cli.exe" instead of "cardano-cli".
     unless isWin32 $ do
       helpFp <- H.note "test/cardano-cli-golden/files/golden/help.cli"
+
+      help <-
+        filterAnsi
+          <$> execCardanoCLIWithEnvVars
+            [ ("CARDANO_CLI_VISIBILITY_LEVEL", "visible")
+            ]
+            [ "help"
+            ]
+
+      H.diffVsGoldenFile help helpFp
+
+hprop_golden_HelpAllHidden :: Property
+hprop_golden_HelpAllHidden =
+  propertyOnce . H.moduleWorkspace "help" $ \_ -> do
+    -- These tests are not run on Windows because the cardano-cli usage
+    -- output is slightly different on Windows.  For example it uses
+    -- "cardano-cli.exe" instead of "cardano-cli".
+    unless isWin32 $ do
+      helpFp <- H.note "test/cardano-cli-golden/files/golden/help-hidden.cli"
+
+      help <-
+        filterAnsi
+          <$> execCardanoCLIWithEnvVars
+            [ ("CARDANO_CLI_VISIBILITY_LEVEL", "hidden")
+            ]
+            [ "help"
+            ]
+
+      H.diffVsGoldenFile help helpFp
+
+hprop_golden_HelpAllInternal :: Property
+hprop_golden_HelpAllInternal =
+  propertyOnce . H.moduleWorkspace "help" $ \_ -> do
+    -- These tests are not run on Windows because the cardano-cli usage
+    -- output is slightly different on Windows.  For example it uses
+    -- "cardano-cli.exe" instead of "cardano-cli".
+    unless isWin32 $ do
+      helpFp <- H.note "test/cardano-cli-golden/files/golden/help-internal.cli"
 
       help <-
         filterAnsi

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
@@ -19,7 +19,7 @@ import Data.Text qualified as Text
 import System.FilePath ((</>))
 import Text.Regex (Regex, mkRegex, subRegex)
 
-import Test.Cardano.CLI.Util (execCardanoCLI, propertyOnce)
+import Test.Cardano.CLI.Util (execCardanoCLIWithEnvVars, propertyOnce)
 import Test.Cardano.CLI.Util qualified as H
 
 import Hedgehog (Property)
@@ -63,7 +63,9 @@ hprop_golden_HelpAll =
 
       help <-
         filterAnsi
-          <$> execCardanoCLI
+          <$> execCardanoCLIWithEnvVars
+            [ ("CARDANO_CLI_VISIBILITY_LEVEL", "internal")
+            ]
             [ "help"
             ]
 
@@ -97,7 +99,9 @@ hprop_golden_HelpCmds =
     unless isWin32 $ do
       help <-
         filterAnsi
-          <$> execCardanoCLI
+          <$> execCardanoCLIWithEnvVars
+            [ ("CARDANO_CLI_VISIBILITY_LEVEL", "internal")
+            ]
             [ "help"
             ]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help-hidden.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help-hidden.cli
@@ -367,6 +367,19 @@ Usage: cardano-cli query stake-snapshot [--cardano-mode [--epoch-slots SLOTS]]
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
+Usage: cardano-cli query pool-params [--cardano-mode [--epoch-slots SLOTS]]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
+                                       [--volatile-tip | --immutable-tip]
+                                       ( --all-stake-pools
+                                       | (--stake-pool-id STAKE_POOL_ID)
+                                       )
+                                       [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
 Usage: cardano-cli query leadership-schedule 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
@@ -1512,6 +1525,22 @@ Usage: cardano-cli shelley query stake-snapshot
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
+Usage: cardano-cli shelley query pool-params 
+                                               [--cardano-mode
+                                                 [--epoch-slots SLOTS]]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               --socket-path SOCKET_PATH
+                                               ( --all-stake-pools
+                                               | (--stake-pool-id STAKE_POOL_ID)
+                                               )
+                                               [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
 Usage: cardano-cli shelley query leadership-schedule 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
@@ -2572,6 +2601,22 @@ Usage: cardano-cli allegra query stake-snapshot
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
+Usage: cardano-cli allegra query pool-params 
+                                               [--cardano-mode
+                                                 [--epoch-slots SLOTS]]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               --socket-path SOCKET_PATH
+                                               ( --all-stake-pools
+                                               | (--stake-pool-id STAKE_POOL_ID)
+                                               )
+                                               [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
 Usage: cardano-cli allegra query leadership-schedule 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
@@ -3627,6 +3672,20 @@ Usage: cardano-cli mary query stake-snapshot
 
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
+
+Usage: cardano-cli mary query pool-params [--cardano-mode [--epoch-slots SLOTS]]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+                                            --socket-path SOCKET_PATH
+                                            ( --all-stake-pools
+                                            | (--stake-pool-id STAKE_POOL_ID)
+                                            )
+                                            [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
 
 Usage: cardano-cli mary query leadership-schedule 
                                                     [--cardano-mode
@@ -4699,6 +4758,22 @@ Usage: cardano-cli alonzo query stake-snapshot
 
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
+
+Usage: cardano-cli alonzo query pool-params 
+                                              [--cardano-mode
+                                                [--epoch-slots SLOTS]]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              --socket-path SOCKET_PATH
+                                              ( --all-stake-pools
+                                              | (--stake-pool-id STAKE_POOL_ID)
+                                              )
+                                              [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
 
 Usage: cardano-cli alonzo query leadership-schedule 
                                                       [--cardano-mode
@@ -5826,6 +5901,22 @@ Usage: cardano-cli babbage query stake-snapshot
 
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
+
+Usage: cardano-cli babbage query pool-params 
+                                               [--cardano-mode
+                                                 [--epoch-slots SLOTS]]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               --socket-path SOCKET_PATH
+                                               ( --all-stake-pools
+                                               | (--stake-pool-id STAKE_POOL_ID)
+                                               )
+                                               [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
 
 Usage: cardano-cli babbage query leadership-schedule 
                                                        [--cardano-mode
@@ -7526,6 +7617,23 @@ Usage: cardano-cli conway query stake-snapshot
 
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
+
+Usage: cardano-cli conway query pool-params 
+                                              [--cardano-mode
+                                                [--epoch-slots SLOTS]]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              --socket-path SOCKET_PATH
+                                              [--volatile-tip | --immutable-tip]
+                                              ( --all-stake-pools
+                                              | (--stake-pool-id STAKE_POOL_ID)
+                                              )
+                                              [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
 
 Usage: cardano-cli conway query leadership-schedule 
                                                       [--cardano-mode
@@ -9611,6 +9719,23 @@ Usage: cardano-cli latest query stake-snapshot
 
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
+
+Usage: cardano-cli latest query pool-params 
+                                              [--cardano-mode
+                                                [--epoch-slots SLOTS]]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              --socket-path SOCKET_PATH
+                                              [--volatile-tip | --immutable-tip]
+                                              ( --all-stake-pools
+                                              | (--stake-pool-id STAKE_POOL_ID)
+                                              )
+                                              [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
 
 Usage: cardano-cli latest query leadership-schedule 
                                                       [--cardano-mode

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help-internal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help-internal.cli
@@ -367,6 +367,19 @@ Usage: cardano-cli query stake-snapshot [--cardano-mode [--epoch-slots SLOTS]]
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
+Usage: cardano-cli query pool-params [--cardano-mode [--epoch-slots SLOTS]]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
+                                       [--volatile-tip | --immutable-tip]
+                                       ( --all-stake-pools
+                                       | (--stake-pool-id STAKE_POOL_ID)
+                                       )
+                                       [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
 Usage: cardano-cli query leadership-schedule 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
@@ -937,6 +950,66 @@ Usage: cardano-cli byron miscellaneous validate-cbor
 Usage: cardano-cli byron miscellaneous pretty-print-cbor --filepath FILEPATH
 
   Pretty print a CBOR file.
+
+Usage: cardano-cli byron submit-proposal-vote --socket-path SOCKET_PATH
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --filepath FILEPATH
+
+  Submit a proposal vote.
+
+Usage: cardano-cli byron submit-update-proposal --socket-path SOCKET_PATH
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  --filepath FILEPATH
+
+  Submit an update proposal.
+
+Usage: cardano-cli byron create-proposal-vote 
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --signing-key FILEPATH
+                                                --proposal-filepath FILEPATH
+                                                (--vote-yes | --vote-no)
+                                                --output-filepath FILEPATH
+
+  Create an update proposal vote.
+
+Usage: cardano-cli byron create-update-proposal 
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  --signing-key FILEPATH
+                                                  --protocol-version-major WORD16
+                                                  --protocol-version-minor WORD16
+                                                  --protocol-version-alt WORD8
+                                                  --application-name STRING
+                                                  --software-version-num WORD32
+                                                  --system-tag STRING
+                                                  --installer-hash HASH
+                                                  --filepath FILEPATH
+                                                  [--script-version WORD16]
+                                                  [--slot-duration NATURAL]
+                                                  [--max-block-size NATURAL]
+                                                  [--max-header-size NATURAL]
+                                                  [--max-tx-size NATURAL]
+                                                  [--max-proposal-size NATURAL]
+                                                  [--max-mpc-thd DOUBLE]
+                                                  [--heavy-del-thd DOUBLE]
+                                                  [--update-vote-thd DOUBLE]
+                                                  [--update-proposal-thd DOUBLE]
+                                                  [--time-to-live WORD64]
+                                                  [--softfork-init-thd DOUBLE
+                                                    --softfork-min-thd DOUBLE
+                                                    --softfork-thd-dec DOUBLE]
+                                                  [--tx-fee-a-constant INT
+                                                    --tx-fee-b-constant DOUBLE]
+                                                  [--unlock-stake-epoch WORD64]
+
+  Create an update proposal.
 
 Usage: cardano-cli shelley 
                              ( address
@@ -1512,6 +1585,22 @@ Usage: cardano-cli shelley query stake-snapshot
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
+Usage: cardano-cli shelley query pool-params 
+                                               [--cardano-mode
+                                                 [--epoch-slots SLOTS]]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               --socket-path SOCKET_PATH
+                                               ( --all-stake-pools
+                                               | (--stake-pool-id STAKE_POOL_ID)
+                                               )
+                                               [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
 Usage: cardano-cli shelley query leadership-schedule 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
@@ -1920,6 +2009,12 @@ Usage: cardano-cli shelley transaction assemble --tx-body-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
+Usage: cardano-cli shelley transaction sign-witness --tx-body-file FILEPATH
+                                                      [--witness-file FILEPATH]
+                                                      --out-file FILEPATH
+
+  Assemble a tx body and witness(es) to form a transaction
+
 Usage: cardano-cli shelley transaction submit 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
@@ -1981,6 +2076,23 @@ Usage: cardano-cli shelley transaction calculate-plutus-script-cost
                                                                       [--out-file FILEPATH]
 
   Calculate the costs of the Plutus scripts of a given transaction.
+
+Usage: cardano-cli shelley transaction calculate-min-value --protocol-params-file FILEPATH
+                                                             --tx-out ADDRESS VALUE
+                                                             [ --tx-out-datum-hash HASH
+                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-hash-file JSON_FILE
+                                                             | --tx-out-datum-hash-value JSON_VALUE
+                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-embed-file JSON_FILE
+                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-inline-datum-file JSON_FILE
+                                                             | --tx-out-inline-datum-value JSON_VALUE
+                                                             ]
+                                                             [--tx-out-reference-script-file FILEPATH]
+
+  DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli shelley transaction hash-script-data 
                                                           ( --script-data-cbor-file CBOR_FILE
@@ -2572,6 +2684,22 @@ Usage: cardano-cli allegra query stake-snapshot
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
+Usage: cardano-cli allegra query pool-params 
+                                               [--cardano-mode
+                                                 [--epoch-slots SLOTS]]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               --socket-path SOCKET_PATH
+                                               ( --all-stake-pools
+                                               | (--stake-pool-id STAKE_POOL_ID)
+                                               )
+                                               [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
 Usage: cardano-cli allegra query leadership-schedule 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
@@ -2980,6 +3108,12 @@ Usage: cardano-cli allegra transaction assemble --tx-body-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
+Usage: cardano-cli allegra transaction sign-witness --tx-body-file FILEPATH
+                                                      [--witness-file FILEPATH]
+                                                      --out-file FILEPATH
+
+  Assemble a tx body and witness(es) to form a transaction
+
 Usage: cardano-cli allegra transaction submit 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
@@ -3041,6 +3175,23 @@ Usage: cardano-cli allegra transaction calculate-plutus-script-cost
                                                                       [--out-file FILEPATH]
 
   Calculate the costs of the Plutus scripts of a given transaction.
+
+Usage: cardano-cli allegra transaction calculate-min-value --protocol-params-file FILEPATH
+                                                             --tx-out ADDRESS VALUE
+                                                             [ --tx-out-datum-hash HASH
+                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-hash-file JSON_FILE
+                                                             | --tx-out-datum-hash-value JSON_VALUE
+                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-embed-file JSON_FILE
+                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-inline-datum-file JSON_FILE
+                                                             | --tx-out-inline-datum-value JSON_VALUE
+                                                             ]
+                                                             [--tx-out-reference-script-file FILEPATH]
+
+  DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli allegra transaction hash-script-data 
                                                           ( --script-data-cbor-file CBOR_FILE
@@ -3628,6 +3779,20 @@ Usage: cardano-cli mary query stake-snapshot
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
+Usage: cardano-cli mary query pool-params [--cardano-mode [--epoch-slots SLOTS]]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+                                            --socket-path SOCKET_PATH
+                                            ( --all-stake-pools
+                                            | (--stake-pool-id STAKE_POOL_ID)
+                                            )
+                                            [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
 Usage: cardano-cli mary query leadership-schedule 
                                                     [--cardano-mode
                                                       [--epoch-slots SLOTS]]
@@ -4043,6 +4208,12 @@ Usage: cardano-cli mary transaction assemble --tx-body-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
+Usage: cardano-cli mary transaction sign-witness --tx-body-file FILEPATH
+                                                   [--witness-file FILEPATH]
+                                                   --out-file FILEPATH
+
+  Assemble a tx body and witness(es) to form a transaction
+
 Usage: cardano-cli mary transaction submit 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
@@ -4104,6 +4275,23 @@ Usage: cardano-cli mary transaction calculate-plutus-script-cost
                                                                    [--out-file FILEPATH]
 
   Calculate the costs of the Plutus scripts of a given transaction.
+
+Usage: cardano-cli mary transaction calculate-min-value --protocol-params-file FILEPATH
+                                                          --tx-out ADDRESS VALUE
+                                                          [ --tx-out-datum-hash HASH
+                                                          | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                          | --tx-out-datum-hash-file JSON_FILE
+                                                          | --tx-out-datum-hash-value JSON_VALUE
+                                                          | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                          | --tx-out-datum-embed-file JSON_FILE
+                                                          | --tx-out-datum-embed-value JSON_VALUE
+                                                          | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                          | --tx-out-inline-datum-file JSON_FILE
+                                                          | --tx-out-inline-datum-value JSON_VALUE
+                                                          ]
+                                                          [--tx-out-reference-script-file FILEPATH]
+
+  DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli mary transaction hash-script-data 
                                                        ( --script-data-cbor-file CBOR_FILE
@@ -4700,6 +4888,22 @@ Usage: cardano-cli alonzo query stake-snapshot
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
+Usage: cardano-cli alonzo query pool-params 
+                                              [--cardano-mode
+                                                [--epoch-slots SLOTS]]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              --socket-path SOCKET_PATH
+                                              ( --all-stake-pools
+                                              | (--stake-pool-id STAKE_POOL_ID)
+                                              )
+                                              [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
 Usage: cardano-cli alonzo query leadership-schedule 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
@@ -5129,6 +5333,12 @@ Usage: cardano-cli alonzo transaction assemble --tx-body-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
+Usage: cardano-cli alonzo transaction sign-witness --tx-body-file FILEPATH
+                                                     [--witness-file FILEPATH]
+                                                     --out-file FILEPATH
+
+  Assemble a tx body and witness(es) to form a transaction
+
 Usage: cardano-cli alonzo transaction submit 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
@@ -5190,6 +5400,23 @@ Usage: cardano-cli alonzo transaction calculate-plutus-script-cost
                                                                      [--out-file FILEPATH]
 
   Calculate the costs of the Plutus scripts of a given transaction.
+
+Usage: cardano-cli alonzo transaction calculate-min-value --protocol-params-file FILEPATH
+                                                            --tx-out ADDRESS VALUE
+                                                            [ --tx-out-datum-hash HASH
+                                                            | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-hash-file JSON_FILE
+                                                            | --tx-out-datum-hash-value JSON_VALUE
+                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-embed-file JSON_FILE
+                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-inline-datum-file JSON_FILE
+                                                            | --tx-out-inline-datum-value JSON_VALUE
+                                                            ]
+                                                            [--tx-out-reference-script-file FILEPATH]
+
+  DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli alonzo transaction hash-script-data 
                                                          ( --script-data-cbor-file CBOR_FILE
@@ -5826,6 +6053,22 @@ Usage: cardano-cli babbage query stake-snapshot
 
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
+
+Usage: cardano-cli babbage query pool-params 
+                                               [--cardano-mode
+                                                 [--epoch-slots SLOTS]]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               --socket-path SOCKET_PATH
+                                               ( --all-stake-pools
+                                               | (--stake-pool-id STAKE_POOL_ID)
+                                               )
+                                               [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
 
 Usage: cardano-cli babbage query leadership-schedule 
                                                        [--cardano-mode
@@ -6516,6 +6759,12 @@ Usage: cardano-cli babbage transaction assemble --tx-body-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
+Usage: cardano-cli babbage transaction sign-witness --tx-body-file FILEPATH
+                                                      [--witness-file FILEPATH]
+                                                      --out-file FILEPATH
+
+  Assemble a tx body and witness(es) to form a transaction
+
 Usage: cardano-cli babbage transaction submit 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
@@ -6577,6 +6826,23 @@ Usage: cardano-cli babbage transaction calculate-plutus-script-cost
                                                                       [--out-file FILEPATH]
 
   Calculate the costs of the Plutus scripts of a given transaction.
+
+Usage: cardano-cli babbage transaction calculate-min-value --protocol-params-file FILEPATH
+                                                             --tx-out ADDRESS VALUE
+                                                             [ --tx-out-datum-hash HASH
+                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-hash-file JSON_FILE
+                                                             | --tx-out-datum-hash-value JSON_VALUE
+                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-embed-file JSON_FILE
+                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-inline-datum-file JSON_FILE
+                                                             | --tx-out-inline-datum-value JSON_VALUE
+                                                             ]
+                                                             [--tx-out-reference-script-file FILEPATH]
+
+  DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli babbage transaction hash-script-data 
                                                           ( --script-data-cbor-file CBOR_FILE
@@ -7526,6 +7792,23 @@ Usage: cardano-cli conway query stake-snapshot
 
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
+
+Usage: cardano-cli conway query pool-params 
+                                              [--cardano-mode
+                                                [--epoch-slots SLOTS]]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              --socket-path SOCKET_PATH
+                                              [--volatile-tip | --immutable-tip]
+                                              ( --all-stake-pools
+                                              | (--stake-pool-id STAKE_POOL_ID)
+                                              )
+                                              [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
 
 Usage: cardano-cli conway query leadership-schedule 
                                                       [--cardano-mode
@@ -8601,6 +8884,12 @@ Usage: cardano-cli conway transaction assemble --tx-body-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
+Usage: cardano-cli conway transaction sign-witness --tx-body-file FILEPATH
+                                                     [--witness-file FILEPATH]
+                                                     --out-file FILEPATH
+
+  Assemble a tx body and witness(es) to form a transaction
+
 Usage: cardano-cli conway transaction submit 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
@@ -8662,6 +8951,23 @@ Usage: cardano-cli conway transaction calculate-plutus-script-cost
                                                                      [--out-file FILEPATH]
 
   Calculate the costs of the Plutus scripts of a given transaction.
+
+Usage: cardano-cli conway transaction calculate-min-value --protocol-params-file FILEPATH
+                                                            --tx-out ADDRESS VALUE
+                                                            [ --tx-out-datum-hash HASH
+                                                            | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-hash-file JSON_FILE
+                                                            | --tx-out-datum-hash-value JSON_VALUE
+                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-embed-file JSON_FILE
+                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-inline-datum-file JSON_FILE
+                                                            | --tx-out-inline-datum-value JSON_VALUE
+                                                            ]
+                                                            [--tx-out-reference-script-file FILEPATH]
+
+  DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli conway transaction hash-script-data 
                                                          ( --script-data-cbor-file CBOR_FILE
@@ -9611,6 +9917,23 @@ Usage: cardano-cli latest query stake-snapshot
 
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
+
+Usage: cardano-cli latest query pool-params 
+                                              [--cardano-mode
+                                                [--epoch-slots SLOTS]]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              --socket-path SOCKET_PATH
+                                              [--volatile-tip | --immutable-tip]
+                                              ( --all-stake-pools
+                                              | (--stake-pool-id STAKE_POOL_ID)
+                                              )
+                                              [--out-file FILEPATH]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
 
 Usage: cardano-cli latest query leadership-schedule 
                                                       [--cardano-mode
@@ -10686,6 +11009,12 @@ Usage: cardano-cli latest transaction assemble --tx-body-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
+Usage: cardano-cli latest transaction sign-witness --tx-body-file FILEPATH
+                                                     [--witness-file FILEPATH]
+                                                     --out-file FILEPATH
+
+  Assemble a tx body and witness(es) to form a transaction
+
 Usage: cardano-cli latest transaction submit 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
@@ -10748,6 +11077,23 @@ Usage: cardano-cli latest transaction calculate-plutus-script-cost
 
   Calculate the costs of the Plutus scripts of a given transaction.
 
+Usage: cardano-cli latest transaction calculate-min-value --protocol-params-file FILEPATH
+                                                            --tx-out ADDRESS VALUE
+                                                            [ --tx-out-datum-hash HASH
+                                                            | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-hash-file JSON_FILE
+                                                            | --tx-out-datum-hash-value JSON_VALUE
+                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-embed-file JSON_FILE
+                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-inline-datum-file JSON_FILE
+                                                            | --tx-out-inline-datum-value JSON_VALUE
+                                                            ]
+                                                            [--tx-out-reference-script-file FILEPATH]
+
+  DEPRECATED: Use 'calculate-min-required-utxo' instead.
+
 Usage: cardano-cli latest transaction hash-script-data 
                                                          ( --script-data-cbor-file CBOR_FILE
                                                          | --script-data-file JSON_FILE
@@ -10795,6 +11141,104 @@ Usage: cardano-cli debug transaction view [--output-json | --output-yaml]
                                             )
 
   Print a transaction.
+
+Usage: cardano-cli genesis --genesis-output-dir FILEPATH
+                             --start-time POSIXSECONDS
+                             --protocol-parameters-file FILEPATH
+                             --k INT
+                             --protocol-magic INT
+                             --n-poor-addresses INT
+                             --n-delegate-addresses INT
+                             --total-balance INT
+                             --delegate-share DOUBLE
+                             --avvm-entry-count INT
+                             --avvm-entry-balance INT
+                             [--avvm-balance-factor DOUBLE]
+                             [--secret-seed INT]
+
+  Create genesis.
+
+Usage: cardano-cli print-genesis-hash --genesis-json FILEPATH
+
+  Compute hash of a genesis file.
+
+Usage: cardano-cli keygen --secret FILEPATH
+
+  Generate a signing key.
+
+Usage: cardano-cli to-verification [--byron-legacy-formats | --byron-formats]
+                                     --secret FILEPATH
+                                     --to FILEPATH
+
+  Extract a verification key in its base64 form.
+
+Usage: cardano-cli signing-key-public [--byron-legacy-formats | --byron-formats]
+                                        --secret FILEPATH
+
+  Pretty-print a signing key's verification key (not a secret).
+
+Usage: cardano-cli signing-key-address 
+                                         [ --byron-legacy-formats
+                                         | --byron-formats
+                                         ]
+                                         (--mainnet | --testnet-magic NATURAL)
+                                         --secret FILEPATH
+
+  Print address of a signing key.
+
+Usage: cardano-cli migrate-delegate-key-from --from FILEPATH --to FILEPATH
+
+  Migrate a delegate key from an older version.
+
+Usage: cardano-cli submit-tx --socket-path SOCKET_PATH
+                               (--mainnet | --testnet-magic NATURAL)
+                               --tx FILEPATH
+
+  Submit a raw, signed transaction, in its on-wire representation.
+
+Usage: cardano-cli issue-genesis-utxo-expenditure --genesis-json FILEPATH
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    [ --byron-legacy-formats
+                                                    | --byron-formats
+                                                    ]
+                                                    --tx FILEPATH
+                                                    --wallet-key FILEPATH
+                                                    --rich-addr-from ADDR
+                                                    (--txout '("ADDR", LOVELACE)')
+
+  Write a file with a signed transaction, spending genesis UTxO.
+
+Usage: cardano-cli issue-utxo-expenditure (--mainnet | --testnet-magic NATURAL)
+                                            [ --byron-legacy-formats
+                                            | --byron-formats
+                                            ]
+                                            --tx FILEPATH
+                                            --wallet-key FILEPATH
+                                            (--txin (TXID,INDEX))
+                                            (--txout '("ADDR", LOVELACE)')
+
+  Write a file with a signed transaction, spending normal UTxO.
+
+Usage: cardano-cli txid --tx FILEPATH
+
+  Print the txid of a raw, signed transaction.
+
+Usage: cardano-cli validate-cbor 
+                                   [ --byron-block INT
+                                   | --byron-delegation-certificate
+                                   | --byron-tx
+                                   | --byron-update-proposal
+                                   | --byron-vote
+                                   ]
+                                   --filepath FILEPATH
+
+  Validate a CBOR blockchain object.
+
+Usage: cardano-cli pretty-print-cbor --filepath FILEPATH
+
+  Pretty print a CBOR file.
 
 Usage: cardano-cli ping [-c|--count COUNT]
                           ((-h|--host HOST) | (-u|--unixsock SOCKET))


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add a new `CARDANO_CLI_VISIBILITY_LEVEL` environment variable which can be defined as `internal`, `hidden` or `visible`. 
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

It is useful to be able to see what the hidden and internal commands are even though they are hidden by default.

The feature is also used to generate golden files that include CLI help for hidden and internal commands so that hidden and internal APIs are also tracked.

# How to trust this PR

No changes to the golden files apart from the rename of `help.cli` to `help-visible.cli` and the addition of `help-hidden.cli` and `help-internal.cli` files.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
