### PR TITLE
Use GovActionId instead of tuples in commands

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -3569,31 +3569,16 @@ pAllOrOnlySPOHashSource = pAll <|> pOnly
         ]
 
 pAllOrOnlyGovActionIds
-  :: ()
-  => ConwayEraOnwards era
-  -> Parser (AllOrOnly L.GovActionId)
-pAllOrOnlyGovActionIds era = pAll <|> pOnly
+  :: Parser (AllOrOnly L.GovActionId)
+pAllOrOnlyGovActionIds = pAll <|> pOnly
  where
-  pOnly = Only <$> pGovActionIds era
+  pOnly = Only <$> some pGovernanceActionId
   pAll =
     Opt.flag' All $
       mconcat
         [ Opt.long "all-proposals"
         , Opt.help "Query for all governance proposals."
         ]
-
-pGovActionIds
-  :: forall era
-   . ()
-  => ConwayEraOnwards era
-  -> Parser [L.GovActionId]
-pGovActionIds era = conwayEraOnwardsConstraints era (some pLedgerGovernanceAction)
- where
-  pLedgerGovernanceAction :: Parser L.GovActionId
-  pLedgerGovernanceAction = uncurry L.GovActionId <$> pairParser
-
-  pairParser :: Parser (L.TxId, L.GovActionIx)
-  pairParser = bimap toShelleyTxId L.GovActionIx <$> pGovernanceActionId
 
 pDRepVerificationKeyHash :: Parser (Hash DRepKey)
 pDRepVerificationKeyHash =
@@ -3731,16 +3716,16 @@ pMustCheckResignationMetadataHash =
     "--resignation-metadata-hash"
     "--resignation-metadata-url"
 
-pPreviousGovernanceAction :: Parser (Maybe (TxId, Word16))
+pPreviousGovernanceAction :: Parser (Maybe L.GovActionId)
 pPreviousGovernanceAction =
   optional $
-    (,)
+    createGovernanceActionId
       <$> pTxId "prev-governance-action-tx-id" "Txid of the previous governance action."
       <*> pWord16 "prev-governance-action-index" "Action index of the previous governance action."
 
-pGovernanceActionId :: Parser (TxId, Word16)
+pGovernanceActionId :: Parser L.GovActionId
 pGovernanceActionId =
-  (,)
+  createGovernanceActionId
     <$> pTxId "governance-action-tx-id" "Txid of the governance action."
     <*> pWord16 "governance-action-index" "Tx's governance action index."
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
@@ -30,7 +30,6 @@ import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Key
 
 import Data.Text (Text)
-import Data.Word
 
 data GovernanceActionCmds era
   = GovernanceActionCreateConstitutionCmd !(GovernanceActionCreateConstitutionCmdArgs era)
@@ -55,7 +54,7 @@ data GovernanceActionUpdateCommitteeCmdArgs era
   , oldCommitteeVkeySource :: ![VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey]
   , newCommitteeVkeySource :: ![(VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey, EpochNo)]
   , requiredThreshold :: !Rational
-  , mPrevGovernanceActionId :: !(Maybe (TxId, Word16))
+  , mPrevGovernanceActionId :: !(Maybe L.GovActionId)
   , outFile :: !(File () Out)
   }
   deriving Show
@@ -66,7 +65,7 @@ data GovernanceActionCreateConstitutionCmdArgs era
   , networkId :: !L.Network
   , deposit :: !Lovelace
   , stakeCredential :: !StakeIdentifier
-  , mPrevGovernanceActionId :: !(Maybe (TxId, Word16))
+  , mPrevGovernanceActionId :: !(Maybe L.GovActionId)
   , proposalUrl :: !ProposalUrl
   , proposalHash :: !(L.SafeHash L.AnchorData)
   , checkProposalHash :: !(MustCheckHash ProposalUrl)
@@ -101,7 +100,7 @@ data GovernanceActionCreateNoConfidenceCmdArgs era
   , proposalUrl :: !ProposalUrl
   , proposalHash :: !(L.SafeHash L.AnchorData)
   , checkProposalHash :: !(MustCheckHash ProposalUrl)
-  , mPrevGovernanceActionId :: !(Maybe (TxId, Word16))
+  , mPrevGovernanceActionId :: !(Maybe L.GovActionId)
   , outFile :: !(File () Out)
   }
   deriving Show
@@ -145,7 +144,7 @@ data GovernanceActionHardforkInitCmdArgs era
   , networkId :: !L.Network
   , deposit :: !Lovelace
   , returnStakeAddress :: !StakeIdentifier
-  , mPrevGovernanceActionId :: !(Maybe (TxId, Word16))
+  , mPrevGovernanceActionId :: !(Maybe L.GovActionId)
   , proposalUrl :: !ProposalUrl
   , proposalHash :: !(L.SafeHash L.AnchorData)
   , checkProposalHash :: !(MustCheckHash ProposalUrl)
@@ -172,7 +171,7 @@ data UpdateProtocolParametersConwayOnwards era
   , proposalUrl :: !ProposalUrl
   , proposalHash :: !(L.SafeHash L.AnchorData)
   , checkProposalHash :: !(MustCheckHash ProposalUrl)
