### PR TITLE
Fix stakePools query output format

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -1323,11 +1323,11 @@ writeStakePools format mOutFile stakePools =
             $ Vary.exhaustiveCase
         )
   writeJson =
+    encodePretty stakePools
+  writeText =
     LBS.unlines $
       map (strictTextToLazyBytestring . serialiseToBech32) $
         toList stakePools
-  writeText =
-    encodePretty stakePools
 
 writeFormattedOutput
   :: MonadIOTransError QueryCmdError t m


### PR DESCRIPTION
Corrected the output format for `writeText` and `writeJson` in `writeStakePools` function. Previously, `writeText` incorrectly outputed JSON and `writeJson` outputed text.

# Changelog

```yaml
- description: |
    Corrected the flipped text & JSON output format for `query stake-pools` function.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/1138

# How to trust this PR

I've built the fixed binary and tested it.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
