### PR TITLE
Wrap CLI help based on terminal width

### DIFF
--- a/cardano-cli/app/cardano-cli.hs
+++ b/cardano-cli/app/cardano-cli.hs
@@ -20,6 +20,8 @@ import qualified Options.Applicative as Opt
 import           Cardano.CLI.OS.Posix
 #endif
 
+import           System.Console.Terminal.Size (Window(..), size)
+
 main :: IO ()
 main = toplevelExceptionHandler $ do
   Crypto.cryptoInit
@@ -30,6 +32,12 @@ main = toplevelExceptionHandler $ do
 #ifdef UNIX
   _ <- setFileCreationMask (otherModes `unionFileModes` groupModes)
 #endif
-  co <- Opt.customExecParser pref (opts envCli)
+
+  mWin <- size
+
+  let termWidth = maybe 80 width mWin
+      dynamicPrefs = pref { Opt.prefColumns = termWidth }
+
+  co <- Opt.customExecParser dynamicPrefs (opts envCli)
 
   orDie (docToText . renderClientCommandError) $ runClientCommand co

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -305,6 +305,7 @@ executable cardano-cli
     cardano-cli,
     cardano-crypto-class ^>=2.2,
     optparse-applicative-fork,
+    terminal-size,
     transformers-except,
 
 library cardano-cli-test-lib


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Wrap CLI help based on terminal width
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

On a wide terminal, the help looks like this:

```
Usage: cardano-cli submit-tx --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL) --tx FILEPATH

  Submit a raw, signed transaction, in its on-wire representation.

Available options:
  --socket-path SOCKET_PATH
                           Path to the node socket. This overrides the CARDANO_NODE_SOCKET_PATH environment variable. The argument is optional if CARDANO_NODE_SOCKET_PATH is defined and mandatory otherwise.
  --mainnet                Use the mainnet magic id. This overrides the CARDANO_NODE_NETWORK_ID environment variable
  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the CARDANO_NODE_NETWORK_ID environment variable
  --tx FILEPATH            File containing the signed transaction.
  -h,--help                Show this help text
```

And on a narrow terminal, the same help looks like this:

```
Usage: cardano-cli submit-tx --socket-path SOCKET_PATH
                               (--mainnet | --testnet-magic NATURAL)
                               --tx FILEPATH

  Submit a raw, signed transaction, in its on-wire representation.

Available options:
  --socket-path SOCKET_PATH
                           Path to the node socket. This overrides the
                           CARDANO_NODE_SOCKET_PATH environment variable. The argument is
                           optional if CARDANO_NODE_SOCKET_PATH is defined and mandatory
                           otherwise.
  --mainnet                Use the mainnet magic id. This overrides the
                           CARDANO_NODE_NETWORK_ID environment variable
  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                           CARDANO_NODE_NETWORK_ID environment variable
  --tx FILEPATH            File containing the signed transaction.
  -h,--help                Show this help text
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