-  , governanceActionId :: !(Maybe (TxId, Word16))
+  , governanceActionId :: !(Maybe L.GovActionId)
   , constitutionScriptHash :: !(Maybe ScriptHash)
   }
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
@@ -153,7 +153,7 @@ runGovernanceActionCreateNoConfidenceCmd
           MotionOfNoConfidence $
             L.maybeToStrictMaybe $
               shelleyBasedEraConstraints sbe $
-                L.GovPurposeId . uncurry createGovernanceActionId <$> mPrevGovernanceActionId
+                L.GovPurposeId <$> mPrevGovernanceActionId
 
         proposalProcedure =
           createProposalProcedure
@@ -204,7 +204,7 @@ runGovernanceActionCreateConstitutionCmd
     let prevGovActId =
           L.maybeToStrictMaybe $
             shelleyBasedEraConstraints sbe $
-              L.GovPurposeId . uncurry createGovernanceActionId <$> mPrevGovernanceActionId
+              L.GovPurposeId <$> mPrevGovernanceActionId
         constitutionAnchor =
           L.Anchor
             { L.anchorUrl = unConstitutionUrl constitutionUrl
@@ -253,7 +253,7 @@ runGovernanceActionUpdateCommitteeCmd
         govActIdentifier =
           L.maybeToStrictMaybe $
             shelleyBasedEraConstraints sbe $
-              L.GovPurposeId . uncurry createGovernanceActionId <$> mPrevGovernanceActionId
+              L.GovPurposeId <$> mPrevGovernanceActionId
         thresholdRational = toRational requiredThreshold
 
     let proposalAnchor =
@@ -365,7 +365,7 @@ runGovernanceActionCreateProtocolParametersUpdateCmd eraBasedPParams' = do
 
         let updateProtocolParams = createEraBasedProtocolParamUpdate sbe eraBasedPParams
 
-            prevGovActId = L.maybeToStrictMaybe $ L.GovPurposeId . uncurry createGovernanceActionId <$> mPrevGovActId
+            prevGovActId = L.maybeToStrictMaybe $ L.GovPurposeId <$> mPrevGovActId
             proposalAnchor =
               L.Anchor
                 { L.anchorUrl = unProposalUrl proposalUrl
@@ -505,8 +505,7 @@ runGovernanceActionHardforkInitCmd
     let sbe = convert eon
         govActIdentifier =
           L.maybeToStrictMaybe $
-            shelleyBasedEraConstraints sbe $
-              L.GovPurposeId . uncurry createGovernanceActionId <$> mPrevGovernanceActionId
+            L.GovPurposeId <$> mPrevGovernanceActionId
         initHardfork =
           InitiateHardfork
             govActIdentifier

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Command.hs
@@ -18,7 +18,6 @@ import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Governance
 
 import Data.Text (Text)
-import Data.Word
 
 data GovernanceVoteCmds era
   = GovernanceVoteCreateCmd
@@ -30,7 +29,7 @@ data GovernanceVoteCreateCmdArgs era
   = GovernanceVoteCreateCmdArgs
   { eon :: ConwayEraOnwards era
   , voteChoice :: Vote
-  , governanceAction :: (TxId, Word16)
+  , governanceActionId :: L.GovActionId
   , votingStakeCredentialSource :: AnyVotingStakeVerificationKeyOrHashOrFile
   , mAnchor
       :: !( Maybe

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Run.hs
@@ -49,13 +49,12 @@ runGovernanceVoteCreateCmd
   Cmd.GovernanceVoteCreateCmdArgs
     { eon
     , voteChoice
-    , governanceAction
+    , governanceActionId
     , votingStakeCredentialSource
     , mAnchor
     , outFile
     } = do
-    let (govActionTxId, govActionIndex) = governanceAction
-        sbe = convert eon -- TODO: Conway era - update vote creation related function to take ConwayEraOnwards
+    let sbe = convert eon -- TODO: Conway era - update vote creation related function to take ConwayEraOnwards
         mAnchor' =
           fmap
             ( \pca@PotentiallyCheckedAnchor{pcaAnchor = (VoteUrl url, voteHash)} ->
@@ -87,8 +86,7 @@ runGovernanceVoteCreateCmd
           hotCred <- readVerificationKeyOrHashOrFileOrScriptHash AsCommitteeHotKey unCommitteeHotKeyHash stake
           pure $ L.CommitteeVoter hotCred
 
-      let govActIdentifier = createGovernanceActionId govActionTxId govActionIndex
-          votingProcedures = singletonVotingProcedures eon voter govActIdentifier (unVotingProcedure voteProcedure)
+      let votingProcedures = singletonVotingProcedures eon voter governanceActionId (unVotingProcedure voteProcedure)
       firstExceptT GovernanceVoteCmdWriteError . newExceptT $
         writeFileTextEnvelope outFile Nothing votingProcedures
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -667,7 +667,7 @@ pQueryProposalsCmd era envCli = do
   pQueryProposalsCmdArgs w =
     QueryProposalsCmdArgs w
       <$> pQueryCommons (convert w) envCli
-      <*> pAllOrOnlyGovActionIds w
+      <*> pAllOrOnlyGovActionIds
       <*> optional pOutputFile
 
 pQuerySPOStakeDistributionCmd


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use GovActionId instead of tuples in commands
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR is stacked on top of:
- https://github.com/IntersectMBO/cardano-cli/pull/1075

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
