### PR TITLE
Replace output format type with `vary`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -6,6 +6,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Redundant id" #-}
 
 {- HLINT ignore "Move brackets to avoid $" -}
 {- HLINT ignore "Use <$>" -}
@@ -56,6 +59,7 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Time.Clock (UTCTime)
 import Data.Time.Format (defaultTimeLocale, parseTimeOrError)
+import Data.Type.Equality
 import Data.Word
 import GHC.Exts (IsList (..))
 import GHC.Natural (Natural)
@@ -70,6 +74,8 @@ import Text.Parsec.String qualified as Parsec
 import Text.Parsec.Token qualified as Parsec
 import Text.Read (readEither, readMaybe)
 import Text.Read qualified as Read
+
+import Type.Reflection qualified as TR
 
 command' :: String -> String -> Parser a -> Mod CommandFields a
 command' c descr p =
@@ -1765,19 +1771,27 @@ pPoolIdOutputFormat =
 
 -- | @pOutputFormatJsonOrText kind@ is a parser to specify in which format
 -- to view some data (json or text). @kind@ is the kind of data considered.
-pOutputFormatJsonOrText :: String -> Parser OutputFormatJsonOrText
+pOutputFormatJsonOrText :: String -> Parser (Vary [FormatJson, FormatText])
 pOutputFormatJsonOrText kind =
   asum
