### PR TITLE
Use `Vary` for key output format

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -1805,6 +1805,28 @@ pFormatFlags content =
       , "."
       ]
 
+-- | Make a parser for an output format.
+-- This is a variant of 'pFormatFlags' that allows for a custom parser for the
+-- format to be used as an alternative to the flags parser and the default parser.
+-- This is useful for supporting backwards compatibility with older parsers.
+pFormatFlagsExt
+  :: String
+  -> Parser (Vary fs)
+  -> [Flag (Vary fs)]
+  -> Parser (Vary fs)
+pFormatFlagsExt content p =
+  parserFromFlags p $ \f ->
+    mconcat
+      [ "Format "
+      , content
+      , " to "
+      , f & Z.format
+      , case f & Z.options & Z.isDefault of
+          IsDefault -> " (default)"
+          NonDefault -> ""
+      , "."
+      ]
+
 flagKeyOutputBech32
   :: FormatBech32 :| fs
   => Flag (Vary fs)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -1793,7 +1793,7 @@ pFormatFlags
   -> [Flag (Vary fs)]
   -> Parser (Vary fs)
 pFormatFlags content =
-  parserFromFlags $ \f ->
+  parserFromFlags empty $ \f ->
     mconcat
       [ "Format "
       , content

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -72,7 +72,6 @@ import Text.Parsec.String qualified as Parsec
 import Text.Parsec.Token qualified as Parsec
 import Text.Read (readEither, readMaybe)
 import Text.Read qualified as Read
-
 import Vary (Vary, (:|))
 import Vary qualified
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -1762,17 +1762,27 @@ pOperationalCertificateFile =
 
 pKeyOutputFormat :: Parser (Vary [FormatBech32, FormatTextEnvelope])
 pKeyOutputFormat =
-  Opt.option readKeyOutputFormat $
-    mconcat
-      [ Opt.long "key-output-format"
-      , Opt.metavar "STRING"
-      , Opt.help $
-          mconcat
-            [ "Optional key output format. Accepted output formats are \"text-envelope\" "
-            , "and \"bech32\" (default is \"text-envelope\")."
-            ]
-      , Opt.value (Vary.from FormatTextEnvelope)
-      ]
+  pFormatFlagsExt
+    "key output"
+    p
+    [ flagKeyOutputBech32
+    , flagKeyOutputTextEnvelope & setDefault
+    ]
+ where
+  p =
+    Opt.option
+      deprecatedReadKeyOutputFormat
+      $ mconcat
+        [ Opt.long "key-output-format"
+        , Opt.metavar "STRING"
+        , Opt.help $
+            mconcat
+              [ "Optional key output format. Accepted output formats are \"text-envelope\" "
+              , "and \"bech32\".  The --key-output-format flag is deprecated and will be "
+              , "removed in a future version."
+              ]
+        , Opt.value (Vary.from FormatTextEnvelope)
+        ]
 
 pPoolIdOutputFormat :: Parser (Vary [FormatBech32, FormatHex])
 pPoolIdOutputFormat =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -1805,6 +1805,18 @@ pFormatFlags content =
       , "."
       ]
 
+flagKeyOutputBech32
+  :: FormatBech32 :| fs
+  => Flag (Vary fs)
+flagKeyOutputBech32 =
+  mkFlag "key-output-bech32" "BECH32" FormatBech32
+
+flagKeyOutputTextEnvelope
+  :: FormatTextEnvelope :| fs
+  => Flag (Vary fs)
+flagKeyOutputTextEnvelope =
+  mkFlag "key-output-text-envelope" "TEXT_ENVELOPE" FormatTextEnvelope
+
 flagFormatCbor
   :: FormatCbor :| fs
   => Flag (Vary fs)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -1760,7 +1760,7 @@ pOperationalCertificateFile :: Parser (File () direction)
 pOperationalCertificateFile =
   File <$> parseFilePath "op-cert-file" "Filepath of the node's operational certificate."
 
-pKeyOutputFormat :: Parser KeyOutputFormat
+pKeyOutputFormat :: Parser (Vary [FormatBech32, FormatTextEnvelope])
 pKeyOutputFormat =
   Opt.option readKeyOutputFormat $
     mconcat
@@ -1771,7 +1771,7 @@ pKeyOutputFormat =
             [ "Optional key output format. Accepted output formats are \"text-envelope\" "
             , "and \"bech32\" (default is \"text-envelope\")."
             ]
-      , Opt.value KeyOutputFormatTextEnvelope
+      , Opt.value (Vary.from FormatTextEnvelope)
       ]
 
 pPoolIdOutputFormat :: Parser (Vary [FormatBech32, FormatHex])

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -74,6 +74,7 @@ import Text.Read (readEither, readMaybe)
 import Text.Read qualified as Read
 
 import Vary (Vary, (:|))
+import Vary qualified
 
 command' :: String -> String -> Parser a -> Mod CommandFields a
 command' c descr p =
@@ -1773,7 +1774,7 @@ pKeyOutputFormat =
       , Opt.value KeyOutputFormatTextEnvelope
       ]
 
-pPoolIdOutputFormat :: Parser IdOutputFormat
+pPoolIdOutputFormat :: Parser (Vary [FormatBech32, FormatHex])
 pPoolIdOutputFormat =
   Opt.option readIdOutputFormat $
     mconcat
@@ -1784,7 +1785,7 @@ pPoolIdOutputFormat =
             [ "Optional pool id output format. Accepted output formats are \"hex\" "
             , "and \"bech32\" (default is \"bech32\")."
             ]
-      , Opt.value IdOutputFormatBech32
+      , Opt.value (Vary.from FormatBech32)
       ]
 
 pFormatFlags

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Command.hs
@@ -28,7 +28,6 @@ import Cardano.Ledger.BaseTypes (NonZero)
 
 import Data.Text (Text)
 import Data.Word (Word64)
-
 import Vary
 
 data GenesisCmds era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Command.hs
@@ -29,6 +29,8 @@ import Cardano.Ledger.BaseTypes (NonZero)
 import Data.Text (Text)
 import Data.Word (Word64)
 
+import Vary
+
 data GenesisCmds era
   = GenesisCreate !(GenesisCreateCmdArgs era)
   | GenesisCreateCardano !(GenesisCreateCardanoCmdArgs era)
@@ -46,7 +48,7 @@ data GenesisCmds era
 
 data GenesisCreateCmdArgs era = GenesisCreateCmdArgs
   { eon :: !(ShelleyBasedEra era)
-  , keyOutputFormat :: !KeyOutputFormat
+  , keyOutputFormat :: !(Vary [FormatBech32, FormatTextEnvelope])
   , genesisDir :: !GenesisDir
   , numGenesisKeys :: !Word
   , numUTxOKeys :: !Word
@@ -77,7 +79,7 @@ data GenesisCreateCardanoCmdArgs era = GenesisCreateCardanoCmdArgs
 
 data GenesisCreateStakedCmdArgs era = GenesisCreateStakedCmdArgs
   { eon :: !(ShelleyBasedEra era)
-  , keyOutputFormat :: !KeyOutputFormat
+  , keyOutputFormat :: !(Vary [FormatBech32, FormatTextEnvelope])
   , genesisDir :: !GenesisDir
   , numGenesisKeys :: !Word
   , numUTxOKeys :: !Word

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/CreateTestnetData/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/CreateTestnetData/Run.hs
@@ -112,7 +112,6 @@ import System.Random qualified as Random
 import Text.JSON.Canonical (parseCanonicalJSON, renderCanonicalJSON)
 import Text.JSON.Canonical qualified (ToJSON)
 import Text.Printf (printf)
-
 import Vary (Vary)
 import Vary qualified
 import Vary.Utils ((:|))

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/CreateTestnetData/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/CreateTestnetData/Run.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Cardano.CLI.EraBased.Genesis.CreateTestnetData.Run
   ( runGenesisKeyGenUTxOCmd
@@ -111,6 +112,10 @@ import System.Random qualified as Random
 import Text.JSON.Canonical (parseCanonicalJSON, renderCanonicalJSON)
 import Text.JSON.Canonical qualified (ToJSON)
 import Text.Printf (printf)
+
+import Vary (Vary)
+import Vary qualified
+import Vary.Utils ((:|))
 
 runGenesisKeyGenGenesisCmd
   :: GenesisKeyGenGenesisCmdArgs
@@ -554,8 +559,8 @@ runGenesisCreateTestNetDataCmd
       return $ h' : rest
 
 -- | The output format used all along this file
-desiredKeyOutputFormat :: KeyOutputFormat
-desiredKeyOutputFormat = KeyOutputFormatTextEnvelope
+desiredKeyOutputFormat :: FormatTextEnvelope :| f => Vary f
+desiredKeyOutputFormat = Vary.from FormatTextEnvelope
 
 writeREADME
   :: ()
@@ -625,7 +630,10 @@ mkPaths numKeys dir segment filename =
     | idx <- [1 .. numKeys]
     ]
 
-createDelegateKeys :: KeyOutputFormat -> FilePath -> ExceptT GenesisCmdError IO ()
+createDelegateKeys
+  :: Vary [FormatBech32, FormatTextEnvelope]
+  -> FilePath
+  -> ExceptT GenesisCmdError IO ()
 createDelegateKeys fmt dir = do
   liftIO $ createDirectoryIfMissing True dir
   runGenesisKeyGenDelegateCmd
@@ -696,7 +704,10 @@ createUtxoKeys dir = do
       , Cmd.signingKeyPath = File @(SigningKey ()) $ dir </> "utxo.skey"
       }
 
-createPoolCredentials :: KeyOutputFormat -> FilePath -> ExceptT GenesisCmdError IO ()
+createPoolCredentials
+  :: Vary [FormatBech32, FormatTextEnvelope]
+  -> FilePath
+  -> ExceptT GenesisCmdError IO ()
 createPoolCredentials fmt dir = do
   liftIO $ createDirectoryIfMissing True dir
   firstExceptT GenesisCmdNodeCmdError $ do

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Run.hs
@@ -104,6 +104,8 @@ import System.Random (StdGen)
 import System.Random qualified as Random
 import Text.Read (readMaybe)
 
+import Vary (Vary)
+
 runGenesisCmds :: GenesisCmds era -> ExceptT GenesisCmdError IO ()
 runGenesisCmds = \case
   GenesisKeyGenGenesis args -> TN.runGenesisKeyGenGenesisCmd args
@@ -835,7 +837,11 @@ updateOutputTemplate
     unLovelace :: Integral a => Lovelace -> a
     unLovelace (L.Coin coin) = fromIntegral coin
 
-createDelegateKeys :: KeyOutputFormat -> FilePath -> Word -> ExceptT GenesisCmdError IO ()
+createDelegateKeys
+  :: Vary [FormatBech32, FormatTextEnvelope]
+  -> FilePath
+  -> Word
+  -> ExceptT GenesisCmdError IO ()
 createDelegateKeys fmt dir index = do
   liftIO $ createDirectoryIfMissing False dir
   TN.runGenesisKeyGenDelegateCmd
@@ -886,7 +892,11 @@ createUtxoKeys dir index = do
       , Cmd.signingKeyPath = File @(SigningKey ()) $ dir </> "utxo" ++ strIndex ++ ".skey"
       }
 
