### PR TITLE
Merge `ViewOutputFormat` and `FriendlyFormat` types into a single `FormatJsonOrYaml` type

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -1810,26 +1810,26 @@ pTxIdOutputFormatJsonOrText =
         , Opt.long ("output-" <> flag_)
         ]
 
-pTxViewOutputFormat :: Parser ViewOutputFormat
+pTxViewOutputFormat :: Parser FormatJsonOrYaml
 pTxViewOutputFormat = pViewOutputFormat "transaction"
 
-pGovernanceActionViewOutputFormat :: Parser ViewOutputFormat
+pGovernanceActionViewOutputFormat :: Parser FormatJsonOrYaml
 pGovernanceActionViewOutputFormat = pViewOutputFormat "governance action"
 
-pGovernanceVoteViewOutputFormat :: Parser ViewOutputFormat
+pGovernanceVoteViewOutputFormat :: Parser FormatJsonOrYaml
 pGovernanceVoteViewOutputFormat = pViewOutputFormat "governance vote"
 
 -- | @pViewOutputFormat kind@ is a parser to specify in which format
 -- to view some data (json or yaml). @what@ is the kind of data considered.
-pViewOutputFormat :: String -> Parser ViewOutputFormat
+pViewOutputFormat :: String -> Parser FormatJsonOrYaml
 pViewOutputFormat kind =
   asum
