### PR TITLE
Standardise default output format for commands

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -1770,15 +1770,6 @@ pPoolIdOutputFormat =
       , Opt.value IdOutputFormatBech32
       ]
 
--- | @pOutputFormatJsonOrText kind@ is a parser to specify in which format
--- to view some data (json or text). @kind@ is the kind of data considered.
-pOutputFormatJsonOrText :: String -> Parser (Vary [FormatJson, FormatText])
-pOutputFormatJsonOrText kind =
-  asum
-    [ make' FormatJson "JSON" "json" (Just " Default format when writing to a file") kind
-    , make' FormatText "TEXT" "text" (Just " Default format when writing to stdout") kind
-    ]
-
 -- | Make a parser for an output format.
 make'
   :: a :| fs

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -1834,9 +1834,6 @@ flagFormatYaml
 flagFormatYaml =
   mkFlag "output-yaml" "YAML" FormatYaml
 
-pTxViewOutputFormat :: Parser (Vary [FormatJson, FormatYaml])
-pTxViewOutputFormat = pViewOutputFormat "transaction"
-
 pGovernanceActionViewOutputFormat :: Parser (Vary [FormatJson, FormatYaml])
 pGovernanceActionViewOutputFormat = pViewOutputFormat "governance action"
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -1834,39 +1834,6 @@ flagFormatYaml
 flagFormatYaml =
   mkFlag "output-yaml" "YAML" FormatYaml
 
-pGovernanceVoteViewOutputFormat :: Parser (Vary [FormatJson, FormatYaml])
-pGovernanceVoteViewOutputFormat = pViewOutputFormat "governance vote"
-
--- | @pViewOutputFormat kind@ is a parser to specify in which format
--- to view some data (json or yaml). @what@ is the kind of data considered.
-pViewOutputFormat :: String -> Parser (Vary [FormatJson, FormatYaml])
-pViewOutputFormat kind =
-  asum
-    [ make FormatJson "JSON" "json" Nothing
-    , make FormatYaml "YAML" "yaml" (Just " Defaults to JSON if unspecified.")
-    ]
- where
-  make
-    :: a :| fs
-    => FormatJson :| fs
-    => a
-    -> String
-    -> String
-    -> Maybe String
-    -> Parser (Vary fs)
-  make format desc flag_ extraHelp =
-    Opt.flag (Vary.from FormatJson) (Vary.from format) $
-      mconcat
-        [ Opt.help $
-            "Format "
-              <> kind
-              <> " view output to "
-              <> desc
-              <> "."
-              <> fromMaybe "" extraHelp
-        , Opt.long ("output-" <> flag_)
-        ]
-
 pMaybeOutputFile :: Parser (Maybe (File content Out))
 pMaybeOutputFile =
   optional $

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -57,7 +57,6 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Time.Clock (UTCTime)
 import Data.Time.Format (defaultTimeLocale, parseTimeOrError)
-import Data.Type.Equality
 import Data.Word
 import GHC.Exts (IsList (..))
 import GHC.Natural (Natural)
@@ -74,7 +73,6 @@ import Text.Parsec.Token qualified as Parsec
 import Text.Read (readEither, readMaybe)
 import Text.Read qualified as Read
 
-import Type.Reflection qualified as TR
 import Vary (Vary, (:|))
 import Vary qualified
 
@@ -1835,35 +1833,6 @@ flagFormatYaml
   => Flag (Vary fs)
 flagFormatYaml =
   mkFlag "output-yaml" "YAML" FormatYaml
-
--- | @pTxIdOutputFormatJsonOrText kind@ is a parser to specify in which format
--- to write @transaction txid@'s output on standard output.
-pTxIdOutputFormatJsonOrText :: Parser (Vary [FormatJson, FormatText])
-pTxIdOutputFormatJsonOrText =
-  asum [make FormatJson "JSON" "json", make FormatText "TEXT" "text"]
-    <|> pure (Vary.from default_)
- where
-  default_ :: FormatText
-  default_ = FormatText
-  make
-    :: forall a fs
-     . a :| fs
-    => Typeable a
-    => a
-    -> String
-    -> String
-    -> Parser (Vary fs)
-  make format desc flag_ =
-    Opt.flag' (Vary.from format) $
-      mconcat
-        [ Opt.help $ "Format output as " <> desc <> maybeDefault <> "."
-        , Opt.long ("output-" <> flag_)
-        ]
-   where
-    maybeDefault =
-      case TR.eqTypeRep (TR.typeRep @a) (TR.typeRep @FormatText) of
-        Just HRefl -> " (the default)"
-        Nothing -> ""
 
 pTxViewOutputFormat :: Parser (Vary [FormatJson, FormatYaml])
 pTxViewOutputFormat = pViewOutputFormat "transaction"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -1834,9 +1834,6 @@ flagFormatYaml
 flagFormatYaml =
   mkFlag "output-yaml" "YAML" FormatYaml
 