-createPoolCredentials :: KeyOutputFormat -> FilePath -> Word -> ExceptT GenesisCmdError IO ()
+createPoolCredentials
+  :: Vary [FormatBech32, FormatTextEnvelope]
+  -> FilePath
+  -> Word
+  -> ExceptT GenesisCmdError IO ()
 createPoolCredentials fmt dir index = do
   liftIO $ createDirectoryIfMissing False dir
   firstExceptT GenesisCmdNodeCmdError $ do

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Run.hs
@@ -103,7 +103,6 @@ import System.IO.Error (isDoesNotExistError)
 import System.Random (StdGen)
 import System.Random qualified as Random
 import Text.Read (readMaybe)
-
 import Vary (Vary)
 
 runGenesisCmds :: GenesisCmds era -> ExceptT GenesisCmdError IO ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
@@ -30,7 +30,6 @@ import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Key
 
 import Data.Text (Text)
-
 import Vary (Vary)
 
 data GovernanceActionCmds era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Command.hs
@@ -24,6 +24,8 @@ import Cardano.CLI.Type.Key
 
 import Data.Text (Text)
 
+import Vary
+
 data GovernanceDRepCmds era
   = GovernanceDRepKeyGenCmd !(GovernanceDRepKeyGenCmdArgs era)
   | GovernanceDRepIdCmd !(GovernanceDRepIdCmdArgs era)
@@ -43,7 +45,7 @@ data GovernanceDRepIdCmdArgs era
   = GovernanceDRepIdCmdArgs
   { eon :: !(ConwayEraOnwards era)
   , vkeySource :: !(VerificationKeyOrHashOrFile DRepKey)
-  , idOutputFormat :: !IdOutputFormat
+  , idOutputFormat :: !(Vary [FormatBech32, FormatHex])
   , mOutFile :: !(Maybe (File () Out))
   }
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Command.hs
@@ -23,7 +23,6 @@ import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Key
 
 import Data.Text (Text)
-
 import Vary
 
 data GovernanceDRepCmds era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Option.hs
@@ -23,6 +23,8 @@ import Data.Foldable (asum)
 import Options.Applicative (Parser)
 import Options.Applicative qualified as Opt
 
+import Vary
+
 pGovernanceDRepCmds
   :: ()
   => ShelleyBasedEra era
@@ -78,12 +80,12 @@ pGovernanceDRepKeyIdCmd era = do
       )
     $ Opt.progDesc "Generate a drep id."
 
-pDRepIdOutputFormat :: Parser IdOutputFormat
+pDRepIdOutputFormat :: Parser (Vary [FormatBech32, FormatHex])
 pDRepIdOutputFormat =
-  asum [make IdOutputFormatHex "hex", make IdOutputFormatBech32 "bech32"]
+  asum [make (Vary.from FormatHex) "hex", make (Vary.from FormatBech32) "bech32"]
     <|> pure default_
  where
-  default_ = IdOutputFormatBech32
+  default_ = Vary.from FormatBech32
   make format flag_ =
     Opt.flag' format $
       mconcat

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Option.hs
@@ -22,7 +22,6 @@ import Control.Applicative (Alternative ((<|>)), optional)
 import Data.Foldable (asum)
 import Options.Applicative (Parser)
 import Options.Applicative qualified as Opt
-
 import Vary
 
 pGovernanceDRepCmds

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Run.hs
@@ -38,7 +38,6 @@ import Control.Monad (void)
 import Data.ByteString (ByteString)
 import Data.Function
 import Data.Text.Encoding qualified as Text
-
 import Vary qualified
 
 runGovernanceDRepCmds

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Command.hs
@@ -18,7 +18,6 @@ import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Governance
 
 import Data.Text (Text)
-
 import Vary (Vary)
 
 data GovernanceVoteCmds era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Run.hs
@@ -31,7 +31,6 @@ import Cardano.CLI.Type.Key
 import Data.Aeson.Encode.Pretty
 import Data.Function
 import Data.Yaml.Pretty qualified as Yaml
-
 import Vary qualified
 
 runGovernanceVoteCmds

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -48,7 +48,6 @@ import Data.Set (Set)
 import Data.Text (Text)
 import Data.Time.Clock
 import GHC.Generics
-
 import Vary
 
 data QueryCmds era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -100,7 +100,6 @@ import Prettyprinter
 import Prettyprinter.Render.Terminal (AnsiStyle)
 import System.IO qualified as IO
 import Text.Printf (printf)
-
 import Vary
 
 runQueryCmds :: Cmd.QueryCmds era -> ExceptT QueryCmdError IO ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Command.hs
@@ -18,9 +18,11 @@ import Prelude
 
 import Data.Text (Text)
 
+import Vary (Vary)
+
 data StakeAddressCmds era
   = StakeAddressKeyGenCmd
-      KeyOutputFormat
+      (Vary [FormatBech32, FormatTextEnvelope])
       (VerificationKeyFile Out)
       (SigningKeyFile Out)
   | StakeAddressKeyHashCmd

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Command.hs
@@ -17,7 +17,6 @@ import Cardano.CLI.Type.Key
 import Prelude
 
 import Data.Text (Text)
-
 import Vary (Vary)
 
 data StakeAddressCmds era

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Run.hs
@@ -39,7 +39,6 @@ import Control.Monad (void)
 import Data.ByteString.Char8 qualified as BS
 import Data.Function ((&))
 import Data.Text.IO qualified as Text
-
 import Vary (Vary)
 import Vary qualified
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Run.hs
@@ -4,8 +4,10 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 {- HLINT ignore "Monad law, left identity" -}
+{- HLINT ignore "Redundant id" -}
 
 module Cardano.CLI.EraBased.StakeAddress.Run
   ( runStakeAddressCmds
@@ -37,6 +39,9 @@ import Control.Monad (void)
 import Data.ByteString.Char8 qualified as BS
 import Data.Function ((&))
 import Data.Text.IO qualified as Text
+
+import Vary (Vary)
+import Vary qualified
 
 runStakeAddressCmds
   :: ()
@@ -110,7 +115,7 @@ runStakeAddressCmds = \case
 
 runStakeAddressKeyGenCmd
   :: ()
-  => KeyOutputFormat
+  => Vary [FormatBech32, FormatTextEnvelope]
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT StakeAddressCmdError IO (VerificationKey StakeKey, SigningKey StakeKey)
@@ -122,17 +127,32 @@ runStakeAddressKeyGenCmd fmt vkFp skFp = do
   let vkey = getVerificationKey skey
 
   firstExceptT StakeAddressCmdWriteFileError $ do
-    case fmt of
-      KeyOutputFormatTextEnvelope ->
-        newExceptT $ writeLazyByteStringFile skFp $ textEnvelopeToJSON (Just skeyDesc) skey
-      KeyOutputFormatBech32 ->
-        newExceptT $ writeTextFile skFp $ serialiseToBech32 skey
+    fmt
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  newExceptT $ writeTextFile skFp $ serialiseToBech32 skey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  newExceptT $ writeLazyByteStringFile skFp $ textEnvelopeToJSON (Just skeyDesc) skey
+              )
+            $ Vary.exhaustiveCase
+        )
 
-    case fmt of
-      KeyOutputFormatTextEnvelope ->
-        newExceptT $ writeLazyByteStringFile vkFp $ textEnvelopeToJSON (Just Key.stakeVkeyDesc) vkey
-      KeyOutputFormatBech32 ->
-        newExceptT $ writeTextFile vkFp $ serialiseToBech32 vkey
+    fmt
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  newExceptT $ writeTextFile vkFp $ serialiseToBech32 vkey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  newExceptT $ writeLazyByteStringFile vkFp $ textEnvelopeToJSON (Just Key.stakeVkeyDesc) vkey
+              )
+            $ Vary.exhaustiveCase
+        )
+
   return (vkey, skey)
 
 runStakeAddressKeyHashCmd

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Command.hs
@@ -25,6 +25,8 @@ import Prelude
 
 import Data.Text (Text)
 
