### PR TITLE
Rename `AllOutputFormats` to `LedgerOutputFormat`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -1787,12 +1787,12 @@ make' format desc flag_ extraHelp kind =
       , Opt.long ("output-" <> flag_)
       ]
 
-pAllOutputFormats :: String -> Parser AllOutputFormats
-pAllOutputFormats kind =
+pLedgerOutputFormat :: String -> Parser LedgerOutputFormat
+pLedgerOutputFormat kind =
   asum
-    [ make' FormatJson "JSON" "json" (Just " Default format when writing to a file") kind
-    , make' FormatText "TEXT" "text" (Just " Default format when writing to stdout") kind
-    , make' FormatCBOR "BASE16 CBOR" "cbor" Nothing kind
+    [ make' LedgerOutputFormatAsJson "JSON" "json" (Just " Default format when writing to a file") kind
+    , make' LedgerOutputFormatAsText "TEXT" "text" (Just " Default format when writing to stdout") kind
+    , make' LedgerOutputFormatAsCBOR "BASE16 CBOR" "cbor" Nothing kind
     ]
 
 -- | @pTxIdOutputFormatJsonOrText kind@ is a parser to specify in which format

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -130,7 +130,7 @@ data QueryStakeAddressInfoCmdArgs = QueryStakeAddressInfoCmdArgs
 data QueryUTxOCmdArgs = QueryUTxOCmdArgs
   { commons :: !QueryCommons
   , queryFilter :: !QueryUTxOFilter
-  , format :: Maybe AllOutputFormats
+  , format :: Maybe LedgerOutputFormat
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -364,7 +364,7 @@ pQueryUTxOCmd era envCli =
     QueryUTxOCmdArgs
       <$> pQueryCommons era envCli
       <*> pQueryUTxOFilter
-      <*> (optional $ pAllOutputFormats "utxo")
+      <*> (optional $ pLedgerOutputFormat "utxo")
       <*> pMaybeOutputFile
 
 pQueryStakePoolsCmd :: ShelleyBasedEra era -> EnvCli -> Parser (QueryCmds era)

--- a/cardano-cli/src/Cardano/CLI/Type/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Common.hs
@@ -7,7 +7,7 @@
 
 module Cardano.CLI.Type.Common
   ( AllOrOnly (..)
-  , AllOutputFormats (..)
+  , LedgerOutputFormat (..)
   , AddressKeyType (..)
   , AnchorScheme (..)
   , AnyPlutusScriptVersion (..)
@@ -489,10 +489,12 @@ data OutputFormatJsonOrText
   | OutputFormatText
   deriving (Eq, Show)
 
-data AllOutputFormats
-  = FormatJson
-  | FormatText
-  | FormatCBOR
+-- | The output format for ledger outputs.  Ledger outputs are those outputs that have a ledger representation
+-- (ie. CBOR).
+data LedgerOutputFormat
+  = LedgerOutputFormatAsJson
+  | LedgerOutputFormatAsText
+  | LedgerOutputFormatAsCBOR
   deriving Show
 
 data ViewOutputFormat


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Rename `AllOutputFormats` to `LedgerOutputFormat`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The name `AllOutputFormats` is misleading because it doesn't actually represent all possible output formats.

Inspecting the code, it is limited to those outputs that are representations of ledger state (in that they have CBOR representation) so the new name is chosen accordingly.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