-pGovernanceActionViewOutputFormat :: Parser (Vary [FormatJson, FormatYaml])
-pGovernanceActionViewOutputFormat = pViewOutputFormat "governance action"
-
 pGovernanceVoteViewOutputFormat :: Parser (Vary [FormatJson, FormatYaml])
 pGovernanceVoteViewOutputFormat = pViewOutputFormat "governance vote"
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Option.hs
@@ -13,10 +13,12 @@ import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Common.Option
 import Cardano.CLI.EraBased.Governance.Actions.Command qualified as Cmd
+import Cardano.CLI.Option.Flag (setDefault)
 import Cardano.CLI.Parser
 import Cardano.CLI.Type.Common
 
 import Data.Foldable
+import Data.Function ((&))
 import GHC.Natural (Natural)
 import Options.Applicative
 import Options.Applicative qualified as Opt
@@ -55,7 +57,11 @@ pGovernanceActionViewCmd era = do
       ( fmap Cmd.GovernanceActionViewCmd $
           Cmd.GovernanceActionViewCmdArgs eon
             <$> pFileInDirection "action-file" "Path to action file."
-            <*> pGovernanceActionViewOutputFormat
+            <*> pFormatFlags
+              "governance action view output"
+              [ flagFormatJson & setDefault
+              , flagFormatYaml
+              ]
             <*> pMaybeOutputFile
       )
     $ Opt.progDesc "View a governance action."

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Option.hs
@@ -14,11 +14,13 @@ import Cardano.CLI.EraBased.Governance.Vote.Command
   , GovernanceVoteCreateCmdArgs (GovernanceVoteCreateCmdArgs)
   , GovernanceVoteViewCmdArgs (GovernanceVoteViewCmdArgs)
   )
+import Cardano.CLI.Option.Flag (setDefault)
 import Cardano.CLI.Parser
 import Cardano.CLI.Type.Governance
 
 import Control.Applicative (optional)
 import Data.Foldable
+import Data.Function ((&))
 import Options.Applicative (Parser)
 import Options.Applicative qualified as Opt
 
@@ -89,6 +91,10 @@ pGovernanceVoteViewCmd era = do
 pGovernanceVoteViewCmdArgs :: ConwayEraOnwards era -> Parser (GovernanceVoteViewCmdArgs era)
 pGovernanceVoteViewCmdArgs cOnwards =
   GovernanceVoteViewCmdArgs cOnwards