+import Vary
+
 data StakePoolCmds era
   = StakePoolDeregistrationCertificateCmd !(StakePoolDeregistrationCertificateCmdArgs era)
   | StakePoolIdCmd !(StakePoolIdCmdArgs era)
@@ -44,7 +46,7 @@ data StakePoolDeregistrationCertificateCmdArgs era
 data StakePoolIdCmdArgs era
   = StakePoolIdCmdArgs
   { poolVerificationKeyOrFile :: !StakePoolVerificationKeySource
-  , outputFormat :: !IdOutputFormat
+  , outputFormat :: !(Vary [FormatBech32, FormatHex])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Command.hs
@@ -24,7 +24,6 @@ import Cardano.CLI.Type.Key
 import Prelude
 
 import Data.Text (Text)
-
 import Vary
 
 data StakePoolCmds era

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Run.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 
+{- HLINT ignore "Redundant id" -}
+
 module Cardano.CLI.EraBased.StakePool.Run
   ( runStakePoolCmds
   , runStakePoolIdCmd
@@ -32,6 +34,9 @@ import Cardano.CLI.Type.Error.StakePoolCmdError
 import Cardano.CLI.Type.Key (readVerificationKeyOrFile)
 
 import Data.ByteString.Char8 qualified as BS
+import Data.Function ((&))
+
+import Vary qualified
 
 runStakePoolCmds
   :: ()
@@ -187,17 +192,24 @@ runStakePoolIdCmd
     } = do
     stakePoolVerKey <- getVerificationKeyFromStakePoolVerificationKeySource poolVerificationKeyOrFile
     let stakePoolKeyHash = anyStakePoolVerificationKeyHash stakePoolVerKey
-    case outputFormat of
-      IdOutputFormatHex ->
-        firstExceptT StakePoolCmdWriteFileError
-          . newExceptT
-          $ writeByteStringOutput mOutFile
-          $ serialiseToRawBytesHex stakePoolKeyHash
-      IdOutputFormatBech32 ->
-        firstExceptT StakePoolCmdWriteFileError
-          . newExceptT
-          $ writeTextOutput mOutFile
-          $ serialiseToBech32 stakePoolKeyHash
+    outputFormat
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  firstExceptT StakePoolCmdWriteFileError
+                    . newExceptT
+                    $ writeTextOutput mOutFile
+                    $ serialiseToBech32 stakePoolKeyHash
+              )
+            . Vary.on
+              ( \FormatHex ->
+                  firstExceptT StakePoolCmdWriteFileError
+                    . newExceptT
+                    $ writeByteStringOutput mOutFile
+                    $ serialiseToRawBytesHex stakePoolKeyHash
+              )
+            $ Vary.exhaustiveCase
+        )
 
 runStakePoolMetadataHashCmd
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Run.hs
@@ -35,7 +35,6 @@ import Cardano.CLI.Type.Key (readVerificationKeyOrFile)
 
 import Data.ByteString.Char8 qualified as BS
 import Data.Function ((&))
-
 import Vary qualified
 
 runStakePoolCmds

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
@@ -45,7 +45,6 @@ import Cardano.CLI.Type.Governance
 
 import Data.Text (Text)
 import Data.Universe (Some)
-
 import Vary (Vary)
 
 data TransactionCmds era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
@@ -113,7 +113,6 @@ import Data.Universe (Some)
 import GHC.Exts (IsList (..))
 import Lens.Micro ((^.))
 import System.IO qualified as IO
-
 import Vary qualified
 
 runTransactionCmds :: Cmd.TransactionCmds era -> ExceptT TxCmdError IO ()

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Command.hs
@@ -16,9 +16,11 @@ import Prelude
 
 import Data.Text (Text)
 
+import Vary (Vary)
+
 data AddressCmds
   = AddressKeyGen
-      KeyOutputFormat
+      (Vary [FormatBech32, FormatTextEnvelope])
       AddressKeyType
       (VerificationKeyFile Out)
       (SigningKeyFile Out)

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Command.hs
@@ -15,7 +15,6 @@ import Cardano.CLI.Type.Key
 import Prelude
 
 import Data.Text (Text)
-
 import Vary (Vary)
 
 data AddressCmds

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Run.hs
@@ -40,7 +40,6 @@ import Control.Monad (void)
 import Data.ByteString.Char8 qualified as BS
 import Data.Function
 import Data.Text.IO qualified as Text
-
 import Vary (Vary)
 import Vary qualified
 

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Run.hs
@@ -3,6 +3,9 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{- HLINT ignore "Redundant id" -}
 
 module Cardano.CLI.EraIndependent.Address.Run
   ( runAddressCmds
@@ -38,6 +41,9 @@ import Data.ByteString.Char8 qualified as BS
 import Data.Function
 import Data.Text.IO qualified as Text
 
+import Vary (Vary)
+import Vary qualified
+
 runAddressCmds
   :: ()
   => AddressCmds
@@ -53,7 +59,7 @@ runAddressCmds = \case
     runAddressInfoCmd txt mOFp & firstExceptT AddressCmdAddressInfoError
 
 runAddressKeyGenCmd
-  :: KeyOutputFormat
+  :: Vary [FormatBech32, FormatTextEnvelope]
   -> AddressKeyType
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
@@ -80,7 +86,7 @@ generateAndWriteKeyFiles
   => HasTypeProxy keyrole
   => SerialiseAsBech32 (SigningKey keyrole)
   => SerialiseAsBech32 (VerificationKey keyrole)
-  => KeyOutputFormat
+  => Vary [FormatBech32, FormatTextEnvelope]
   -> AsType keyrole
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
@@ -94,7 +100,7 @@ writePaymentKeyFiles
   :: Key keyrole
   => SerialiseAsBech32 (SigningKey keyrole)
   => SerialiseAsBech32 (VerificationKey keyrole)
-  => KeyOutputFormat
+  => Vary [FormatBech32, FormatTextEnvelope]
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
   -> VerificationKey keyrole
@@ -102,25 +108,39 @@ writePaymentKeyFiles
   -> ExceptT AddressCmdError IO ()
 writePaymentKeyFiles fmt vkeyPath skeyPath vkey skey = do
   firstExceptT AddressCmdWriteFileError $ do
-    case fmt of
-      KeyOutputFormatTextEnvelope ->
-        newExceptT $
-          writeLazyByteStringFile skeyPath $
-            textEnvelopeToJSON (Just skeyDesc) skey
-      KeyOutputFormatBech32 ->
-        newExceptT $
-          writeTextFile skeyPath $
-            serialiseToBech32 skey
+    fmt
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  newExceptT
+                    . writeTextFile skeyPath
+                    $ serialiseToBech32 skey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  newExceptT
+                    . writeLazyByteStringFile skeyPath
+                    $ textEnvelopeToJSON (Just skeyDesc) skey
+              )
+            $ Vary.exhaustiveCase
+        )
 
-    case fmt of
-      KeyOutputFormatTextEnvelope ->
-        newExceptT $
-          writeLazyByteStringFile vkeyPath $
-            textEnvelopeToJSON (Just Key.paymentVkeyDesc) vkey
-      KeyOutputFormatBech32 ->
-        newExceptT $
-          writeTextFile vkeyPath $
-            serialiseToBech32 vkey
+    fmt
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  newExceptT
+                    . writeTextFile vkeyPath
+                    $ serialiseToBech32 vkey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  newExceptT
+                    . writeLazyByteStringFile vkeyPath
+                    $ textEnvelopeToJSON (Just Key.paymentVkeyDesc) vkey
+              )
+            $ Vary.exhaustiveCase
+        )
  where
   skeyDesc :: TextEnvelopeDescr
   skeyDesc = "Payment Signing Key"

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Command.hs
@@ -27,6 +27,8 @@ import Cardano.Prelude (Word32)
 
 import Data.Text (Text)
 
+import Vary (Vary)
+
 data KeyCmds
   = KeyVerificationKeyCmd !KeyVerificationKeyCmdArgs
   | KeyNonExtendedKeyCmd !KeyNonExtendedKeyCmdArgs
@@ -70,7 +72,7 @@ data KeyGenerateMnemonicCmdArgs = KeyGenerateMnemonicCmdArgs
 
 -- | Get an extended signing key from a mnemonic.
 data KeyExtendedSigningKeyFromMnemonicArgs = KeyExtendedSigningKeyFromMnemonicArgs
