### PR TITLE
Skip HLS on trivial changes

### DIFF
--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -21,7 +21,59 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check if changes were trivial
+        id: check_trivial_changes
+        run: |
+          git fetch origin ${{ github.base_ref }} --unshallow
+          base_ref=origin/${{ github.base_ref }}
+          head_ref=HEAD
+          changed_files=$(git diff-tree --name-status -r "$base_ref".."$head_ref" -- | cut -f2 -d$'\t')
+          # Flag to check whether we do the rest of checks
+          exception=true
+
+          for file in $changed_files; do
+            # If changes were to a markdown file we don't mind
+            if [[ $file == *.md ]]; then
+              echo "$file: is markdown, so it doesn't matter (trivial change)"
+              continue
+            fi
+
+            # If changes were to a .cabal file, we ensure only the version changed
+            if [[ $file == *.cabal ]]; then
+              # If file doesn't exist it means it was moved or removed
+              if [ ! -f "$file" ]; then
+                echo "$file: was moved or removed and is a cabal file (non-trivial change)"
+                exception=false
+                break
+              fi
+
+              # We ensure the only change was to the version field
+              diff_version=$(git diff "$base_ref".."$head_ref" -- "$file" | perl -ne 'print if /^-(?!version:)/' | wc -l)
+              diff_no_version=$(git diff "$base_ref".."$head_ref" -- "$file" | perl -ne 'print if /^\+(?!version:)/' | wc -l)
+
+              if [ "$diff_version" -gt 1 ] || [ "$diff_no_version" -gt 1 ]; then
+                echo "$file: was modified beyond the version tag (non-trivial change)"
+                exception=false
+                break
+              fi
+              echo "In $file, at most the version field was modified"
+            else
+              # If other types of files were changed, do not skip the checks
+              echo "$file: was changed and is not a markdown nor a cabal file (non-trivial change)"
+              exception=false
+              break
+            fi
+          done
+
+          if $exception; then
+            echo "CHECK_HLS_WORKS=0" >> "$GITHUB_OUTPUT"
+            echo "All changes are trival, skipping rest of checks..."
+          else
+            echo "CHECK_HLS_WORKS=1" >> "$GITHUB_OUTPUT"
+            echo "Some changes are non-trivial. We need to do the checks!"
+          fi
       - uses: cachix/install-nix-action@v30
+        if: steps.check_trivial_changes.outputs.CHECK_HLS_WORKS > 0
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
@@ -29,16 +81,20 @@ jobs:
             substituters = https://cache.iog.io/ https://cache.nixos.org/
 
       - uses: rrbutani/use-nix-shell-action@v1
+        if: steps.check_trivial_changes.outputs.CHECK_HLS_WORKS > 0
 
       - name: Update dependencies
+        if: steps.check_trivial_changes.outputs.CHECK_HLS_WORKS > 0
         run: cabal update; cabal freeze
 
       - name: Obtain GHC version
+        if: steps.check_trivial_changes.outputs.CHECK_HLS_WORKS > 0
         run: |
           echo "VERSION=$(ghc --numeric-version)" >> "$GITHUB_OUTPUT"
         id: ghc
 
       - name: HLS caching
+        if: steps.check_trivial_changes.outputs.CHECK_HLS_WORKS > 0
         uses: actions/cache@v4
         with:
           path: |
@@ -52,4 +108,5 @@ jobs:
             hls-cache-${{ env.HLS_CACHE_VERSION }}-${{ runner.os }}-${{ steps.ghc.outputs.VERSION }}-${{ hashFiles('**/cabal.project.freeze') }}-
 
       - name: Test HLS works
+        if: steps.check_trivial_changes.outputs.CHECK_HLS_WORKS > 0
         run: haskell-language-server


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Skip HLS checks on trivial changes
  type:
  - maintenance    # not directly related to the code
```

# Context

Doing releases doesn't affect whether HLS works or not. For that reason, we want to skip the check when it doesn't make sense. This PR introduces an exception for when only markdown is changed and for when only the version in a cabal file is changed.

# How to trust this PR

That is tricky. I've been testing the different possibilities, but it isn't easy to test.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