-    [ make ViewOutputFormatJson "JSON" "json" Nothing
-    , make ViewOutputFormatYaml "YAML" "yaml" (Just " Defaults to JSON if unspecified.")
+    [ make FormatJsonOrYamlWithJson "JSON" "json" Nothing
+    , make FormatJsonOrYamlWithYaml "YAML" "yaml" (Just " Defaults to JSON if unspecified.")
     ]
  where
   make format desc flag_ extraHelp =
-    Opt.flag ViewOutputFormatJson format $
+    Opt.flag FormatJsonOrYamlWithJson format $
       mconcat
         [ Opt.help $
             "Format "

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
@@ -158,7 +158,7 @@ data GovernanceActionViewCmdArgs era
   = GovernanceActionViewCmdArgs
   { eon :: !(ConwayEraOnwards era)
   , actionFile :: !(ProposalFile In)
-  , outFormat :: !ViewOutputFormat
+  , outFormat :: !FormatJsonOrYaml
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
@@ -70,10 +70,7 @@ runGovernanceActionViewCmd
         readProposal eon (actionFile, Nothing)
     firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
       friendlyProposal
-        ( case outFormat of
-            ViewOutputFormatJson -> FriendlyJson
-            ViewOutputFormatYaml -> FriendlyYaml
-        )
+        outFormat
         mOutFile
         eon
         proposal

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Command.hs
@@ -45,7 +45,7 @@ data GovernanceVoteCreateCmdArgs era
 data GovernanceVoteViewCmdArgs era
   = GovernanceVoteViewCmdArgs
   { eon :: ConwayEraOnwards era
-  , outFormat :: !ViewOutputFormat
+  , outFormat :: !FormatJsonOrYaml
   , voteFile :: VoteFile In
   , mOutFile :: Maybe (File () Out)
   }

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Run.hs
@@ -114,11 +114,11 @@ runGovernanceVoteViewCmd
       firstExceptT GovernanceVoteCmdWriteError
         . newExceptT
         . ( case outFormat of
-              ViewOutputFormatYaml ->
+              FormatJsonOrYamlWithYaml ->
                 writeByteStringOutput mOutFile
                   . Yaml.encodePretty
                     (Yaml.setConfCompare compare Yaml.defConfig)
-              ViewOutputFormatJson ->
+              FormatJsonOrYamlWithJson ->
                 writeLazyByteStringOutput mOutFile
                   . encodePretty'
                     (defConfig{confCompare = compare})

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/TransactionView/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/TransactionView/Command.hs
@@ -5,7 +5,7 @@ module Cardano.CLI.EraIndependent.Debug.TransactionView.Command where
 import Cardano.CLI.Type.Common
 
 data TransactionViewCmdArgs = TransactionViewCmdArgs
-  { outputFormat :: !ViewOutputFormat
+  { outputFormat :: !FormatJsonOrYaml
   , mOutFile :: !(Maybe (File () Out))
   , inputTxBodyOrTxFile :: !InputTxBodyOrTxFile
   }

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/TransactionView/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/TransactionView/Run.hs
@@ -11,7 +11,6 @@ import Cardano.CLI.EraIndependent.Debug.TransactionView.Command
 import Cardano.CLI.Json.Friendly
   ( friendlyTx
   , friendlyTxBody
-  , viewOutputFormatToFriendlyFormat
   )
 import Cardano.CLI.Read
 import Cardano.CLI.Type.Common
@@ -42,9 +41,9 @@ runTransactionViewCmd
         -- this would mean that we'd have an empty list of witnesses mentioned in the output, which
         -- is arguably not part of the transaction body.
         firstExceptT TxCmdWriteFileError . newExceptT $
-          friendlyTxBody (viewOutputFormatToFriendlyFormat outputFormat) mOutFile (toCardanoEra era) txbody
+          friendlyTxBody outputFormat mOutFile (toCardanoEra era) txbody
       InputTxFile (File txFilePath) -> do
         txFile <- liftIO $ fileOrPipe txFilePath
         InAnyShelleyBasedEra era tx <- lift (readFileTx txFile) & onLeft (left . TxCmdTextEnvCddlError)
         firstExceptT TxCmdWriteFileError . newExceptT $
-          friendlyTx (viewOutputFormatToFriendlyFormat outputFormat) mOutFile (toCardanoEra era) tx
+          friendlyTx outputFormat mOutFile (toCardanoEra era) tx

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -34,8 +34,7 @@ module Cardano.CLI.Json.Friendly
   , friendlyProposalImpl
 
     -- * Ubiquitous types
-  , FriendlyFormat (..)
-  , viewOutputFormatToFriendlyFormat
+  , FormatJsonOrYaml (..)
   )
 where
 
@@ -59,7 +58,7 @@ import Cardano.Api.Shelley
   )
 
 import Cardano.CLI.Orphan ()
-import Cardano.CLI.Type.Common (ViewOutputFormat (..))
+import Cardano.CLI.Type.Common (FormatJsonOrYaml (..))
 import Cardano.CLI.Type.MonadWarning (MonadWarning, runWarningIO)
 import Cardano.Crypto.Hash (hashToTextAsHex)
 
@@ -90,30 +89,23 @@ import GHC.Real (denominator)
 import GHC.Unicode (isAlphaNum)
 import Lens.Micro ((^.))
 
-data FriendlyFormat = FriendlyJson | FriendlyYaml
-
-viewOutputFormatToFriendlyFormat :: ViewOutputFormat -> FriendlyFormat
-viewOutputFormatToFriendlyFormat = \case
-  ViewOutputFormatJson -> FriendlyJson
-  ViewOutputFormatYaml -> FriendlyYaml
-
 friendly
   :: (MonadIO m, Aeson.ToJSON a)
-  => FriendlyFormat
+  => FormatJsonOrYaml
   -> Maybe (File () Out)
   -> a
   -> m (Either (FileError e) ())
-friendly FriendlyJson mOutFile = writeLazyByteStringOutput mOutFile . Aeson.encodePretty' jsonConfig
-friendly FriendlyYaml mOutFile = writeByteStringOutput mOutFile . Yaml.encodePretty yamlConfig
+friendly FormatJsonOrYamlWithJson mOutFile = writeLazyByteStringOutput mOutFile . Aeson.encodePretty' jsonConfig
+friendly FormatJsonOrYamlWithYaml mOutFile = writeByteStringOutput mOutFile . Yaml.encodePretty yamlConfig
 
 friendlyBS
   :: ()
   => Aeson.ToJSON a
-  => FriendlyFormat
+  => FormatJsonOrYaml
   -> a
   -> BS.ByteString
-friendlyBS FriendlyJson a = BS.concat . LBS.toChunks $ Aeson.encodePretty' jsonConfig a
-friendlyBS FriendlyYaml a = Yaml.encodePretty yamlConfig a
+friendlyBS FormatJsonOrYamlWithJson a = BS.concat . LBS.toChunks $ Aeson.encodePretty' jsonConfig a
+friendlyBS FormatJsonOrYamlWithYaml a = Yaml.encodePretty yamlConfig a
 
 jsonConfig :: Aeson.Config
 jsonConfig = Aeson.defConfig{Aeson.confCompare = compare}
@@ -123,7 +115,7 @@ yamlConfig = Yaml.defConfig & setConfCompare compare
 
 friendlyTx
   :: MonadIO m
-  => FriendlyFormat
+  => FormatJsonOrYaml
   -> Maybe (File () Out)
   -> CardanoEra era
   -> Tx era
@@ -138,7 +130,7 @@ friendlyTx format mOutFile era =
 
 friendlyTxBody
   :: MonadIO m
-  => FriendlyFormat
+  => FormatJsonOrYaml
   -> Maybe (File () Out)
   -> CardanoEra era
   -> TxBody era
@@ -153,7 +145,7 @@ friendlyTxBody format mOutFile era =
 
 friendlyProposal
   :: MonadIO m
-  => FriendlyFormat
+  => FormatJsonOrYaml
   -> Maybe (File () Out)
   -> ConwayEraOnwards era
   -> Proposal era

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -59,15 +59,15 @@ readKeyOutputFormat = do
           , ". Accepted output formats are \"text-envelope\" and \"bech32\"."
           ]
 
-readTxViewOutputFormat :: Opt.ReadM ViewOutputFormat
+readTxViewOutputFormat :: Opt.ReadM FormatJsonOrYaml
 readTxViewOutputFormat = readViewOutputFormat "transaction"
 
-readViewOutputFormat :: String -> Opt.ReadM ViewOutputFormat
+readViewOutputFormat :: String -> Opt.ReadM FormatJsonOrYaml
 readViewOutputFormat kind = do
   s <- Opt.str @String
   case s of
-    "json" -> pure ViewOutputFormatJson
-    "yaml" -> pure ViewOutputFormatYaml
+    "json" -> pure FormatJsonOrYamlWithJson
+    "yaml" -> pure FormatJsonOrYamlWithYaml
     _ ->
       fail $
         mconcat
@@ -77,7 +77,7 @@ readViewOutputFormat kind = do
           , ". Accepted output formats are \"json\" and \"yaml\"."
           ]
 
-readGovernanceActionViewOutputFormat :: Opt.ReadM ViewOutputFormat
+readGovernanceActionViewOutputFormat :: Opt.ReadM FormatJsonOrYaml
 readGovernanceActionViewOutputFormat = readViewOutputFormat "governance action view"
 
 readURIOfMaxLength :: Int -> Opt.ReadM Text

--- a/cardano-cli/src/Cardano/CLI/Type/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Common.hs
@@ -83,7 +83,7 @@ module Cardano.CLI.Type.Common
   , UpdateProposalFile (..)
   , VerificationKeyBase64 (..)
   , VerificationKeyFile
-  , ViewOutputFormat (..)
+  , FormatJsonOrYaml (..)
   , VoteUrl (..)
   , VoteText (..)
   , VoteHashSource (..)
@@ -495,9 +495,9 @@ data AllOutputFormats
   | FormatCBOR
   deriving Show
 
-data ViewOutputFormat
-  = ViewOutputFormatJson
-  | ViewOutputFormatYaml
+data FormatJsonOrYaml
+  = FormatJsonOrYamlWithJson
+  | FormatJsonOrYamlWithYaml
   deriving Show
 
 --


### PR DESCRIPTION
The two original types are isomorphic and represent the same things.

New type name adds clarity to what the type means.

# Changelog

```yaml
- description: |
    Merge `ViewOutputFormat` and `FriendlyFormat` types into a single `FormatJsonOrYaml` type
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

These are duplicate types and even the code that maps between them is duplicated.

# How to trust this PR

Straightforward refactoring.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
