### PR TITLE
Don't skip HLS check on missing base-ref

### DIFF
--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -24,46 +24,50 @@ jobs:
       - name: Check if changes were trivial
         id: check_trivial_changes
         run: |
-          git fetch origin ${{ github.base_ref }} --unshallow
-          base_ref=origin/${{ github.base_ref }}
-          head_ref=HEAD
-          changed_files=$(git diff-tree --name-status -r "$base_ref".."$head_ref" -- | cut -f2 -d$'\t')
-          # Flag to check whether we do the rest of checks
-          exception=true
-
-          for file in $changed_files; do
-            # If changes were to a markdown file we don't mind
-            if [[ $file == *.md ]]; then
-              echo "$file: is markdown, so it doesn't matter (trivial change)"
-              continue
-            fi
-
-            # If changes were to a .cabal file, we ensure only the version changed
-            if [[ $file == *.cabal ]]; then
-              # If file doesn't exist it means it was moved or removed
-              if [ ! -f "$file" ]; then
-                echo "$file: was moved or removed and is a cabal file (non-trivial change)"
+          if [ -z "${{ github.base_ref }}" ]; then
+            exception=false
+          else
+            git fetch origin ${{ github.base_ref }} --unshallow
+            base_ref=origin/${{ github.base_ref }}
+            head_ref=HEAD
+            changed_files=$(git diff-tree --name-status -r "$base_ref".."$head_ref" -- | cut -f2 -d$'\t')
+            # Flag to check whether we do the rest of checks
+            exception=true
+  
+            for file in $changed_files; do
+              # If changes were to a markdown file we don't mind
+              if [[ $file == *.md ]]; then
+                echo "$file: is markdown, so it doesn't matter (trivial change)"
+                continue
+              fi
+  
+              # If changes were to a .cabal file, we ensure only the version changed
+              if [[ $file == *.cabal ]]; then
+                # If file doesn't exist it means it was moved or removed
+                if [ ! -f "$file" ]; then
+                  echo "$file: was moved or removed and is a cabal file (non-trivial change)"
+                  exception=false
+                  break
+                fi
+  
+                # We ensure the only change was to the version field
+                diff_version=$(git diff "$base_ref".."$head_ref" -- "$file" | perl -ne 'print if /^-(?!version:)/' | wc -l)
+                diff_no_version=$(git diff "$base_ref".."$head_ref" -- "$file" | perl -ne 'print if /^\+(?!version:)/' | wc -l)
+  
+                if [ "$diff_version" -gt 1 ] || [ "$diff_no_version" -gt 1 ]; then
+                  echo "$file: was modified beyond the version tag (non-trivial change)"
+                  exception=false
+                  break
+                fi
+                echo "In $file, at most the version field was modified"
+              else
+                # If other types of files were changed, do not skip the checks
+                echo "$file: was changed and is not a markdown nor a cabal file (non-trivial change)"
                 exception=false
                 break
               fi
-
-              # We ensure the only change was to the version field
-              diff_version=$(git diff "$base_ref".."$head_ref" -- "$file" | perl -ne 'print if /^-(?!version:)/' | wc -l)
-              diff_no_version=$(git diff "$base_ref".."$head_ref" -- "$file" | perl -ne 'print if /^\+(?!version:)/' | wc -l)
-
-              if [ "$diff_version" -gt 1 ] || [ "$diff_no_version" -gt 1 ]; then
-                echo "$file: was modified beyond the version tag (non-trivial change)"
-                exception=false
-                break
-              fi
-              echo "In $file, at most the version field was modified"
-            else
-              # If other types of files were changed, do not skip the checks
-              echo "$file: was changed and is not a markdown nor a cabal file (non-trivial change)"
-              exception=false
-              break
-            fi
-          done
+            done
+          fi
 
           if $exception; then
             echo "CHECK_HLS_WORKS=0" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix code to not skip CI HLS check when base-ref var is undefined
  type:
  - maintenance
```

# Context

When pushing to `master`, CI is apparently not providing a `base-ref` variable, and this is causing the HLS check to be skipped every time (see [this CI run](https://github.com/IntersectMBO/cardano-cli/actions/runs/14592150292/job/40929667626) for an example). This PR tries to address this by not skipping the check when `base-ref` is not set. This should only affect the `master` CI check bit, and not the unmerged PRs.

# How to trust this PR

It is hard to test it without merging it. But check the code changes make sense, and you cannot find any edge case.

Note that the non-space changes only add four new lines. The rest is just formatting:

```diff
diff --git a/.github/workflows/hls.yml b/.github/workflows/hls.yml
index 2398b66d9..b2c05688c 100644
--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Check if changes were trivial
         id: check_trivial_changes
         run: |
+          if [ -z "${{ github.base_ref }}" ]; then
+            exception=false
+          else
             git fetch origin ${{ github.base_ref }} --unshallow
             base_ref=origin/${{ github.base_ref }}
             head_ref=HEAD
@@ -64,6 +67,7 @@ jobs:
                 break
               fi
             done
+          fi
 
           if $exception; then
             echo "CHECK_HLS_WORKS=0" >> "$GITHUB_OUTPUT"
```

You can see the diff without whitespace in this link: https://github.com/IntersectMBO/cardano-cli/pull/1151/files?diff=split&w=1

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
