### PR TITLE
A more precise way to specify flags

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -176,6 +176,8 @@ library
     Cardano.CLI.Legacy.Run
     Cardano.CLI.OS.Posix
     Cardano.CLI.Option
+    Cardano.CLI.Option.Flag
+    Cardano.CLI.Option.Flag.Type
     Cardano.CLI.Orphan
     Cardano.CLI.Parser
     Cardano.CLI.Read
@@ -264,6 +266,7 @@ library
     exceptions,
     filepath,
     formatting,
+    generic-lens,
     haskeline,
     http-client,
     http-client-tls,

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -133,7 +133,7 @@ data QueryStakeAddressInfoCmdArgs = QueryStakeAddressInfoCmdArgs
 data QueryUTxOCmdArgs = QueryUTxOCmdArgs
   { commons :: !QueryCommons
   , queryFilter :: !QueryUTxOFilter
-  , format :: Maybe (Vary [FormatCBOR, FormatJson, FormatText])
+  , format :: Vary [FormatCbor, FormatJson, FormatText]
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -20,11 +20,13 @@ import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 import Cardano.CLI.Environment (EnvCli (..))
 import Cardano.CLI.EraBased.Common.Option
 import Cardano.CLI.EraBased.Query.Command
+import Cardano.CLI.Option.Flag
 import Cardano.CLI.Parser
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Key
 
 import Data.Foldable
+import Data.Function
 import GHC.Exts (IsList (..))
 import Options.Applicative hiding (help, str)
 import Options.Applicative qualified as Opt
@@ -366,13 +368,12 @@ pQueryUTxOCmd era envCli =
     QueryUTxOCmdArgs
       <$> pQueryCommons era envCli
       <*> pQueryUTxOFilter
-      <*> ( optional $
-              asum
-                [ pFormatCBOR "utxo"
-                , pFormatJsonFileDefault "utxo"
-                , pFormatTextStdoutDefault "utxo"
-                ]
-          )
+      <*> pFormatFlags
+        "utxo query output"
+        [ flagFormatCbor
+        , flagFormatJson & setDefault
+        , flagFormatText
+        ]
       <*> pMaybeOutputFile
 
 pQueryStakePoolsCmd :: ShelleyBasedEra era -> EnvCli -> Parser (QueryCmds era)

--- a/cardano-cli/src/Cardano/CLI/Option/Flag.hs
+++ b/cardano-cli/src/Cardano/CLI/Option/Flag.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.CLI.Option.Flag
+  ( Flag (Flag)
+  , FlagOptions (FlagOptions)
+  , Defaultness (..)
+  , setDefault
+  , mkFlag
+  , parserFromFlags
+  )
+where
+
+import Cardano.CLI.Option.Flag.Type
+  ( Defaultness (IsDefault)
+  , Flag (Flag)
+  , FlagOptions (FlagOptions)
+  , defaultFlagOptions
+  )
+import Cardano.CLI.Option.Flag.Type qualified as Z
+import Cardano.CLI.Vary
+import Cardano.CLI.Vary qualified as Vary
+
+import Control.Applicative
+import Data.Function
+import Data.Generics.Product.Any
+import Lens.Micro
+import Options.Applicative (Parser)
+import Options.Applicative qualified as Opt
+
+-- | Create a parser from a help rendering function and list of flags.
+-- A default parser is included at the end of parser alternatives for
+-- the default flag (there should only be one default, but if more than
+-- one is specified, the first such one is used as the default).
+parserFromFlags :: (Flag a -> String) -> [Flag a] -> Parser a
+parserFromFlags _ [] = empty
+parserFromFlags mkHelp fs =
+  alternatives fs <|> defaults fs
+ where
+  alternatives [] = empty
+  alternatives (x : xs) =
+    parserFromFlag mkHelp x <|> alternatives xs
+
+  defaults :: [Flag a] -> Parser a
+  defaults = \case
+    [] -> empty
+    (x : xs) | flagIsDefault x -> parserFromFlagDefault x <|> defaults xs
+    (_ : xs) -> defaults xs
+
+flagIsDefault :: Flag a -> Bool
+flagIsDefault flag =
+  Z.isDefault (Z.options flag) == Z.IsDefault
+
+parserFromFlag :: (Flag a -> String) -> Flag a -> Parser a
+parserFromFlag mkHelp flag =
+  Opt.flag' (flag & Z.value) $
+    mconcat
+      [ Opt.long $ flag & Z.longName
+      , Opt.help $ mkHelp flag
+      ]
+
+parserFromFlagDefault :: Flag a -> Parser a
+parserFromFlagDefault flag =
+  pure $ flag & Z.value
+
+mkFlag
+  :: a :| fs
+  => String
+  -> String
+  -> a
+  -> Flag (Vary fs)
+mkFlag longName format value =
+  Flag longName format defaultFlagOptions (Vary.from value)
+
+setDefault :: Flag a -> Flag a
+setDefault flag =
+  flag & the @"options" . the @"isDefault" .~ IsDefault

--- a/cardano-cli/src/Cardano/CLI/Option/Flag/Type.hs
+++ b/cardano-cli/src/Cardano/CLI/Option/Flag/Type.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module Cardano.CLI.Option.Flag.Type
+  ( Flag (..)
+  , Defaultness (..)
+  , FlagOptions (..)
+  , defaultFlagOptions
+  )
+where
+
+import GHC.Generics
+
+data Defaultness
+  = IsDefault
+  | NonDefault
+  deriving (Show, Eq, Generic)
+
+-- | Options for a flag that control how it is rendered and parsed.
+newtype FlagOptions = FlagOptions
+  { isDefault :: Defaultness
+  -- ^ Whether the flag is a default value.
+  }
+  deriving (Show, Eq, Generic)
+
+-- instance Semigroup FlagOptions where
+--   FlagOptions IsDefault <> FlagOptions _ = FlagOptions IsDefault
+--   FlagOptions _ <> FlagOptions IsDefault = FlagOptions IsDefault
+--   FlagOptions _ <> FlagOptions _ = FlagOptions NonDefault
+
+-- instance Monoid FlagOptions where
+--   mempty = FlagOptions NonDefault
+--   mappend = (<>)
+
+-- | A flag that can be used in the command line interface.
+--
+-- It contains information about how to render the flag, its long name,
+-- its content, and its value.
+-- The type variable 'a' represents the type of the value that the flag holds.
+--
+-- The reason for this type instead of using 'Parser a' directly is to
+-- allow for more complex parsing logic, such as handling default values.
+data Flag a = Flag
+  { longName :: String
+  , format :: String
+  , options :: FlagOptions
+  , value :: a
+  }
+  deriving (Show, Eq, Generic)
+
+defaultFlagOptions :: FlagOptions
+defaultFlagOptions = FlagOptions NonDefault

--- a/cardano-cli/src/Cardano/CLI/Type/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Common.hs
@@ -26,7 +26,7 @@ module Cardano.CLI.Type.Common
   , EpochLeadershipSchedule (..)
   , File (..)
   , FileDirection (..)
-  , FormatCBOR (..)
+  , FormatCbor (..)
   , FormatJson (..)
   , FormatText (..)
   , FormatYaml (..)
@@ -485,7 +485,7 @@ data TxMempoolQuery
   | TxMempoolQueryInfo
   deriving Show
 
-data FormatCBOR = FormatCBOR
+data FormatCbor = FormatCbor
   deriving (Enum, Eq, Ord, Show)
 
 data FormatJson = FormatJson

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
@@ -36,9 +36,7 @@ Available options:
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
   --tx-in TX-IN            Filter by transaction input (TxId#TxIx).
   --output-cbor            Format utxo query output to BASE16 CBOR.
-  --output-json            Format utxo query output to JSON. Default format when
-                           writing to a file
-  --output-text            Format utxo query output to TEXT. Default format when
-                           writing to stdout
+  --output-json            Format utxo query output to JSON (default).
+  --output-text            Format utxo query output to TEXT.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_utxo.cli
@@ -36,9 +36,7 @@ Available options:
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
   --tx-in TX-IN            Filter by transaction input (TxId#TxIx).
   --output-cbor            Format utxo query output to BASE16 CBOR.
-  --output-json            Format utxo query output to JSON. Default format when
-                           writing to a file
-  --output-text            Format utxo query output to TEXT. Default format when
-                           writing to stdout
+  --output-json            Format utxo query output to JSON (default).
+  --output-text            Format utxo query output to TEXT.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_utxo.cli
@@ -33,9 +33,7 @@ Available options:
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
   --tx-in TX-IN            Filter by transaction input (TxId#TxIx).
   --output-cbor            Format utxo query output to BASE16 CBOR.
-  --output-json            Format utxo query output to JSON. Default format when
-                           writing to a file
-  --output-text            Format utxo query output to TEXT. Default format when
-                           writing to stdout
+  --output-json            Format utxo query output to JSON (default).
+  --output-text            Format utxo query output to TEXT.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Make the output format flag for the `query utxo` command only have one default: JSON (rather than a different default depending on whether the output file is specified)
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

A new way to specify flags in code that makes the default flag specification more concise and DRY whilst making it easier to standardise on flag help wording whilst still providing flexibility.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