-    [ make' OutputFormatJson "JSON" "json" (Just " Default format when writing to a file") kind
-    , make' OutputFormatText "TEXT" "text" (Just " Default format when writing to stdout") kind
+    [ make' FormatJson "JSON" "json" (Just " Default format when writing to a file") kind
+    , make' FormatText "TEXT" "text" (Just " Default format when writing to stdout") kind
     ]
 
-make' :: a -> String -> String -> Maybe String -> String -> Parser a
+-- | Make a parser for an output format.
+make'
+  :: a :| fs
+  => a
+  -> String
+  -> String
+  -> Maybe String
+  -> String
+  -> Parser (Vary fs)
 make' format desc flag_ extraHelp kind =
   -- Not using Opt.flag, because there is no default. We can't have
   -- a default and preserve the historical behavior (that differed whether
   -- an output file was specified or not).
-  Opt.flag' format $
+  Opt.flag' (Vary.from format) $
     mconcat
       [ Opt.help $
           "Format "
@@ -1789,32 +1803,55 @@ make' format desc flag_ extraHelp kind =
       , Opt.long ("output-" <> flag_)
       ]
 
-pFormatCBOR :: String -> Parser FormatCBOR
+pFormatCBOR
+  :: FormatCBOR :| fs
+  => String
+  -> Parser (Vary fs)
 pFormatCBOR =
   make' FormatCBOR "BASE16 CBOR" "cbor" Nothing
 
-pFormatJsonFileDefault :: String -> Parser FormatJson
+pFormatJsonFileDefault
+  :: FormatJson :| fs
+  => String
+  -> Parser (Vary fs)
 pFormatJsonFileDefault =
   make' FormatJson "JSON" "json" (Just " Default format when writing to a file")
 
-pFormatTextStdoutDefault :: String -> Parser FormatText
+pFormatTextStdoutDefault
+  :: FormatText :| fs
+  => String
+  -> Parser (Vary fs)
 pFormatTextStdoutDefault =
   make' FormatText "TEXT" "text" (Just " Default format when writing to stdout")
 
 -- | @pTxIdOutputFormatJsonOrText kind@ is a parser to specify in which format
 -- to write @transaction txid@'s output on standard output.
-pTxIdOutputFormatJsonOrText :: Parser OutputFormatJsonOrText
+pTxIdOutputFormatJsonOrText :: Parser (Vary [FormatJson, FormatText])
 pTxIdOutputFormatJsonOrText =
-  asum [make OutputFormatJson "JSON" "json", make OutputFormatText "TEXT" "text"]
-    <|> pure default_
+  asum [make FormatJson "JSON" "json", make FormatText "TEXT" "text"]
+    <|> pure (Vary.from default_)
  where
-  default_ = OutputFormatText
+  default_ :: FormatText
+  default_ = FormatText
+  make
+    :: forall a fs
+     . a :| fs
+    => Typeable a
+    => a
+    -> String
+    -> String
+    -> Parser (Vary fs)
   make format desc flag_ =
-    Opt.flag' format $
+    Opt.flag' (Vary.from format) $
       mconcat
-        [ Opt.help $ "Format output as " <> desc <> (if format == default_ then " (the default)." else ".")
+        [ Opt.help $ "Format output as " <> desc <> maybeDefault <> "."
         , Opt.long ("output-" <> flag_)
         ]
+   where
+    maybeDefault =
+      case TR.eqTypeRep (TR.typeRep @a) (TR.typeRep @FormatText) of
+        Just HRefl -> " (the default)"
+        Nothing -> ""
 
 pTxViewOutputFormat :: Parser (Vary [FormatJson, FormatYaml])
 pTxViewOutputFormat = pViewOutputFormat "transaction"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
@@ -28,6 +28,7 @@ import Cardano.Api.Shelley
 
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Key
+import Cardano.CLI.Vary (Vary)
 
 import Data.Text (Text)
 
@@ -157,7 +158,7 @@ data GovernanceActionViewCmdArgs era
   = GovernanceActionViewCmdArgs
   { eon :: !(ConwayEraOnwards era)
   , actionFile :: !(ProposalFile In)
-  , outFormat :: !ViewOutputFormat
+  , outFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
@@ -29,11 +29,9 @@ import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Error.GovernanceActionsError
 import Cardano.CLI.Type.Error.HashCmdError (FetchURLError)
 import Cardano.CLI.Type.Key
-import Cardano.CLI.Vary qualified as Vary
 import Cardano.Ledger.Hashes qualified as L
 
 import Control.Monad
-import Data.Function ((&))
 import GHC.Exts (IsList (..))
 
 runGovernanceActionCmds
@@ -73,17 +71,7 @@ runGovernanceActionViewCmd
       fmap fst . firstExceptT GovernanceActionsCmdProposalError . newExceptT $
         readProposal eon (actionFile, Nothing)
     firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
-      friendlyProposal
-        ( outFormat
-            & ( id
-                  . Vary.on (\FormatJson -> FriendlyJson)
-                  . Vary.on (\FormatYaml -> FriendlyYaml)
-                  $ Vary.exhaustiveCase
-              )
-        )
-        mOutFile
-        eon
-        proposal
+      friendlyProposal outFormat mOutFile eon proposal
 
 runGovernanceActionInfoCmd
   :: forall era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
+{- HLINT ignore "Redundant id" -}
+
 module Cardano.CLI.EraBased.Governance.Actions.Run
   ( runGovernanceActionCmds
   , GovernanceActionsError (..)
@@ -27,9 +29,11 @@ import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Error.GovernanceActionsError
 import Cardano.CLI.Type.Error.HashCmdError (FetchURLError)
 import Cardano.CLI.Type.Key
+import Cardano.CLI.Vary qualified as Vary
 import Cardano.Ledger.Hashes qualified as L
 
 import Control.Monad
+import Data.Function ((&))
 import GHC.Exts (IsList (..))
 
 runGovernanceActionCmds
@@ -70,9 +74,12 @@ runGovernanceActionViewCmd
         readProposal eon (actionFile, Nothing)
     firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
       friendlyProposal
-        ( case outFormat of
-            ViewOutputFormatJson -> FriendlyJson
-            ViewOutputFormatYaml -> FriendlyYaml
+        ( outFormat
+            & ( id
+                  . Vary.on (\FormatJson -> FriendlyJson)
+                  . Vary.on (\FormatYaml -> FriendlyYaml)
+                  $ Vary.exhaustiveCase
+              )
         )
         mOutFile
         eon

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Command.hs
@@ -16,6 +16,7 @@ import Cardano.Api.Shelley
 
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Governance
+import Cardano.CLI.Vary (Vary)
 
 import Data.Text (Text)
 
@@ -44,7 +45,7 @@ data GovernanceVoteCreateCmdArgs era
 data GovernanceVoteViewCmdArgs era
   = GovernanceVoteViewCmdArgs
   { eon :: ConwayEraOnwards era
-  , outFormat :: !ViewOutputFormat
+  , outFormat :: !(Vary [FormatJson, FormatYaml])
   , voteFile :: VoteFile In
   , mOutFile :: Maybe (File () Out)
   }

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -92,7 +92,7 @@ data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
   , poolColdVerKeyFile :: !(VerificationKeyOrHashOrFile StakePoolKey)
   , vrkSkeyFp :: !(SigningKeyFile In)
   , whichSchedule :: !EpochLeadershipSchedule
-  , format :: Maybe OutputFormatJsonOrText
+  , format :: Maybe (Vary [FormatJson, FormatText])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -111,14 +111,14 @@ data QueryTipCmdArgs = QueryTipCmdArgs
 
 data QueryStakePoolsCmdArgs = QueryStakePoolsCmdArgs
   { commons :: !QueryCommons
-  , format :: Maybe OutputFormatJsonOrText
+  , format :: Maybe (Vary [FormatJson, FormatText])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
 
 data QueryStakeDistributionCmdArgs = QueryStakeDistributionCmdArgs
   { commons :: !QueryCommons
-  , format :: Maybe OutputFormatJsonOrText
+  , format :: Maybe (Vary [FormatJson, FormatText])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -194,7 +194,7 @@ data QuerySlotNumberCmdArgs = QuerySlotNumberCmdArgs
 data QueryRefScriptSizeCmdArgs = QueryRefScriptSizeCmdArgs
   { commons :: !QueryCommons
   , transactionInputs :: !(Set TxIn)
-  , format :: Maybe OutputFormatJsonOrText
+  , format :: Maybe (Vary [FormatJson, FormatText])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators #-}
 
 {- HLINT ignore "Alternative law, left identity" -}
 {- HLINT ignore "Move brackets to avoid $" -}
@@ -24,7 +23,6 @@ import Cardano.CLI.EraBased.Query.Command
 import Cardano.CLI.Parser
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Key
-import Cardano.CLI.Vary
 
 import Data.Foldable
 import GHC.Exts (IsList (..))
@@ -362,9 +360,6 @@ pQueryTipCmd era envCli =
       <$> pQueryCommons era envCli
       <*> pMaybeOutputFile
 
-fFrom :: Functor f => a :| l => f a -> f (Vary l)
-fFrom = fmap from
-
 pQueryUTxOCmd :: ShelleyBasedEra era -> EnvCli -> Parser (QueryCmds era)
 pQueryUTxOCmd era envCli =
   fmap QueryUTxOCmd $
@@ -372,10 +367,11 @@ pQueryUTxOCmd era envCli =
       <$> pQueryCommons era envCli
       <*> pQueryUTxOFilter
       <*> ( optional $
-              empty
-                <|> fFrom (pFormatCBOR "utxo")
-                <|> fFrom (pFormatJsonFileDefault "utxo")
-                <|> fFrom (pFormatTextStdoutDefault "utxo")
+              asum
+                [ pFormatCBOR "utxo"
+                , pFormatJsonFileDefault "utxo"
+                , pFormatTextStdoutDefault "utxo"
+                ]
           )
       <*> pMaybeOutputFile
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
@@ -36,6 +36,7 @@ import Cardano.CLI.EraBased.Script.Withdrawal.Type
 import Cardano.CLI.Orphan ()
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Governance
+import Cardano.CLI.Vary (Vary)
 
 import Data.Text (Text)
 
@@ -231,7 +232,7 @@ data TransactionCalculateMinFeeCmdArgs = TransactionCalculateMinFeeCmdArgs
   , txByronWitnessCount :: !TxByronWitnessCount
   , referenceScriptSize :: !ReferenceScriptSize
   -- ^ The total size in bytes of the transaction reference scripts.
-  , outputFormat :: !(Maybe OutputFormatJsonOrText)
+  , outputFormat :: !(Maybe (Vary [FormatJson, FormatText]))
   , outFile :: !(Maybe (File () Out))
   }
   deriving Show
@@ -256,7 +257,7 @@ newtype TransactionHashScriptDataCmdArgs = TransactionHashScriptDataCmdArgs
 
 data TransactionTxIdCmdArgs = TransactionTxIdCmdArgs
   { inputTxBodyOrTxFile :: InputTxBodyOrTxFile
-  , outputFormat :: !OutputFormatJsonOrText
+  , outputFormat :: !(Vary [FormatJson, FormatText])
   }
   deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/TransactionView/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/TransactionView/Command.hs
@@ -3,9 +3,10 @@
 module Cardano.CLI.EraIndependent.Debug.TransactionView.Command where
 
 import Cardano.CLI.Type.Common
+import Cardano.CLI.Vary (Vary)
 
 data TransactionViewCmdArgs = TransactionViewCmdArgs
-  { outputFormat :: !ViewOutputFormat
+  { outputFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   , inputTxBodyOrTxFile :: !InputTxBodyOrTxFile
   }

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/TransactionView/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/TransactionView/Run.hs
@@ -11,7 +11,6 @@ import Cardano.CLI.EraIndependent.Debug.TransactionView.Command
 import Cardano.CLI.Json.Friendly
   ( friendlyTx
   , friendlyTxBody
-  , viewOutputFormatToFriendlyFormat
   )
 import Cardano.CLI.Read
 import Cardano.CLI.Type.Common
@@ -42,9 +41,9 @@ runTransactionViewCmd
         -- this would mean that we'd have an empty list of witnesses mentioned in the output, which
         -- is arguably not part of the transaction body.
         firstExceptT TxCmdWriteFileError . newExceptT $
-          friendlyTxBody (viewOutputFormatToFriendlyFormat outputFormat) mOutFile (toCardanoEra era) txbody
+          friendlyTxBody outputFormat mOutFile (toCardanoEra era) txbody
       InputTxFile (File txFilePath) -> do
         txFile <- liftIO $ fileOrPipe txFilePath
         InAnyShelleyBasedEra era tx <- lift (readFileTx txFile) & onLeft (left . TxCmdTextEnvCddlError)
         firstExceptT TxCmdWriteFileError . newExceptT $
-          friendlyTx (viewOutputFormatToFriendlyFormat outputFormat) mOutFile (toCardanoEra era) tx
+          friendlyTx outputFormat mOutFile (toCardanoEra era) tx

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -9,6 +9,7 @@
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 {-# HLINT ignore "Redundant bracket" #-}
+{-# HLINT ignore "Redundant id" #-}
 
 -- | User-friendly pretty-printing for textual user interfaces (TUI)
 module Cardano.CLI.Json.Friendly
@@ -59,8 +60,10 @@ import Cardano.Api.Shelley
   )
 
 import Cardano.CLI.Orphan ()
-import Cardano.CLI.Type.Common (ViewOutputFormat (..))
+import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.MonadWarning (MonadWarning, runWarningIO)
+import Cardano.CLI.Vary (Vary)
+import Cardano.CLI.Vary qualified as Vary
 import Cardano.Crypto.Hash (hashToTextAsHex)
 
 import Data.Aeson (Value (..), object, toJSON, (.=))
@@ -92,10 +95,12 @@ import Lens.Micro ((^.))
 
 data FriendlyFormat = FriendlyJson | FriendlyYaml
 
-viewOutputFormatToFriendlyFormat :: ViewOutputFormat -> FriendlyFormat
-viewOutputFormatToFriendlyFormat = \case
-  ViewOutputFormatJson -> FriendlyJson
-  ViewOutputFormatYaml -> FriendlyYaml
+viewOutputFormatToFriendlyFormat :: (Vary [FormatJson, FormatYaml]) -> FriendlyFormat
+viewOutputFormatToFriendlyFormat =
+  id
+    . Vary.on (\FormatJson -> FriendlyJson)
+    . Vary.on (\FormatYaml -> FriendlyYaml)
+    $ Vary.exhaustiveCase
 
 friendly
   :: (MonadIO m, Aeson.ToJSON a)

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -4,14 +4,11 @@
 module Cardano.CLI.Parser
   ( readerFromAttoParser
   , readFractionAsRational
-  , readGovernanceActionViewOutputFormat
   , readKeyOutputFormat
   , readIdOutputFormat
-  , readTxViewOutputFormat
   , readRational
   , readRationalUnitInterval
   , readStringOfMaxLength
-  , readViewOutputFormat
   , readURIOfMaxLength
   , commandWithMetavar
   , eDNSName
@@ -22,8 +19,6 @@ where
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Type.Common
-import Cardano.CLI.Vary (Vary)
-import Cardano.CLI.Vary qualified as Vary
 
 import Data.Attoparsec.ByteString.Char8 qualified as Atto
 import Data.ByteString (ByteString)
@@ -61,28 +56,6 @@ readKeyOutputFormat = do
           [ "Invalid key output format: " <> show s
           , ". Accepted output formats are \"text-envelope\" and \"bech32\"."
           ]
-
-readTxViewOutputFormat :: Opt.ReadM (Vary [FormatJson, FormatYaml])
-readTxViewOutputFormat = readViewOutputFormat "transaction"
-
-readViewOutputFormat :: String -> Opt.ReadM (Vary [FormatJson, FormatYaml])
-readViewOutputFormat kind = do
-  s <- Opt.str @String
-  case s of
-    "json" -> pure (Vary.from FormatJson)
-    "yaml" -> pure (Vary.from FormatYaml)
-    _ ->
-      fail $
-        mconcat
-          [ "Invalid "
-          , kind
-          , " output format: " <> show s
-          , ". Accepted output formats are \"json\" and \"yaml\"."
-          ]
-
-readGovernanceActionViewOutputFormat :: Opt.ReadM (Vary [FormatJson, FormatYaml])
-readGovernanceActionViewOutputFormat =
-  readViewOutputFormat "governance action view"
 
 readURIOfMaxLength :: Int -> Opt.ReadM Text
 readURIOfMaxLength maxLen =

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.CLI.Parser
@@ -21,6 +22,8 @@ where
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Type.Common
+import Cardano.CLI.Vary (Vary)
+import Cardano.CLI.Vary qualified as Vary
 
 import Data.Attoparsec.ByteString.Char8 qualified as Atto
 import Data.ByteString (ByteString)
@@ -59,15 +62,15 @@ readKeyOutputFormat = do
           , ". Accepted output formats are \"text-envelope\" and \"bech32\"."
           ]
 
-readTxViewOutputFormat :: Opt.ReadM ViewOutputFormat
+readTxViewOutputFormat :: Opt.ReadM (Vary [FormatJson, FormatYaml])
 readTxViewOutputFormat = readViewOutputFormat "transaction"
 
-readViewOutputFormat :: String -> Opt.ReadM ViewOutputFormat
+readViewOutputFormat :: String -> Opt.ReadM (Vary [FormatJson, FormatYaml])
 readViewOutputFormat kind = do
   s <- Opt.str @String
   case s of
-    "json" -> pure ViewOutputFormatJson
-    "yaml" -> pure ViewOutputFormatYaml
+    "json" -> pure (Vary.from FormatJson)
+    "yaml" -> pure (Vary.from FormatYaml)
     _ ->
       fail $
         mconcat
@@ -77,8 +80,9 @@ readViewOutputFormat kind = do
           , ". Accepted output formats are \"json\" and \"yaml\"."
           ]
 
-readGovernanceActionViewOutputFormat :: Opt.ReadM ViewOutputFormat
-readGovernanceActionViewOutputFormat = readViewOutputFormat "governance action view"
+readGovernanceActionViewOutputFormat :: Opt.ReadM (Vary [FormatJson, FormatYaml])
+readGovernanceActionViewOutputFormat =
+  readViewOutputFormat "governance action view"
 
 readURIOfMaxLength :: Int -> Opt.ReadM Text
 readURIOfMaxLength maxLen =

--- a/cardano-cli/src/Cardano/CLI/Type/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Common.hs
@@ -55,7 +55,6 @@ module Cardano.CLI.Type.Common
   , ProposalText
   , ProposalUrl (..)
   , ProtocolParamsFile (..)
-  , OutputFormatJsonOrText (..)
   , ReferenceScriptAnyEra (..)
   , ReferenceScriptSize (..)
   , RequiredSigner (..)
@@ -485,11 +484,6 @@ data TxMempoolQuery
   | TxMempoolQueryNextTx
   | TxMempoolQueryInfo
   deriving Show
-
-data OutputFormatJsonOrText
-  = OutputFormatJson
-  | OutputFormatText
-  deriving (Eq, Show)
 
 data FormatCBOR = FormatCBOR
   deriving (Enum, Eq, Ord, Show)

--- a/cardano-cli/src/Cardano/CLI/Type/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Common.hs
@@ -29,6 +29,7 @@ module Cardano.CLI.Type.Common
   , FormatCBOR (..)
   , FormatJson (..)
   , FormatText (..)
+  , FormatYaml (..)
   , GenesisDir (..)
   , GenesisFile (..)
   , GenesisKeyFile (..)
@@ -85,7 +86,6 @@ module Cardano.CLI.Type.Common
   , UpdateProposalFile (..)
   , VerificationKeyBase64 (..)
   , VerificationKeyFile
-  , ViewOutputFormat (..)
   , VoteUrl (..)
   , VoteText (..)
   , VoteHashSource (..)
@@ -491,19 +491,17 @@ data OutputFormatJsonOrText
   | OutputFormatText
   deriving (Eq, Show)
 
+data FormatCBOR = FormatCBOR
+  deriving (Enum, Eq, Ord, Show)
+
 data FormatJson = FormatJson
   deriving (Enum, Eq, Ord, Show)
 
 data FormatText = FormatText
   deriving (Enum, Eq, Ord, Show)
 
-data FormatCBOR = FormatCBOR
+data FormatYaml = FormatYaml
   deriving (Enum, Eq, Ord, Show)
-
-data ViewOutputFormat
-  = ViewOutputFormatJson
-  | ViewOutputFormatYaml
-  deriving Show
 
 --
 -- Shelley CLI flag/option data types


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Replace various output format types with `Vary [..]`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This unifies the way we handle output formats except for consistent alphabetical re-ordering or output formation options.

# How to trust this PR

Golden files unchanged.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