-  { keyOutputFormat :: !KeyOutputFormat
+  { keyOutputFormat :: !(Vary [FormatBech32, FormatTextEnvelope])
   , derivedExtendedSigningKeyType :: !ExtendedSigningType
   , derivationAccountNo :: !Word32
   , mnemonicSource :: !MnemonicSource

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Command.hs
@@ -26,7 +26,6 @@ import Cardano.CLI.Type.Common
 import Cardano.Prelude (Word32)
 
 import Data.Text (Text)
-
 import Vary (Vary)
 
 data KeyCmds

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Command.hs
@@ -20,7 +20,6 @@ import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Key
 
 import Data.Text (Text)
-
 import Vary (Vary)
 
 data NodeCmds

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Command.hs
@@ -21,6 +21,8 @@ import Cardano.CLI.Type.Key
 
 import Data.Text (Text)
 
+import Vary (Vary)
+
 data NodeCmds
   = NodeKeyGenColdCmd !NodeKeyGenColdCmdArgs
   | NodeKeyGenKESCmd !NodeKeyGenKESCmdArgs
@@ -32,7 +34,7 @@ data NodeCmds
 
 data NodeKeyGenColdCmdArgs
   = NodeKeyGenColdCmdArgs
-  { keyOutputFormat :: !KeyOutputFormat
+  { keyOutputFormat :: !(Vary [FormatBech32, FormatTextEnvelope])
   , vkeyFile :: !(VerificationKeyFile Out)
   , skeyFile :: !(SigningKeyFile Out)
   , operationalCertificateIssueCounter :: !(OpCertCounterFile Out)
@@ -41,7 +43,7 @@ data NodeKeyGenColdCmdArgs
 
 data NodeKeyGenKESCmdArgs
   = NodeKeyGenKESCmdArgs
-  { keyOutputFormat :: !KeyOutputFormat
+  { keyOutputFormat :: !(Vary [FormatBech32, FormatTextEnvelope])
   , vkeyFile :: !(VerificationKeyFile Out)
   , skeyFile :: !(SigningKeyFile Out)
   }
@@ -49,7 +51,7 @@ data NodeKeyGenKESCmdArgs
 
 data NodeKeyGenVRFCmdArgs
   = NodeKeyGenVRFCmdArgs
-  { keyOutputFormat :: !KeyOutputFormat
+  { keyOutputFormat :: !(Vary [FormatBech32, FormatTextEnvelope])
   , vkeyFile :: !(VerificationKeyFile Out)
   , skeyFile :: !(SigningKeyFile Out)
   }

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Run.hs
@@ -2,6 +2,9 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{- HLINT ignore "Redundant id" -}
 
 module Cardano.CLI.EraIndependent.Node.Run
   ( runNodeCmds
@@ -23,8 +26,11 @@ import Cardano.CLI.Type.Error.NodeCmdError
 import Cardano.CLI.Type.Key
 
 import Data.ByteString.Char8 qualified as BS
+import Data.Function ((&))
 import Data.String (fromString)
 import Data.Word (Word64)
+
+import Vary qualified
 
 {- HLINT ignore "Reduce duplication" -}
 
@@ -54,29 +60,43 @@ runNodeKeyGenColdCmd
     skey <- generateSigningKey AsStakePoolKey
     let vkey = getVerificationKey skey
 
-    case keyOutputFormat of
-      KeyOutputFormatTextEnvelope ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeLazyByteStringFile skeyFile
-          $ textEnvelopeToJSON (Just skeyDesc) skey
-      KeyOutputFormatBech32 ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeTextFile skeyFile
-          $ serialiseToBech32 skey
+    keyOutputFormat
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  firstExceptT NodeCmdWriteFileError
+                    . newExceptT
+                    . writeTextFile skeyFile
+                    $ serialiseToBech32 skey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  firstExceptT NodeCmdWriteFileError
+                    . newExceptT
+                    $ writeLazyByteStringFile skeyFile
+                    $ textEnvelopeToJSON (Just skeyDesc) skey
+              )
+            $ Vary.exhaustiveCase
+        )
 
-    case keyOutputFormat of
-      KeyOutputFormatTextEnvelope ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeLazyByteStringFile vkeyFile
-          $ textEnvelopeToJSON (Just vkeyDesc) vkey
-      KeyOutputFormatBech32 ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeTextFile vkeyFile
-          $ serialiseToBech32 vkey
+    keyOutputFormat
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  firstExceptT NodeCmdWriteFileError
+                    . newExceptT
+                    . writeTextFile vkeyFile
+                    $ serialiseToBech32 vkey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  firstExceptT NodeCmdWriteFileError
+                    . newExceptT
+                    . writeLazyByteStringFile vkeyFile
+                    $ textEnvelopeToJSON (Just vkeyDesc) vkey
+              )
+            $ Vary.exhaustiveCase
+        )
 
     firstExceptT NodeCmdWriteFileError
       . newExceptT
@@ -114,29 +134,43 @@ runNodeKeyGenKesCmd
 
     let vkey = getVerificationKey skey
 
-    case keyOutputFormat of
-      KeyOutputFormatTextEnvelope ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeLazyByteStringFileWithOwnerPermissions skeyFile
-          $ textEnvelopeToJSON (Just skeyDesc) skey
-      KeyOutputFormatBech32 ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeTextFile skeyFile
-          $ serialiseToBech32 skey
+    keyOutputFormat
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  firstExceptT NodeCmdWriteFileError
+                    . newExceptT
+                    . writeTextFile skeyFile
+                    $ serialiseToBech32 skey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  firstExceptT NodeCmdWriteFileError
+                    . newExceptT
+                    . writeLazyByteStringFileWithOwnerPermissions skeyFile
+                    $ textEnvelopeToJSON (Just skeyDesc) skey
+              )
+            $ Vary.exhaustiveCase
+        )
 
-    case keyOutputFormat of
-      KeyOutputFormatTextEnvelope ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeLazyByteStringFile vkeyFile
-          $ textEnvelopeToJSON (Just vkeyDesc) vkey
-      KeyOutputFormatBech32 ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeTextFile vkeyFile
-          $ serialiseToBech32 vkey
+    keyOutputFormat
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  firstExceptT NodeCmdWriteFileError
+                    . newExceptT
+                    . writeTextFile vkeyFile
+                    $ serialiseToBech32 vkey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  firstExceptT NodeCmdWriteFileError
+                    . newExceptT
+                    . writeLazyByteStringFile vkeyFile
+                    $ textEnvelopeToJSON (Just vkeyDesc) vkey
+              )
+            $ Vary.exhaustiveCase
+        )
    where
     skeyDesc :: TextEnvelopeDescr
     skeyDesc = "KES Signing Key"
@@ -158,29 +192,43 @@ runNodeKeyGenVrfCmd
 
     let vkey = getVerificationKey skey
 
-    case keyOutputFormat of
-      KeyOutputFormatTextEnvelope ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeLazyByteStringFileWithOwnerPermissions skeyFile
-          $ textEnvelopeToJSON (Just skeyDesc) skey
-      KeyOutputFormatBech32 ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeTextFile skeyFile
-          $ serialiseToBech32 skey
+    keyOutputFormat
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  firstExceptT NodeCmdWriteFileError
+                    . newExceptT
+                    . writeTextFile skeyFile
+                    $ serialiseToBech32 skey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  firstExceptT NodeCmdWriteFileError
+                    . newExceptT
+                    . writeLazyByteStringFileWithOwnerPermissions skeyFile
+                    $ textEnvelopeToJSON (Just skeyDesc) skey
+              )
+            $ Vary.exhaustiveCase
+        )
 
-    case keyOutputFormat of
-      KeyOutputFormatTextEnvelope ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeLazyByteStringFile vkeyFile
-          $ textEnvelopeToJSON (Just vkeyDesc) vkey
-      KeyOutputFormatBech32 ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeTextFile vkeyFile
-          $ serialiseToBech32 vkey
+    keyOutputFormat
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  firstExceptT NodeCmdWriteFileError
+                    . newExceptT
+                    $ writeTextFile vkeyFile
+                    $ serialiseToBech32 vkey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  firstExceptT NodeCmdWriteFileError
+                    . newExceptT
+                    $ writeLazyByteStringFile vkeyFile
+                    $ textEnvelopeToJSON (Just vkeyDesc) vkey
+              )
+            $ Vary.exhaustiveCase
+        )
    where
     skeyDesc, vkeyDesc :: TextEnvelopeDescr
     skeyDesc = "VRF Signing Key"

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Run.hs
@@ -29,7 +29,6 @@ import Data.ByteString.Char8 qualified as BS
 import Data.Function ((&))
 import Data.String (fromString)
 import Data.Word (Word64)
-
 import Vary qualified
 
 {- HLINT ignore "Reduce duplication" -}

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -86,7 +86,6 @@ import GHC.Exts (IsList (..))
 import GHC.Real (denominator)
 import GHC.Unicode (isAlphaNum)
 import Lens.Micro ((^.))
-
 import Vary (Vary)
 import Vary qualified
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Genesis/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Genesis/Command.hs
@@ -15,7 +15,6 @@ import Cardano.Ledger.BaseTypes (NonZero)
 
 import Data.Text (Text)
 import Data.Word (Word64)
-
 import Vary (Vary)
 
 data LegacyGenesisCmds

--- a/cardano-cli/src/Cardano/CLI/Legacy/Genesis/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Genesis/Command.hs
@@ -16,10 +16,12 @@ import Cardano.Ledger.BaseTypes (NonZero)
 import Data.Text (Text)
 import Data.Word (Word64)
 
+import Vary (Vary)
+
 data LegacyGenesisCmds
   = GenesisCreate
       (EraInEon ShelleyBasedEra)
-      KeyOutputFormat
+      (Vary [FormatBech32, FormatTextEnvelope])
       GenesisDir
       Word
       Word
@@ -45,7 +47,7 @@ data LegacyGenesisCmds
   | -- | Relay specification filepath
     GenesisCreateStaked
       (EraInEon ShelleyBasedEra)
-      KeyOutputFormat
+      (Vary [FormatBech32, FormatTextEnvelope])
       GenesisDir
       Word
       Word

