### PR TITLE
Update CHaP index and flake input to match cardano-node

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2025-04-16T18:30:40Z
-  , cardano-haskell-packages 2025-04-18T06:38:47Z
+  , cardano-haskell-packages 2025-04-22T10:01:33Z
 
 packages:
   cardano-cli

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1744959461,
-        "narHash": "sha256-rPOr9nXAYOOgv+uJ5nP2UCPKLi4y/xCVjdoa5+l9tF4=",
+        "lastModified": 1745317107,
+        "narHash": "sha256-mnctX3WY7zqy9QS4bSdpluCpq4MdSEe8XEOD+opYRhk=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "bdb90651c5f9c236068965945fd2d0b03ef40891",
+        "rev": "39c2a07ca686c111f11c81eca826c3f7b78d9ed7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update CHaP index and flake input
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This ensures that `cardano-cli` is building with the same dependency versions as `cardano-node`.

# How to trust this PR

The `index-state` timestamp for `cardano-haskell-packages` in `cabal.project` is the same as in `cardano-node`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