-    <$> pGovernanceVoteViewOutputFormat
+    <$> pFormatFlags
+      "governance vote view output"
+      [ flagFormatJson & setDefault
+      , flagFormatYaml
+      ]
     <*> pFileInDirection "vote-file" "Input filepath of the vote."
     <*> pMaybeOutputFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -195,7 +195,7 @@ data QuerySlotNumberCmdArgs = QuerySlotNumberCmdArgs
 data QueryRefScriptSizeCmdArgs = QueryRefScriptSizeCmdArgs
   { commons :: !QueryCommons
   , transactionInputs :: !(Set TxIn)
-  , format :: Maybe (Vary [FormatJson, FormatText])
+  , format :: Vary [FormatJson, FormatText]
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -112,7 +112,7 @@ data QueryTipCmdArgs = QueryTipCmdArgs
 
 data QueryStakePoolsCmdArgs = QueryStakePoolsCmdArgs
   { commons :: !QueryCommons
-  , format :: Maybe (Vary [FormatJson, FormatText])
+  , format :: Vary [FormatJson, FormatText]
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -119,7 +119,7 @@ data QueryStakePoolsCmdArgs = QueryStakePoolsCmdArgs
 
 data QueryStakeDistributionCmdArgs = QueryStakeDistributionCmdArgs
   { commons :: !QueryCommons
-  , format :: Maybe (Vary [FormatJson, FormatText])
+  , format :: Vary [FormatJson, FormatText]
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -93,7 +93,7 @@ data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
   , poolColdVerKeyFile :: !(VerificationKeyOrHashOrFile StakePoolKey)
   , vrkSkeyFp :: !(SigningKeyFile In)
   , whichSchedule :: !EpochLeadershipSchedule
-  , format :: Maybe (Vary [FormatJson, FormatText])
+  , format :: Vary [FormatJson, FormatText]
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -93,7 +93,7 @@ data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
   , poolColdVerKeyFile :: !(VerificationKeyOrHashOrFile StakePoolKey)
   , vrkSkeyFp :: !(SigningKeyFile In)
   , whichSchedule :: !EpochLeadershipSchedule
-  , format :: Vary [FormatJson, FormatText]
+  , format :: !(Vary [FormatJson, FormatText])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -112,14 +112,14 @@ data QueryTipCmdArgs = QueryTipCmdArgs
 
 data QueryStakePoolsCmdArgs = QueryStakePoolsCmdArgs
   { commons :: !QueryCommons
-  , format :: Vary [FormatJson, FormatText]
+  , format :: !(Vary [FormatJson, FormatText])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
 
 data QueryStakeDistributionCmdArgs = QueryStakeDistributionCmdArgs
   { commons :: !QueryCommons
-  , format :: Vary [FormatJson, FormatText]
+  , format :: !(Vary [FormatJson, FormatText])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -134,7 +134,7 @@ data QueryStakeAddressInfoCmdArgs = QueryStakeAddressInfoCmdArgs
 data QueryUTxOCmdArgs = QueryUTxOCmdArgs
   { commons :: !QueryCommons
   , queryFilter :: !QueryUTxOFilter
-  , format :: Vary [FormatCbor, FormatJson, FormatText]
+  , format :: !(Vary [FormatCbor, FormatJson, FormatText])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -195,7 +195,7 @@ data QuerySlotNumberCmdArgs = QuerySlotNumberCmdArgs
 data QueryRefScriptSizeCmdArgs = QueryRefScriptSizeCmdArgs
   { commons :: !QueryCommons
   , transactionInputs :: !(Set TxIn)
-  , format :: Vary [FormatJson, FormatText]
+  , format :: !(Vary [FormatJson, FormatText])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -393,7 +393,11 @@ pQueryStakeDistributionCmd era envCli =
   fmap QueryStakeDistributionCmd $
     QueryStakeDistributionCmdArgs
       <$> pQueryCommons era envCli
-      <*> (optional $ pOutputFormatJsonOrText "stake-distribution")
+      <*> pFormatFlags
+        "stake-distribution query output"
+        [ flagFormatJson & setDefault
+        , flagFormatText
+        ]
       <*> pMaybeOutputFile
 
 pQueryStakeAddressInfoCmd :: ShelleyBasedEra era -> EnvCli -> Parser (QueryCmds era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -496,7 +496,11 @@ pLeadershipScheduleCmd era envCli =
       <*> pStakePoolVerificationKeyOrHashOrFile Nothing
       <*> pVrfSigningKeyFile
       <*> pWhichLeadershipSchedule
-      <*> (optional $ pOutputFormatJsonOrText "leadership-schedule")
+      <*> pFormatFlags
+        "leadership-schedule query output"
+        [ flagFormatJson & setDefault
+        , flagFormatText
+        ]
       <*> pMaybeOutputFile
 
 pKesPeriodInfoCmd :: ShelleyBasedEra era -> EnvCli -> Parser (QueryCmds era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -531,7 +531,11 @@ pQueryRefScriptSizeCmd era envCli =
     QueryRefScriptSizeCmdArgs
       <$> pQueryCommons era envCli
       <*> (fromList <$> some pByTxIn)
-      <*> (optional $ pOutputFormatJsonOrText "reference inputs")
+      <*> pFormatFlags
+        "reference inputs query output"
+        [ flagFormatJson & setDefault
+        , flagFormatText
+        ]
       <*> pMaybeOutputFile
  where
   pByTxIn :: Parser TxIn

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -381,7 +381,11 @@ pQueryStakePoolsCmd era envCli =
   fmap QueryStakePoolsCmd $
     QueryStakePoolsCmdArgs
       <$> pQueryCommons era envCli
-      <*> (optional $ pOutputFormatJsonOrText "stake-pools")
+      <*> pFormatFlags
+        "stake-pools query output"
+        [ flagFormatJson & setDefault
+        , flagFormatText
+        ]
       <*> pMaybeOutputFile
 
 pQueryStakeDistributionCmd :: ShelleyBasedEra era -> EnvCli -> Parser (QueryCmds era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -1375,7 +1375,7 @@ runQueryStakeDistributionCmd
             result <- easyRunQuery (queryStakeDistribution sbe)
 
             pure $ do
-              writeStakeDistribution (newOutputFormat format mOutFile) mOutFile result
+              writeStakeDistribution format mOutFile result
         )
         & onLeft (left . QueryCmdAcquireFailure)
         & onLeft left

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -1300,7 +1300,7 @@ runQueryStakePoolsCmd
 
             poolIds <- easyRunQuery (queryStakePools sbe)
 
-            pure $ writeStakePools (newOutputFormat format mOutFile) mOutFile poolIds
+            pure $ writeStakePools format mOutFile poolIds
         )
         & onLeft (left . QueryCmdAcquireFailure)
         & onLeft left

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -1333,16 +1333,16 @@ writeFormattedOutput
   :: MonadIOTransError QueryCmdError t m
   => ToJSON a
   => Pretty a
-  => Maybe (Vary [FormatJson, FormatText])
+  => Vary [FormatJson, FormatText]
   -> Maybe (File b Out)
   -> a
   -> t m ()
-writeFormattedOutput mFormat mOutFile value =
+writeFormattedOutput format mOutFile value =
   modifyError QueryCmdWriteFileError . hoistIOEither $
     writeLazyByteStringOutput mOutFile toWrite
  where
   toWrite :: LBS.ByteString =
-    newOutputFormat mFormat mOutFile
+    format
       & ( id
             . Vary.on (\FormatJson -> encodePretty value)
             . Vary.on (\FormatText -> fromString . docToString $ pretty value)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -1515,7 +1515,7 @@ runQueryLeadershipScheduleCmd
      where
       start = SystemStart $ sgSystemStart shelleyGenesis
       toWrite =
-        newOutputFormat format mOutFile'
+        format
           & ( id
                 . Vary.on (\FormatJson -> encodePretty $ leadershipScheduleToJson schedule eInfo start)
                 . Vary.on (\FormatText -> strictTextToLazyBytestring $ leadershipScheduleToText schedule eInfo start)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -33,7 +33,6 @@ module Cardano.CLI.EraBased.Query.Run
   , runQueryTxMempoolCmd
   , runQueryUTxOCmd
   , DelegationsAndRewards (..)
-  , newOutputFormat
   , renderQueryCmdError
   , renderOpCertIntervalInformation
   , percentage
@@ -1986,19 +1985,6 @@ requireEon minEra era =
   hoistMaybe
     (mkEraMismatchError NodeEraMismatchError{nodeEra = era, era = minEra})
     (forEraMaybeEon era)
-
--- | The output format to use, for commands with a recently introduced --output-[json,text] flag
--- and that used to have the following default: --out-file implies JSON,
--- output to stdout implied text.
-newOutputFormat
-  :: Maybe (Vary [FormatJson, FormatText])
-  -> Maybe a
-  -> Vary [FormatJson, FormatText]
-newOutputFormat format mOutFile =
-  case (format, mOutFile) of
-    (Just f, _) -> f -- Take flag from CLI if specified
-    (Nothing, Nothing) -> Vary.from FormatText -- No CLI flag, writing to stdout: write text
-    (Nothing, Just _) -> Vary.from FormatJson -- No CLI flag, writing to a file: write JSON
 
 strictTextToLazyBytestring :: Text -> LBS.ByteString
 strictTextToLazyBytestring t = BS.fromChunks [Text.encodeUtf8 t]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
@@ -248,7 +248,7 @@ data TransactionCalculateMinFeeCmdArgs = TransactionCalculateMinFeeCmdArgs
   , txByronWitnessCount :: !TxByronWitnessCount
   , referenceScriptSize :: !ReferenceScriptSize
   -- ^ The total size in bytes of the transaction reference scripts.
-  , outputFormat :: !(Maybe (Vary [FormatJson, FormatText]))
+  , outputFormat :: !(Vary [FormatJson, FormatText])
   , outFile :: !(Maybe (File () Out))
   }
   deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
@@ -429,7 +429,11 @@ pTransactionId =
   fmap TransactionTxIdCmd $
     TransactionTxIdCmdArgs
       <$> pInputTxOrTxBodyFile
-      <*> pTxIdOutputFormatJsonOrText
+      <*> pFormatFlags
+        "output"
+        [ flagFormatJson & setDefault
+        , flagFormatText
+        ]
 
 pIsCborOutCanonical :: Parser TxCborFormat
 pIsCborOutCanonical =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
@@ -16,11 +16,13 @@ import Cardano.Api.Experimental qualified as Exp
 import Cardano.CLI.Environment (EnvCli (..))
 import Cardano.CLI.EraBased.Common.Option
 import Cardano.CLI.EraBased.Transaction.Command
+import Cardano.CLI.Option.Flag
 import Cardano.CLI.Parser
 import Cardano.CLI.Type.Common
 
 import Control.Monad
 import Data.Foldable
+import Data.Function ((&))
 import Data.Functor
 import Options.Applicative hiding (help, str)
 import Options.Applicative qualified as Opt
@@ -380,7 +382,11 @@ pTransactionCalculateMinFee =
       <*> pTxShelleyWitnessCount
       <*> pTxByronWitnessCount
       <*> pReferenceScriptSize
-      <*> (optional $ pOutputFormatJsonOrText "calculate-min-fee")
+      <*> pFormatFlags
+        "calculate-min-fee query output"
+        [ flagFormatJson & setDefault
+        , flagFormatText
+        ]
       <*> optional pOutputFile
       -- Deprecated options:
       <* optional pNetworkIdDeprecated

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
@@ -49,7 +49,6 @@ import Cardano.Api.Shelley
 
 import Cardano.Binary qualified as CBOR
 import Cardano.CLI.EraBased.Genesis.Internal.Common (readProtocolParameters)
-import Cardano.CLI.EraBased.Query.Run
 import Cardano.CLI.EraBased.Script.Certificate.Read
 import Cardano.CLI.EraBased.Script.Certificate.Type (CertificateScriptWitness (..))
 import Cardano.CLI.EraBased.Script.Mint.Read
@@ -1581,7 +1580,7 @@ runTransactionCalculateMinFeeCmd
         textToWrite = docToText $ pretty fee
         jsonToWrite = encodePretty $ Aeson.object ["fee" .= fee]
 
-    newOutputFormat outputFormat outFile
+    outputFormat
       & ( id
             . Vary.on
               ( \FormatJson -> case outFile of

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/Option.hs
@@ -19,9 +19,11 @@ import Cardano.CLI.EraIndependent.Debug.CheckNodeConfiguration.Command
 import Cardano.CLI.EraIndependent.Debug.Command
 import Cardano.CLI.EraIndependent.Debug.LogEpochState.Command
 import Cardano.CLI.EraIndependent.Debug.TransactionView.Command
+import Cardano.CLI.Option.Flag
 import Cardano.CLI.Parser
 
 import Data.Foldable
+import Data.Function ((&))
 import Options.Applicative hiding (help, str)
 import Options.Applicative qualified as Opt
 
@@ -84,7 +86,11 @@ pDebugCmds envCli =
   pTransactionView =
     fmap DebugTransactionViewCmd $
       TransactionViewCmdArgs
-        <$> pTxViewOutputFormat
+        <$> pFormatFlags
+          "transaction view output"
+          [ flagFormatJson & setDefault
+          , flagFormatYaml
+          ]
         <*> pMaybeOutputFile
         <*> pInputTxOrTxBodyFile
 

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -92,7 +92,7 @@ import Vary qualified
 
 friendly
   :: (MonadIO m, Aeson.ToJSON a)
-  => (Vary [FormatJson, FormatYaml])
+  => Vary [FormatJson, FormatYaml]
   -> Maybe (File () Out)
   -> a
   -> m (Either (FileError e) ())
@@ -107,7 +107,7 @@ friendly format mOutFile =
 friendlyBS
   :: ()
   => Aeson.ToJSON a
-  => (Vary [FormatJson, FormatYaml])
+  => Vary [FormatJson, FormatYaml]
   -> a
   -> BS.ByteString
 friendlyBS format a =
@@ -126,7 +126,7 @@ yamlConfig = Yaml.defConfig & setConfCompare compare
 
 friendlyTx
   :: MonadIO m
-  => (Vary [FormatJson, FormatYaml])
+  => Vary [FormatJson, FormatYaml]
   -> Maybe (File () Out)
   -> CardanoEra era
   -> Tx era
@@ -141,7 +141,7 @@ friendlyTx format mOutFile era =
 
 friendlyTxBody
   :: MonadIO m
-  => (Vary [FormatJson, FormatYaml])
+  => Vary [FormatJson, FormatYaml]
   -> Maybe (File () Out)
   -> CardanoEra era
   -> TxBody era
@@ -156,7 +156,7 @@ friendlyTxBody format mOutFile era =
 
 friendlyProposal
   :: MonadIO m
-  => (Vary [FormatJson, FormatYaml])
+  => Vary [FormatJson, FormatYaml]
   -> Maybe (File () Out)
   -> ConwayEraOnwards era
   -> Proposal era

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Babbage/Transaction/CalculateMinFee.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Babbage/Transaction/CalculateMinFee.hs
@@ -5,10 +5,14 @@ module Test.Golden.Babbage.Transaction.CalculateMinFee
   )
 where
 
+import Data.Aeson ((.=))
+import Data.Aeson qualified as Aeson
+import Data.Text.Lazy qualified as TL
+import Data.Text.Lazy.Encoding qualified as TL
+
 import Test.Cardano.CLI.Util
 
-import Hedgehog (Property)
-import Hedgehog qualified as H
+import Hedgehog (Property, (===))
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -34,4 +38,4 @@ hprop_golden_babbage_transaction_calculate_min_fee = propertyOnce $ do
       , txBodyFile
       ]
 
-  H.diff minFeeTxt (==) "165633 Lovelace\n"
+  Aeson.decode (TL.encodeUtf8 (TL.pack minFeeTxt)) === Just (Aeson.object ["fee" .= (165633 :: Int)])

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
@@ -12,7 +12,7 @@ import System.FilePath ((</>))
 
 import Test.Cardano.CLI.Util
 
-import Hedgehog (Property)
+import Hedgehog (Property, (===))
 import Hedgehog qualified as H
 import Hedgehog.Extras qualified as H
 
@@ -62,7 +62,7 @@ hprop_golden_shelley_transaction_calculate_min_fee = do
 
       case flags of
         [] ->
-          H.diff minFeeTxt (==) "2050100 Lovelace\n"
+          Aeson.decode (TL.encodeUtf8 (TL.pack minFeeTxt)) === Just (Aeson.object ["fee" .= (2050100 :: Int)])
         ["--output-text"] ->
           H.diff minFeeTxt (==) "2050100 Lovelace\n"
         ["--output-text", "--out-file"] -> do

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Id.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Id.hs
@@ -19,9 +19,10 @@ hprop_golden_shelley_transaction_id = propertyOnce $ do
   let baseCmd = ["latest", "transaction", "txid", "--tx-file", txFile]
 
   output1 <- execCardanoCLI baseCmd
-  goldenFile1 <- H.note "test/cardano-cli-golden/files/golden/shelley/transaction-id-flagless"
-  H.diffVsGoldenFile output1 goldenFile1
+  goldenFile0 <- H.note "test/cardano-cli-golden/files/golden/shelley/transaction-id-default"
+  H.diffVsGoldenFile output1 goldenFile0
 
+  goldenFile1 <- H.note "test/cardano-cli-golden/files/golden/shelley/transaction-id-flagless"
   output2 <- execCardanoCLI $ baseCmd ++ ["--output-text"]
   H.diffVsGoldenFile output2 goldenFile1
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_view.cli
@@ -8,8 +8,8 @@ Usage: cardano-cli compatible conway governance action view --action-file FILEPA
 
 Available options:
   --action-file FILEPATH   Path to action file.
-  --output-json            Format governance action view output to JSON.
+  --output-json            Format governance action view output to JSON
+                           (default).
   --output-yaml            Format governance action view output to YAML.
-                           Defaults to JSON if unspecified.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_vote_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_vote_view.cli
@@ -8,9 +8,8 @@ Usage: cardano-cli compatible conway governance vote view
   Vote viewing.
 
 Available options:
-  --output-json            Format governance vote view output to JSON.
-  --output-yaml            Format governance vote view output to YAML. Defaults
-                           to JSON if unspecified.
+  --output-json            Format governance vote view output to JSON (default).
+  --output-yaml            Format governance vote view output to YAML.
   --vote-file FILEPATH     Input filepath of the vote.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_view.cli
@@ -8,8 +8,8 @@ Usage: cardano-cli conway governance action view --action-file FILEPATH
 
 Available options:
   --action-file FILEPATH   Path to action file.
-  --output-json            Format governance action view output to JSON.
+  --output-json            Format governance action view output to JSON
+                           (default).
   --output-yaml            Format governance action view output to YAML.
-                           Defaults to JSON if unspecified.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_view.cli
@@ -5,9 +5,8 @@ Usage: cardano-cli conway governance vote view [--output-json | --output-yaml]
   Vote viewing.
 
 Available options:
-  --output-json            Format governance vote view output to JSON.
-  --output-yaml            Format governance vote view output to YAML. Defaults
-                           to JSON if unspecified.
+  --output-json            Format governance vote view output to JSON (default).
+  --output-yaml            Format governance vote view output to YAML.
   --vote-file FILEPATH     Input filepath of the vote.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_leadership-schedule.cli
@@ -51,9 +51,8 @@ Available options:
                            Input filepath of the VRF signing key.
   --current                Get the leadership schedule for the current epoch.
   --next                   Get the leadership schedule for the following epoch.
-  --output-json            Format leadership-schedule query output to JSON.
-                           Default format when writing to a file
+  --output-json            Format leadership-schedule query output to JSON
+                           (default).
   --output-text            Format leadership-schedule query output to TEXT.
-                           Default format when writing to stdout
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ref-script-size.cli
@@ -35,9 +35,8 @@ Available options:
                            default)
   --immutable-tip          Use the immutable tip as a target.
   --tx-in TX-IN            Transaction input (TxId#TxIx).
-  --output-json            Format reference inputs query output to JSON. Default
-                           format when writing to a file
-  --output-text            Format reference inputs query output to TEXT. Default
-                           format when writing to stdout
+  --output-json            Format reference inputs query output to JSON
+                           (default).
+  --output-text            Format reference inputs query output to TEXT.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-distribution.cli
@@ -32,9 +32,8 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
-  --output-json            Format stake-distribution query output to JSON.
-                           Default format when writing to a file
+  --output-json            Format stake-distribution query output to JSON
+                           (default).
   --output-text            Format stake-distribution query output to TEXT.
-                           Default format when writing to stdout
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-pools.cli
@@ -28,9 +28,7 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
-  --output-json            Format stake-pools query output to JSON. Default
-                           format when writing to a file
-  --output-text            Format stake-pools query output to TEXT. Default
-                           format when writing to stdout
+  --output-json            Format stake-pools query output to JSON (default).
+  --output-text            Format stake-pools query output to TEXT.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-fee.cli
@@ -25,10 +25,9 @@ Available options:
   --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
                            (default is 0).
-  --output-json            Format calculate-min-fee query output to JSON.
-                           Default format when writing to a file
+  --output-json            Format calculate-min-fee query output to JSON
+                           (default).
   --output-text            Format calculate-min-fee query output to TEXT.
-                           Default format when writing to stdout
   --out-file FILEPATH      The output file.
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_txid.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_txid.cli
@@ -9,6 +9,6 @@ Usage: cardano-cli conway transaction txid
 Available options:
   --tx-body-file FILEPATH  Input filepath of the JSON TxBody.
   --tx-file FILEPATH       Input filepath of the JSON Tx.
-  --output-json            Format output as JSON.
-  --output-text            Format output as TEXT (the default).
+  --output-json            Format output to JSON (default).
+  --output-text            Format output to TEXT.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/debug_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/debug_transaction_view.cli
@@ -7,9 +7,8 @@ Usage: cardano-cli debug transaction view [--output-json | --output-yaml]
   Print a transaction.
 
 Available options:
-  --output-json            Format transaction view output to JSON.
-  --output-yaml            Format transaction view output to YAML. Defaults to
-                           JSON if unspecified.
+  --output-json            Format transaction view output to JSON (default).
+  --output-yaml            Format transaction view output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   --tx-body-file FILEPATH  Input filepath of the JSON TxBody.
   --tx-file FILEPATH       Input filepath of the JSON Tx.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_action_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_action_view.cli
@@ -8,8 +8,8 @@ Usage: cardano-cli latest governance action view --action-file FILEPATH
 
 Available options:
   --action-file FILEPATH   Path to action file.
-  --output-json            Format governance action view output to JSON.
+  --output-json            Format governance action view output to JSON
+                           (default).
   --output-yaml            Format governance action view output to YAML.
-                           Defaults to JSON if unspecified.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_vote_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_vote_view.cli
@@ -5,9 +5,8 @@ Usage: cardano-cli latest governance vote view [--output-json | --output-yaml]
   Vote viewing.
 
 Available options:
-  --output-json            Format governance vote view output to JSON.
-  --output-yaml            Format governance vote view output to YAML. Defaults
-                           to JSON if unspecified.
+  --output-json            Format governance vote view output to JSON (default).
+  --output-yaml            Format governance vote view output to YAML.
   --vote-file FILEPATH     Input filepath of the vote.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_leadership-schedule.cli
@@ -51,9 +51,8 @@ Available options:
                            Input filepath of the VRF signing key.
   --current                Get the leadership schedule for the current epoch.
   --next                   Get the leadership schedule for the following epoch.
-  --output-json            Format leadership-schedule query output to JSON.
-                           Default format when writing to a file
+  --output-json            Format leadership-schedule query output to JSON
+                           (default).
   --output-text            Format leadership-schedule query output to TEXT.
-                           Default format when writing to stdout
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ref-script-size.cli
@@ -35,9 +35,8 @@ Available options:
                            default)
   --immutable-tip          Use the immutable tip as a target.
   --tx-in TX-IN            Transaction input (TxId#TxIx).
-  --output-json            Format reference inputs query output to JSON. Default
-                           format when writing to a file
-  --output-text            Format reference inputs query output to TEXT. Default
-                           format when writing to stdout
+  --output-json            Format reference inputs query output to JSON
+                           (default).
+  --output-text            Format reference inputs query output to TEXT.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-distribution.cli
@@ -32,9 +32,8 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
-  --output-json            Format stake-distribution query output to JSON.
-                           Default format when writing to a file
+  --output-json            Format stake-distribution query output to JSON
+                           (default).
   --output-text            Format stake-distribution query output to TEXT.
-                           Default format when writing to stdout
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-pools.cli
@@ -28,9 +28,7 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
-  --output-json            Format stake-pools query output to JSON. Default
-                           format when writing to a file
-  --output-text            Format stake-pools query output to TEXT. Default
-                           format when writing to stdout
+  --output-json            Format stake-pools query output to JSON (default).
+  --output-text            Format stake-pools query output to TEXT.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-fee.cli
@@ -25,10 +25,9 @@ Available options:
   --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
                            (default is 0).
-  --output-json            Format calculate-min-fee query output to JSON.
-                           Default format when writing to a file
+  --output-json            Format calculate-min-fee query output to JSON
+                           (default).
   --output-text            Format calculate-min-fee query output to TEXT.
-                           Default format when writing to stdout
   --out-file FILEPATH      The output file.
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_txid.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_txid.cli
@@ -9,6 +9,6 @@ Usage: cardano-cli latest transaction txid
 Available options:
   --tx-body-file FILEPATH  Input filepath of the JSON TxBody.
   --tx-file FILEPATH       Input filepath of the JSON Tx.
-  --output-json            Format output as JSON.
-  --output-text            Format output as TEXT (the default).
+  --output-json            Format output to JSON (default).
+  --output-text            Format output to TEXT.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_leadership-schedule.cli
@@ -49,9 +49,8 @@ Available options:
                            Input filepath of the VRF signing key.
   --current                Get the leadership schedule for the current epoch.
   --next                   Get the leadership schedule for the following epoch.
-  --output-json            Format leadership-schedule query output to JSON.
-                           Default format when writing to a file
+  --output-json            Format leadership-schedule query output to JSON
+                           (default).
   --output-text            Format leadership-schedule query output to TEXT.
-                           Default format when writing to stdout
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-distribution.cli
@@ -28,9 +28,8 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
-  --output-json            Format stake-distribution query output to JSON.
-                           Default format when writing to a file
+  --output-json            Format stake-distribution query output to JSON
+                           (default).
   --output-text            Format stake-distribution query output to TEXT.
-                           Default format when writing to stdout
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-pools.cli
@@ -24,9 +24,7 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
-  --output-json            Format stake-pools query output to JSON. Default
-                           format when writing to a file
-  --output-text            Format stake-pools query output to TEXT. Default
-                           format when writing to stdout
+  --output-json            Format stake-pools query output to JSON (default).
+  --output-text            Format stake-pools query output to TEXT.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/shelley/transaction-id-default
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/shelley/transaction-id-default
@@ -1,0 +1,1 @@
+{"txhash":"345b88a38821ce10b1a19c41cbc9b48a55c26001cee4a7d2ad83fd9ddb157667"}


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Standardise default output format for commands
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