--- a/cardano-cli/src/Cardano/CLI/Legacy/Genesis/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Genesis/Run.hs
@@ -24,7 +24,6 @@ import Cardano.CLI.Type.Error.GenesisCmdError
 import Cardano.Ledger.BaseTypes (NonZero)
 
 import Data.Word (Word64)
-
 import Vary (Vary)
 
 runLegacyGenesisCmds :: LegacyGenesisCmds -> ExceptT GenesisCmdError IO ()

--- a/cardano-cli/src/Cardano/CLI/Legacy/Genesis/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Genesis/Run.hs
@@ -25,6 +25,8 @@ import Cardano.Ledger.BaseTypes (NonZero)
 
 import Data.Word (Word64)
 
+import Vary (Vary)
+
 runLegacyGenesisCmds :: LegacyGenesisCmds -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisCmds = \case
   GenesisKeyGenGenesis vk sk ->
@@ -128,7 +130,7 @@ runLegacyGenesisAddrCmd vkf nid mOf =
 runLegacyGenesisCreateCmd
   :: ()
   => EraInEon ShelleyBasedEra
-  -> KeyOutputFormat
+  -> Vary [FormatBech32, FormatTextEnvelope]
   -> GenesisDir
   -> Word
   -- ^ num genesis & delegate keys to make
@@ -214,7 +216,7 @@ runLegacyGenesisCreateCardanoCmd
 runLegacyGenesisCreateStakedCmd
   :: ()
   => EraInEon ShelleyBasedEra
-  -> KeyOutputFormat
+  -> Vary [FormatBech32, FormatTextEnvelope]
   -- ^ key output format
   -> GenesisDir
   -> Word

--- a/cardano-cli/src/Cardano/CLI/Option/Flag.hs
+++ b/cardano-cli/src/Cardano/CLI/Option/Flag.hs
@@ -36,10 +36,9 @@ import Vary
 -- A default parser is included at the end of parser alternatives for
 -- the default flag (there should only be one default, but if more than
 -- one is specified, the first such one is used as the default).
-parserFromFlags :: (Flag a -> String) -> [Flag a] -> Parser a
-parserFromFlags _ [] = empty
-parserFromFlags mkHelp fs =
-  alternatives fs <|> defaults fs
+parserFromFlags :: Parser a -> (Flag a -> String) -> [Flag a] -> Parser a
+parserFromFlags p mkHelp fs =
+  alternatives fs <|> p <|> defaults fs
  where
   alternatives [] = empty
   alternatives (x : xs) =

--- a/cardano-cli/src/Cardano/CLI/Option/Flag.hs
+++ b/cardano-cli/src/Cardano/CLI/Option/Flag.hs
@@ -29,7 +29,6 @@ import Data.Generics.Product.Any
 import Lens.Micro
 import Options.Applicative (Parser)
 import Options.Applicative qualified as Opt
-
 import Vary
 
 -- | Create a parser from a help rendering function and list of flags.

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -4,7 +4,6 @@
 module Cardano.CLI.Parser
   ( readerFromAttoParser
   , readFractionAsRational
-  , readKeyOutputFormat
   , readIdOutputFormat
   , readRational
   , readRationalUnitInterval
@@ -13,6 +12,7 @@ module Cardano.CLI.Parser
   , commandWithMetavar
   , eDNSName
   , stringToAnchorScheme
+  , deprecatedReadKeyOutputFormat
   )
 where
 
@@ -46,8 +46,8 @@ readIdOutputFormat = do
           , ". Accepted output formats are \"hex\" and \"bech32\"."
           ]
 
-readKeyOutputFormat :: Opt.ReadM (Vary [FormatBech32, FormatTextEnvelope])
-readKeyOutputFormat = do
+deprecatedReadKeyOutputFormat :: Opt.ReadM (Vary [FormatBech32, FormatTextEnvelope])
+deprecatedReadKeyOutputFormat = do
   s <- Opt.str @String
   case s of
     "text-envelope" -> pure (Vary.from FormatTextEnvelope)

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -31,12 +31,14 @@ import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Options.Applicative qualified as Opt
 
-readIdOutputFormat :: Opt.ReadM IdOutputFormat
+import Vary
+
+readIdOutputFormat :: Opt.ReadM (Vary [FormatBech32, FormatHex])
 readIdOutputFormat = do
   s <- Opt.str @String
   case s of
-    "hex" -> pure IdOutputFormatHex
-    "bech32" -> pure IdOutputFormatBech32
+    "hex" -> pure $ Vary.from FormatHex
+    "bech32" -> pure $ Vary.from FormatBech32
     _ ->
       fail $
         mconcat

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -46,12 +46,12 @@ readIdOutputFormat = do
           , ". Accepted output formats are \"hex\" and \"bech32\"."
           ]
 
-readKeyOutputFormat :: Opt.ReadM KeyOutputFormat
+readKeyOutputFormat :: Opt.ReadM (Vary [FormatBech32, FormatTextEnvelope])
 readKeyOutputFormat = do
   s <- Opt.str @String
   case s of
-    "text-envelope" -> pure KeyOutputFormatTextEnvelope
-    "bech32" -> pure KeyOutputFormatBech32
+    "text-envelope" -> pure (Vary.from FormatTextEnvelope)
+    "bech32" -> pure (Vary.from FormatBech32)
     _ ->
       fail $
         mconcat

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -30,7 +30,6 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Options.Applicative qualified as Opt
-
 import Vary
 
 readIdOutputFormat :: Opt.ReadM (Vary [FormatBech32, FormatHex])

--- a/cardano-cli/src/Cardano/CLI/Run/Mnemonic.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Mnemonic.hs
@@ -72,7 +72,6 @@ import System.Console.Haskeline
   , simpleCompletion
   )
 import System.Console.Haskeline.Completion (CompletionFunc)
-
 import Vary (Vary)
 import Vary qualified
 

--- a/cardano-cli/src/Cardano/CLI/Run/Mnemonic.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Mnemonic.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{- HLINT ignore "Redundant id" -}
 
 module Cardano.CLI.Run.Mnemonic (generateMnemonic, extendedSigningKeyFromMnemonicImpl) where
 
@@ -36,7 +39,11 @@ import Cardano.Api
 import Cardano.Api qualified as Api
 
 import Cardano.CLI.EraIndependent.Key.Command qualified as Cmd
-import Cardano.CLI.Type.Common (KeyOutputFormat (..), SigningKeyFile)
+import Cardano.CLI.Type.Common
+  ( FormatBech32 (FormatBech32)
+  , FormatTextEnvelope (FormatTextEnvelope)
+  , SigningKeyFile
+  )
 import Cardano.CLI.Type.Error.KeyCmdError
   ( KeyCmdError
       ( KeyCmdMnemonicError
@@ -49,6 +56,7 @@ import Cardano.Prelude (isSpace)
 
 import Control.Monad (when)
 import Data.Bifunctor (Bifunctor (..))
+import Data.Function ((&))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Word (Word32)
@@ -64,6 +72,9 @@ import System.Console.Haskeline
   , simpleCompletion
   )
 import System.Console.Haskeline.Completion (CompletionFunc)
+
+import Vary (Vary)
+import Vary qualified
 
 -- | Generate a mnemonic and write it to a file or stdout.
 generateMnemonic
@@ -95,7 +106,7 @@ generateMnemonic mnemonicWords mnemonicOutputFormat = do
 
 -- | Derive an extended signing key from a mnemonic and write it to a file.
 extendedSigningKeyFromMnemonicImpl
-  :: KeyOutputFormat
+  :: Vary [FormatBech32, FormatTextEnvelope]
   -- ^ The format in which to write the signing key.
   -> Cmd.ExtendedSigningType
   -- ^ The type of the extended signing key to derive with an optional payment key index.
@@ -151,18 +162,28 @@ extendedSigningKeyFromMnemonicImpl keyOutputFormat derivedExtendedSigningKeyType
  where
   writeSigningKeyFile
     :: (HasTextEnvelope (SigningKey a), SerialiseAsBech32 (SigningKey a))
-    => KeyOutputFormat -> SigningKeyFile Out -> SigningKey a -> ExceptT KeyCmdError IO ()
+    => Vary [FormatBech32, FormatTextEnvelope]
+    -> SigningKeyFile Out
+    -> SigningKey a
+    -> ExceptT KeyCmdError IO ()
   writeSigningKeyFile fmt sKeyPath skey =
     firstExceptT KeyCmdWriteFileError $
-      case fmt of
-        KeyOutputFormatTextEnvelope ->
-          newExceptT $
-            writeLazyByteStringFile sKeyPath $
-              textEnvelopeToJSON Nothing skey
-        KeyOutputFormatBech32 ->
-          newExceptT $
-            writeTextFile sKeyPath $
-              serialiseToBech32 skey
+      fmt
+        & ( id
+              . Vary.on
+                ( \FormatBech32 ->
+                    newExceptT $
+                      writeTextFile sKeyPath $
+                        serialiseToBech32 skey
+                )
+              . Vary.on
+                ( \FormatTextEnvelope ->
+                    newExceptT $
+                      writeLazyByteStringFile sKeyPath $
+                        textEnvelopeToJSON Nothing skey
+                )
+              $ Vary.exhaustiveCase
+          )
 
   readMnemonic :: Cmd.MnemonicSource -> ExceptT KeyCmdError IO [Text]
   readMnemonic (Cmd.MnemonicFromFile filePath) = do

--- a/cardano-cli/src/Cardano/CLI/Type/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Common.hs
@@ -27,17 +27,17 @@ module Cardano.CLI.Type.Common
   , File (..)
   , FileDirection (..)
   , FormatBech32 (..)
-  , FormatHex (..)
   , FormatCbor (..)
+  , FormatHex (..)
   , FormatJson (..)
   , FormatText (..)
+  , FormatTextEnvelope (..)
   , FormatYaml (..)
   , GenesisDir (..)
   , GenesisFile (..)
   , GenesisKeyFile (..)
   , IncludeStake (..)
   , InputTxBodyOrTxFile (..)
-  , KeyOutputFormat (..)
   , MetadataFile (..)
   , MustCheckHash (..)
   , OpCertCounter
@@ -340,11 +340,6 @@ instance FromJSON GenesisFile where
         <> "Encountered: "
         <> show invalid
 
-data KeyOutputFormat
-  = KeyOutputFormatTextEnvelope
-  | KeyOutputFormatBech32
-  deriving (Eq, Show)
-
 data AllOrOnly a = All | Only [a] deriving (Eq, Show)
 
 -- | This data structure is used to allow nicely formatted output in the query pool-params command.
@@ -491,6 +486,9 @@ data FormatJson = FormatJson
   deriving (Enum, Eq, Ord, Show)
 
 data FormatText = FormatText
+  deriving (Enum, Eq, Ord, Show)
+
+data FormatTextEnvelope = FormatTextEnvelope
   deriving (Enum, Eq, Ord, Show)
 
 data FormatYaml = FormatYaml

--- a/cardano-cli/src/Cardano/CLI/Type/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Common.hs
@@ -26,6 +26,8 @@ module Cardano.CLI.Type.Common
   , EpochLeadershipSchedule (..)
   , File (..)
   , FileDirection (..)
+  , FormatBech32 (..)
+  , FormatHex (..)
   , FormatCbor (..)
   , FormatJson (..)
   , FormatText (..)
@@ -48,7 +50,6 @@ module Cardano.CLI.Type.Common
   , OpCertStartingKesPeriod (..)
   , Params (..)
   , ParserFileDirection (..)
-  , IdOutputFormat (..)
   , PrivKeyFile (..)
   , ProposalBinary
   , ProposalFile
@@ -339,14 +340,6 @@ instance FromJSON GenesisFile where
         <> "Encountered: "
         <> show invalid
 
--- | Some entities such as stake pools and dreps have a notion of an ID and that id can be
--- encoded as either a bech32 or hex string.  This type is used to specify which encoding
--- to use.
-data IdOutputFormat
-  = IdOutputFormatHex
-  | IdOutputFormatBech32
-  deriving (Eq, Show)
-
 data KeyOutputFormat
   = KeyOutputFormatTextEnvelope
   | KeyOutputFormatBech32
@@ -484,6 +477,12 @@ data TxMempoolQuery
   | TxMempoolQueryNextTx
   | TxMempoolQueryInfo
   deriving Show
+
+data FormatBech32 = FormatBech32
+  deriving (Enum, Eq, Ord, Show)
+
+data FormatHex = FormatHex
+  deriving (Enum, Eq, Ord, Show)
 
 data FormatCbor = FormatCbor
   deriving (Enum, Eq, Ord, Show)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -17,7 +17,11 @@ Usage: cardano-cli address (key-gen | key-hash | build | info)
 
   Payment address commands.
 
-Usage: cardano-cli address key-gen [--key-output-format STRING]
+Usage: cardano-cli address key-gen 
+                                     [ --key-output-bech32
+                                     | --key-output-text-envelope
+                                     | --key-output-format STRING
+                                     ]
                                      [ --normal-key
                                      | --extended-key
                                      | --byron-key
@@ -85,7 +89,11 @@ Usage: cardano-cli key generate-mnemonic [--out-file FILEPATH] --size WORD32
 
   Generate a mnemonic sentence that can be used for key derivation.
 
-Usage: cardano-cli key derive-from-mnemonic [--key-output-format STRING]
+Usage: cardano-cli key derive-from-mnemonic 
+                                              [ --key-output-bech32
+                                              | --key-output-text-envelope
+                                              | --key-output-format STRING
+                                              ]
                                               ( --payment-key-with-number WORD32
                                               | --stake-key-with-number WORD32
                                               | --drep-key
@@ -171,7 +179,11 @@ Usage: cardano-cli node
 
   Node operation commands.
 
-Usage: cardano-cli node key-gen [--key-output-format STRING]
+Usage: cardano-cli node key-gen 
+                                  [ --key-output-bech32
+                                  | --key-output-text-envelope
+                                  | --key-output-format STRING
+                                  ]
                                   --cold-verification-key-file FILEPATH
                                   --cold-signing-key-file FILEPATH
                                   --operational-certificate-issue-counter-file FILEPATH
@@ -179,13 +191,21 @@ Usage: cardano-cli node key-gen [--key-output-format STRING]
   Create a key pair for a node operator's offline key and a new certificate
   issue counter
 
-Usage: cardano-cli node key-gen-KES [--key-output-format STRING]
+Usage: cardano-cli node key-gen-KES 
+                                      [ --key-output-bech32
+                                      | --key-output-text-envelope
+                                      | --key-output-format STRING
+                                      ]
                                       --verification-key-file FILEPATH
                                       --signing-key-file FILEPATH
 
   Create a key pair for a node KES operational key
 
-Usage: cardano-cli node key-gen-VRF [--key-output-format STRING]
+Usage: cardano-cli node key-gen-VRF 
+                                      [ --key-output-bech32
+                                      | --key-output-text-envelope
+                                      | --key-output-format STRING
+                                      ]
                                       --verification-key-file FILEPATH
                                       --signing-key-file FILEPATH
 
@@ -702,7 +722,10 @@ Usage: cardano-cli legacy genesis create
                                            | --babbage-era
                                            | --conway-era
                                            ]
-                                           [--key-output-format STRING]
+                                           [ --key-output-bech32
+                                           | --key-output-text-envelope
+                                           | --key-output-format STRING
+                                           ]
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]
@@ -721,7 +744,10 @@ Usage: cardano-cli legacy genesis create-staked
                                                   | --babbage-era
                                                   | --conway-era
                                                   ]
-                                                  [--key-output-format STRING]
+                                                  [ --key-output-bech32
+                                                  | --key-output-text-envelope
+                                                  | --key-output-format STRING
+                                                  ]
                                                   --genesis-dir DIR
                                                   [--gen-genesis-keys INT]
                                                   [--gen-utxo-keys INT]
@@ -1041,7 +1067,11 @@ Usage: cardano-cli conway address (key-gen | key-hash | build | info)
 
   Payment address commands.
 
-Usage: cardano-cli conway address key-gen [--key-output-format STRING]
+Usage: cardano-cli conway address key-gen 
+                                            [ --key-output-bech32
+                                            | --key-output-text-envelope
+                                            | --key-output-format STRING
+                                            ]
                                             [ --normal-key
                                             | --extended-key
                                             | --byron-key
@@ -1110,7 +1140,11 @@ Usage: cardano-cli conway key generate-mnemonic [--out-file FILEPATH]
 
   Generate a mnemonic sentence that can be used for key derivation.
 
-Usage: cardano-cli conway key derive-from-mnemonic [--key-output-format STRING]
+Usage: cardano-cli conway key derive-from-mnemonic 
+                                                     [ --key-output-bech32
+                                                     | --key-output-text-envelope
+                                                     | --key-output-format STRING
+                                                     ]
                                                      ( --payment-key-with-number WORD32
                                                      | --stake-key-with-number WORD32
                                                      | --drep-key
@@ -1263,7 +1297,11 @@ Usage: cardano-cli conway genesis create-cardano --genesis-dir DIR
   Create a Byron and Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.
 
-Usage: cardano-cli conway genesis create [--key-output-format STRING]
+Usage: cardano-cli conway genesis create 
+                                           [ --key-output-bech32
+                                           | --key-output-text-envelope
+                                           | --key-output-format STRING
+                                           ]
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]
@@ -1274,7 +1312,11 @@ Usage: cardano-cli conway genesis create [--key-output-format STRING]
   Create a Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.
 
-Usage: cardano-cli conway genesis create-staked [--key-output-format STRING]
+Usage: cardano-cli conway genesis create-staked 
+                                                  [ --key-output-bech32
+                                                  | --key-output-text-envelope
+                                                  | --key-output-format STRING
+                                                  ]
                                                   --genesis-dir DIR
                                                   [--gen-genesis-keys INT]
                                                   [--gen-utxo-keys INT]
@@ -1732,7 +1774,11 @@ Usage: cardano-cli conway node
 
   Node operation commands.
 
-Usage: cardano-cli conway node key-gen [--key-output-format STRING]
+Usage: cardano-cli conway node key-gen 
+                                         [ --key-output-bech32
+                                         | --key-output-text-envelope
+                                         | --key-output-format STRING
+                                         ]
                                          --cold-verification-key-file FILEPATH
                                          --cold-signing-key-file FILEPATH
                                          --operational-certificate-issue-counter-file FILEPATH
@@ -1740,13 +1786,21 @@ Usage: cardano-cli conway node key-gen [--key-output-format STRING]
   Create a key pair for a node operator's offline key and a new certificate
   issue counter
 
-Usage: cardano-cli conway node key-gen-KES [--key-output-format STRING]
+Usage: cardano-cli conway node key-gen-KES 
+                                             [ --key-output-bech32
+                                             | --key-output-text-envelope
+                                             | --key-output-format STRING
+                                             ]
                                              --verification-key-file FILEPATH
                                              --signing-key-file FILEPATH
 
   Create a key pair for a node KES operational key
 
-Usage: cardano-cli conway node key-gen-VRF [--key-output-format STRING]
+Usage: cardano-cli conway node key-gen-VRF 
+                                             [ --key-output-bech32
+                                             | --key-output-text-envelope
+                                             | --key-output-format STRING
+                                             ]
                                              --verification-key-file FILEPATH
                                              --signing-key-file FILEPATH
 
@@ -2306,7 +2360,11 @@ Usage: cardano-cli conway stake-address
 
   Stake address commands.
 
-Usage: cardano-cli conway stake-address key-gen [--key-output-format STRING]
+Usage: cardano-cli conway stake-address key-gen 
+                                                  [ --key-output-bech32
+                                                  | --key-output-text-envelope
+                                                  | --key-output-format STRING
+                                                  ]
                                                   --verification-key-file FILEPATH
                                                   --signing-key-file FILEPATH
 
@@ -3242,7 +3300,11 @@ Usage: cardano-cli latest address (key-gen | key-hash | build | info)
 
   Payment address commands.
 
-Usage: cardano-cli latest address key-gen [--key-output-format STRING]
+Usage: cardano-cli latest address key-gen 
+                                            [ --key-output-bech32
+                                            | --key-output-text-envelope
+                                            | --key-output-format STRING
+                                            ]
                                             [ --normal-key
                                             | --extended-key
                                             | --byron-key
@@ -3311,7 +3373,11 @@ Usage: cardano-cli latest key generate-mnemonic [--out-file FILEPATH]
 
   Generate a mnemonic sentence that can be used for key derivation.
 
-Usage: cardano-cli latest key derive-from-mnemonic [--key-output-format STRING]
+Usage: cardano-cli latest key derive-from-mnemonic 
+                                                     [ --key-output-bech32
+                                                     | --key-output-text-envelope
+                                                     | --key-output-format STRING
+                                                     ]
                                                      ( --payment-key-with-number WORD32
                                                      | --stake-key-with-number WORD32
                                                      | --drep-key
@@ -3464,7 +3530,11 @@ Usage: cardano-cli latest genesis create-cardano --genesis-dir DIR
   Create a Byron and Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.
 
-Usage: cardano-cli latest genesis create [--key-output-format STRING]
+Usage: cardano-cli latest genesis create 
+                                           [ --key-output-bech32
+                                           | --key-output-text-envelope
+                                           | --key-output-format STRING
+                                           ]
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]
@@ -3475,7 +3545,11 @@ Usage: cardano-cli latest genesis create [--key-output-format STRING]
   Create a Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.
 
-Usage: cardano-cli latest genesis create-staked [--key-output-format STRING]
+Usage: cardano-cli latest genesis create-staked 
+                                                  [ --key-output-bech32
+                                                  | --key-output-text-envelope
+                                                  | --key-output-format STRING
+                                                  ]
                                                   --genesis-dir DIR
                                                   [--gen-genesis-keys INT]
                                                   [--gen-utxo-keys INT]
@@ -3933,7 +4007,11 @@ Usage: cardano-cli latest node
 
   Node operation commands.
 
-Usage: cardano-cli latest node key-gen [--key-output-format STRING]
+Usage: cardano-cli latest node key-gen 
+                                         [ --key-output-bech32
+                                         | --key-output-text-envelope
+                                         | --key-output-format STRING
+                                         ]
                                          --cold-verification-key-file FILEPATH
                                          --cold-signing-key-file FILEPATH
                                          --operational-certificate-issue-counter-file FILEPATH
@@ -3941,13 +4019,21 @@ Usage: cardano-cli latest node key-gen [--key-output-format STRING]
   Create a key pair for a node operator's offline key and a new certificate
   issue counter
 
-Usage: cardano-cli latest node key-gen-KES [--key-output-format STRING]
+Usage: cardano-cli latest node key-gen-KES 
+                                             [ --key-output-bech32
+                                             | --key-output-text-envelope
+                                             | --key-output-format STRING
+                                             ]
                                              --verification-key-file FILEPATH
                                              --signing-key-file FILEPATH
 
   Create a key pair for a node KES operational key
 
-Usage: cardano-cli latest node key-gen-VRF [--key-output-format STRING]
+Usage: cardano-cli latest node key-gen-VRF 
+                                             [ --key-output-bech32
+                                             | --key-output-text-envelope
+                                             | --key-output-format STRING
+                                             ]
                                              --verification-key-file FILEPATH
                                              --signing-key-file FILEPATH
 
@@ -4507,7 +4593,11 @@ Usage: cardano-cli latest stake-address
 
   Stake address commands.
 
-Usage: cardano-cli latest stake-address key-gen [--key-output-format STRING]
+Usage: cardano-cli latest stake-address key-gen 
+                                                  [ --key-output-bech32
+                                                  | --key-output-text-envelope
+                                                  | --key-output-format STRING
+                                                  ]
                                                   --verification-key-file FILEPATH
                                                   --signing-key-file FILEPATH
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/address_key-gen.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli address key-gen [--key-output-format STRING]
+Usage: cardano-cli address key-gen 
+                                     [ --key-output-bech32
+                                     | --key-output-text-envelope
+                                     | --key-output-format STRING
+                                     ]
                                      [ --normal-key
                                      | --extended-key
                                      | --byron-key
@@ -9,10 +13,14 @@ Usage: cardano-cli address key-gen [--key-output-format STRING]
   Create an address key pair.
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --normal-key             Use a normal Shelley-era key (default).
   --extended-key           Use an extended ed25519 Shelley-era key.
   --byron-key              Use a Byron-era key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address_key-gen.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli conway address key-gen [--key-output-format STRING]
+Usage: cardano-cli conway address key-gen 
+                                            [ --key-output-bech32
+                                            | --key-output-text-envelope
+                                            | --key-output-format STRING
+                                            ]
                                             [ --normal-key
                                             | --extended-key
                                             | --byron-key
@@ -9,10 +13,14 @@ Usage: cardano-cli conway address key-gen [--key-output-format STRING]
   Create an address key pair.
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --normal-key             Use a normal Shelley-era key (default).
   --extended-key           Use an extended ed25519 Shelley-era key.
   --byron-key              Use a Byron-era key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-staked.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli conway genesis create-staked [--key-output-format STRING]
+Usage: cardano-cli conway genesis create-staked 
+                                                  [ --key-output-bech32
+                                                  | --key-output-text-envelope
+                                                  | --key-output-format STRING
+                                                  ]
                                                   --genesis-dir DIR
                                                   [--gen-genesis-keys INT]
                                                   [--gen-utxo-keys INT]
@@ -19,10 +23,14 @@ Usage: cardano-cli conway genesis create-staked [--key-output-format STRING]
   genesis/delegation/spending keys.
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli conway genesis create [--key-output-format STRING]
+Usage: cardano-cli conway genesis create 
+                                           [ --key-output-bech32
+                                           | --key-output-text-envelope
+                                           | --key-output-format STRING
+                                           ]
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]
@@ -10,10 +14,14 @@ Usage: cardano-cli conway genesis create [--key-output-format STRING]
   genesis/delegation/spending keys.
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_derive-from-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_derive-from-mnemonic.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli conway key derive-from-mnemonic [--key-output-format STRING]
+Usage: cardano-cli conway key derive-from-mnemonic 
+                                                     [ --key-output-bech32
+                                                     | --key-output-text-envelope
+                                                     | --key-output-format STRING
+                                                     ]
                                                      ( --payment-key-with-number WORD32
                                                      | --stake-key-with-number WORD32
                                                      | --drep-key
@@ -16,10 +20,14 @@ Usage: cardano-cli conway key derive-from-mnemonic [--key-output-format STRING]
   air-gapped environment.
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --payment-key-with-number WORD32
                            Derive an extended payment key with the given payment
                            address number from the derivation path.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen-KES.cli
@@ -1,14 +1,22 @@
-Usage: cardano-cli conway node key-gen-KES [--key-output-format STRING]
+Usage: cardano-cli conway node key-gen-KES 
+                                             [ --key-output-bech32
+                                             | --key-output-text-envelope
+                                             | --key-output-format STRING
+                                             ]
                                              --verification-key-file FILEPATH
                                              --signing-key-file FILEPATH
 
   Create a key pair for a node KES operational key
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --verification-key-file FILEPATH
                            Output filepath of the verification key.
   --signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen-VRF.cli
@@ -1,14 +1,22 @@
-Usage: cardano-cli conway node key-gen-VRF [--key-output-format STRING]
+Usage: cardano-cli conway node key-gen-VRF 
+                                             [ --key-output-bech32
+                                             | --key-output-text-envelope
+                                             | --key-output-format STRING
+                                             ]
                                              --verification-key-file FILEPATH
                                              --signing-key-file FILEPATH
 
   Create a key pair for a node VRF operational key
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --verification-key-file FILEPATH
                            Output filepath of the verification key.
   --signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli conway node key-gen [--key-output-format STRING]
+Usage: cardano-cli conway node key-gen 
+                                         [ --key-output-bech32
+                                         | --key-output-text-envelope
+                                         | --key-output-format STRING
+                                         ]
                                          --cold-verification-key-file FILEPATH
                                          --cold-signing-key-file FILEPATH
                                          --operational-certificate-issue-counter-file FILEPATH
@@ -7,10 +11,14 @@ Usage: cardano-cli conway node key-gen [--key-output-format STRING]
   issue counter
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --cold-verification-key-file FILEPATH
                            Filepath of the cold verification key.
   --cold-signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_key-gen.cli
@@ -1,14 +1,22 @@
-Usage: cardano-cli conway stake-address key-gen [--key-output-format STRING]
+Usage: cardano-cli conway stake-address key-gen 
+                                                  [ --key-output-bech32
+                                                  | --key-output-text-envelope
+                                                  | --key-output-format STRING
+                                                  ]
                                                   --verification-key-file FILEPATH
                                                   --signing-key-file FILEPATH
 
   Create a stake address key pair
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --verification-key-file FILEPATH
                            Output filepath of the verification key.
   --signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/key_derive-from-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/key_derive-from-mnemonic.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli key derive-from-mnemonic [--key-output-format STRING]
+Usage: cardano-cli key derive-from-mnemonic 
+                                              [ --key-output-bech32
+                                              | --key-output-text-envelope
+                                              | --key-output-format STRING
+                                              ]
                                               ( --payment-key-with-number WORD32
                                               | --stake-key-with-number WORD32
                                               | --drep-key
@@ -16,10 +20,14 @@ Usage: cardano-cli key derive-from-mnemonic [--key-output-format STRING]
   air-gapped environment.
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --payment-key-with-number WORD32
                            Derive an extended payment key with the given payment
                            address number from the derivation path.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address_key-gen.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli latest address key-gen [--key-output-format STRING]
+Usage: cardano-cli latest address key-gen 
+                                            [ --key-output-bech32
+                                            | --key-output-text-envelope
+                                            | --key-output-format STRING
+                                            ]
                                             [ --normal-key
                                             | --extended-key
                                             | --byron-key
@@ -9,10 +13,14 @@ Usage: cardano-cli latest address key-gen [--key-output-format STRING]
   Create an address key pair.
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --normal-key             Use a normal Shelley-era key (default).
   --extended-key           Use an extended ed25519 Shelley-era key.
   --byron-key              Use a Byron-era key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-staked.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli latest genesis create-staked [--key-output-format STRING]
+Usage: cardano-cli latest genesis create-staked 
+                                                  [ --key-output-bech32
+                                                  | --key-output-text-envelope
+                                                  | --key-output-format STRING
+                                                  ]
                                                   --genesis-dir DIR
                                                   [--gen-genesis-keys INT]
                                                   [--gen-utxo-keys INT]
@@ -19,10 +23,14 @@ Usage: cardano-cli latest genesis create-staked [--key-output-format STRING]
   genesis/delegation/spending keys.
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli latest genesis create [--key-output-format STRING]
+Usage: cardano-cli latest genesis create 
+                                           [ --key-output-bech32
+                                           | --key-output-text-envelope
+                                           | --key-output-format STRING
+                                           ]
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]
@@ -10,10 +14,14 @@ Usage: cardano-cli latest genesis create [--key-output-format STRING]
   genesis/delegation/spending keys.
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_derive-from-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_derive-from-mnemonic.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli latest key derive-from-mnemonic [--key-output-format STRING]
+Usage: cardano-cli latest key derive-from-mnemonic 
+                                                     [ --key-output-bech32
+                                                     | --key-output-text-envelope
+                                                     | --key-output-format STRING
+                                                     ]
                                                      ( --payment-key-with-number WORD32
                                                      | --stake-key-with-number WORD32
                                                      | --drep-key
@@ -16,10 +20,14 @@ Usage: cardano-cli latest key derive-from-mnemonic [--key-output-format STRING]
   air-gapped environment.
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --payment-key-with-number WORD32
                            Derive an extended payment key with the given payment
                            address number from the derivation path.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen-KES.cli
@@ -1,14 +1,22 @@
-Usage: cardano-cli latest node key-gen-KES [--key-output-format STRING]
+Usage: cardano-cli latest node key-gen-KES 
+                                             [ --key-output-bech32
+                                             | --key-output-text-envelope
+                                             | --key-output-format STRING
+                                             ]
                                              --verification-key-file FILEPATH
                                              --signing-key-file FILEPATH
 
   Create a key pair for a node KES operational key
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --verification-key-file FILEPATH
                            Output filepath of the verification key.
   --signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen-VRF.cli
@@ -1,14 +1,22 @@
-Usage: cardano-cli latest node key-gen-VRF [--key-output-format STRING]
+Usage: cardano-cli latest node key-gen-VRF 
+                                             [ --key-output-bech32
+                                             | --key-output-text-envelope
+                                             | --key-output-format STRING
+                                             ]
                                              --verification-key-file FILEPATH
                                              --signing-key-file FILEPATH
 
   Create a key pair for a node VRF operational key
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --verification-key-file FILEPATH
                            Output filepath of the verification key.
   --signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli latest node key-gen [--key-output-format STRING]
+Usage: cardano-cli latest node key-gen 
+                                         [ --key-output-bech32
+                                         | --key-output-text-envelope
+                                         | --key-output-format STRING
+                                         ]
                                          --cold-verification-key-file FILEPATH
                                          --cold-signing-key-file FILEPATH
                                          --operational-certificate-issue-counter-file FILEPATH
@@ -7,10 +11,14 @@ Usage: cardano-cli latest node key-gen [--key-output-format STRING]
   issue counter
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --cold-verification-key-file FILEPATH
                            Filepath of the cold verification key.
   --cold-signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_key-gen.cli
@@ -1,14 +1,22 @@
-Usage: cardano-cli latest stake-address key-gen [--key-output-format STRING]
+Usage: cardano-cli latest stake-address key-gen 
+                                                  [ --key-output-bech32
+                                                  | --key-output-text-envelope
+                                                  | --key-output-format STRING
+                                                  ]
                                                   --verification-key-file FILEPATH
                                                   --signing-key-file FILEPATH
 
   Create a stake address key pair
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --verification-key-file FILEPATH
                            Output filepath of the verification key.
   --signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create-staked.cli
@@ -6,7 +6,10 @@ Usage: cardano-cli legacy genesis create-staked
                                                   | --babbage-era
                                                   | --conway-era
                                                   ]
-                                                  [--key-output-format STRING]
+                                                  [ --key-output-bech32
+                                                  | --key-output-text-envelope
+                                                  | --key-output-format STRING
+                                                  ]
                                                   --genesis-dir DIR
                                                   [--gen-genesis-keys INT]
                                                   [--gen-utxo-keys INT]
@@ -38,10 +41,14 @@ Available options:
   --babbage-era            Specify the Babbage era (default) - DEPRECATED - will
                            be removed in the future
   --conway-era             Specify the Conway era
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create.cli
@@ -6,7 +6,10 @@ Usage: cardano-cli legacy genesis create
                                            | --babbage-era
                                            | --conway-era
                                            ]
-                                           [--key-output-format STRING]
+                                           [ --key-output-bech32
+                                           | --key-output-text-envelope
+                                           | --key-output-format STRING
+                                           ]
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]
@@ -29,10 +32,14 @@ Available options:
   --babbage-era            Specify the Babbage era (default) - DEPRECATED - will
                            be removed in the future
   --conway-era             Specify the Conway era
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-KES.cli
@@ -1,14 +1,22 @@
-Usage: cardano-cli node key-gen-KES [--key-output-format STRING]
+Usage: cardano-cli node key-gen-KES 
+                                      [ --key-output-bech32
+                                      | --key-output-text-envelope
+                                      | --key-output-format STRING
+                                      ]
                                       --verification-key-file FILEPATH
                                       --signing-key-file FILEPATH
 
   Create a key pair for a node KES operational key
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --verification-key-file FILEPATH
                            Output filepath of the verification key.
   --signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-VRF.cli
@@ -1,14 +1,22 @@
-Usage: cardano-cli node key-gen-VRF [--key-output-format STRING]
+Usage: cardano-cli node key-gen-VRF 
+                                      [ --key-output-bech32
+                                      | --key-output-text-envelope
+                                      | --key-output-format STRING
+                                      ]
                                       --verification-key-file FILEPATH
                                       --signing-key-file FILEPATH
 
   Create a key pair for a node VRF operational key
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --verification-key-file FILEPATH
                            Output filepath of the verification key.
   --signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli node key-gen [--key-output-format STRING]
+Usage: cardano-cli node key-gen 
+                                  [ --key-output-bech32
+                                  | --key-output-text-envelope
+                                  | --key-output-format STRING
+                                  ]
                                   --cold-verification-key-file FILEPATH
                                   --cold-signing-key-file FILEPATH
                                   --operational-certificate-issue-counter-file FILEPATH
@@ -7,10 +11,14 @@ Usage: cardano-cli node key-gen [--key-output-format STRING]
   issue counter
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
   --key-output-format STRING
                            Optional key output format. Accepted output formats
-                           are "text-envelope" and "bech32" (default is
-                           "text-envelope").
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --cold-verification-key-file FILEPATH
                            Filepath of the cold verification key.
   --cold-signing-key-file FILEPATH

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -27,6 +27,7 @@ import-grouping:
     - glob: Prettyprinter**
     - glob: System**
     - glob: Text**
+    - glob: Vary**
   - rules:
     - glob: Test.Gen.Cardano.Api**
   - rules:


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use `Vary` for key output format
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Progression towards https://github.com/input-output-hk/cardano-node-wiki/pull/72

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
