### PR TITLE
Use experimental `Era` type in governance actions

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,6 +16,12 @@ index-state:
   , hackage.haskell.org 2025-04-16T18:30:40Z
   , cardano-haskell-packages 2025-04-25T15:50:18Z
 
+source-repository-package
+  type: git
+  location: https://github.com/intersectmbo/cardano-api.git
+  tag: 664d95473b40a23333495641159623761370c201
+  subdir: cardano-api
+  --sha256: sha256-B/4eaFkXWhf5KJXynxgZy1r87kJENS/Yo/Y4Dp/GYTs=
 
 packages:
   cardano-cli

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
@@ -83,7 +83,7 @@ data GovernanceActionCreateConstitutionCmdArgs era
 -- | Datatype to carry data for the create-info governance action
 data GovernanceActionInfoCmdArgs era
   = GovernanceActionInfoCmdArgs
-  { eon :: !(ConwayEraOnwards era)
+  { eon :: !(Era era)
   , networkId :: !L.Network
   , deposit :: !Lovelace
   , returnStakeAddress :: !StakeIdentifier
@@ -128,7 +128,7 @@ data GovernanceActionProtocolParametersUpdateCmdArgs era
 
 data GovernanceActionTreasuryWithdrawalCmdArgs era
   = GovernanceActionTreasuryWithdrawalCmdArgs
-  { eon :: !(ConwayEraOnwards era)
+  { eon :: !(Era era)
   , networkId :: !L.Network
   , deposit :: !Lovelace
   , returnAddr :: !StakeIdentifier
@@ -143,7 +143,7 @@ data GovernanceActionTreasuryWithdrawalCmdArgs era
 
 data GovernanceActionHardforkInitCmdArgs era
   = GovernanceActionHardforkInitCmdArgs
-  { eon :: !(ConwayEraOnwards era)
+  { eon :: !(Era era)
   , networkId :: !L.Network
   , deposit :: !Lovelace
   , returnStakeAddress :: !StakeIdentifier

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
@@ -23,6 +23,7 @@ module Cardano.CLI.EraBased.Governance.Actions.Command
 where
 
 import Cardano.Api
+import Cardano.Api.Experimental (Era)
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Shelley
 
@@ -46,7 +47,7 @@ data GovernanceActionCmds era
 
 data GovernanceActionUpdateCommitteeCmdArgs era
   = GovernanceActionUpdateCommitteeCmdArgs
-  { eon :: !(ConwayEraOnwards era)
+  { eon :: !(Era era)
   , networkId :: !L.Network
   , deposit :: !Lovelace
   , returnAddress :: !StakeIdentifier

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Option.hs
@@ -8,6 +8,7 @@ module Cardano.CLI.EraBased.Governance.Actions.Option
 where
 
 import Cardano.Api
+import Cardano.Api.Experimental (Era)
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Shelley
 
@@ -129,7 +130,7 @@ pGovernanceActionUpdateCommitteeCmd era = do
 
 pUpdateCommitteeCmd
   :: ()
-  => ConwayEraOnwards era
+  => Era era
   -> Parser (Cmd.GovernanceActionUpdateCommitteeCmdArgs era)
 pUpdateCommitteeCmd eon =
   Cmd.GovernanceActionUpdateCommitteeCmdArgs eon

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
@@ -102,12 +102,11 @@ runGovernanceActionInfoCmd
 
     carryHashChecks checkProposalHash proposalAnchor ProposalCheck
 
-    let sbe = convert eon
-        govAction = InfoAct
-        proposalProcedure = createProposalProcedure sbe networkId deposit depositStakeCredential govAction proposalAnchor
+    let govAction = InfoAct
+        proposalProcedure = createProposalProcedure eon networkId deposit depositStakeCredential govAction proposalAnchor
 
     firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
-      conwayEraOnwardsConstraints eon $
+      obtainCommonConstraints eon $
         writeFileTextEnvelope outFile (Just "Info proposal") proposalProcedure
 
 fetchURLErrorToGovernanceActionError
@@ -451,14 +450,13 @@ runGovernanceActionTreasuryWithdrawalCmd
         firstExceptT GovernanceActionsReadStakeCredErrror $ getStakeCredentialFromIdentifier stakeIdentifier
       pure (networkId, stakeCredential, lovelace)
 
-    let sbe = convert eon
-        treasuryWithdrawals =
+    let treasuryWithdrawals =
           TreasuryWithdrawal
             withdrawals
             (toShelleyScriptHash <$> L.maybeToStrictMaybe constitutionScriptHash)
         proposal =
           createProposalProcedure
-            sbe
+            eon
             networkId
             deposit
             depositStakeCredential
@@ -466,7 +464,7 @@ runGovernanceActionTreasuryWithdrawalCmd
             proposalAnchor
 
     firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
-      conwayEraOnwardsConstraints eon $
+      obtainCommonConstraints eon $
         writeFileTextEnvelope outFile (Just "Treasury withdrawal proposal") proposal
 
 runGovernanceActionHardforkInitCmd
@@ -499,8 +497,7 @@ runGovernanceActionHardforkInitCmd
 
     carryHashChecks checkProposalHash proposalAnchor ProposalCheck
 
-    let sbe = convert eon
-        govActIdentifier =
+    let govActIdentifier =
           L.maybeToStrictMaybe $
             L.GovPurposeId <$> mPrevGovernanceActionId
         initHardfork =
@@ -508,10 +505,10 @@ runGovernanceActionHardforkInitCmd
             govActIdentifier
             protVer
 
-        proposalProcedure = createProposalProcedure sbe networkId deposit depositStakeCredential initHardfork proposalAnchor
+        proposalProcedure = createProposalProcedure eon networkId deposit depositStakeCredential initHardfork proposalAnchor
 
     firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
-      conwayEraOnwardsConstraints eon $
+      obtainCommonConstraints eon $
         writeFileTextEnvelope outFile (Just "Hardfork initiation proposal") proposalProcedure
 
 -- | Check the hash of the anchor data against the hash in the anchor if

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
@@ -16,6 +16,7 @@ module Cardano.CLI.EraBased.Governance.Actions.Run
 where
 
 import Cardano.Api
+import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Ledger (StrictMaybe (..))
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Shelley
@@ -295,11 +296,12 @@ runGovernanceActionUpdateCommitteeCmd
             proposalAnchor
 
     firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
-      conwayEraOnwardsConstraints eon $
-        writeFileTextEnvelope
-          outFile
-          (Just "New constitutional committee and/or threshold and/or terms proposal")
-          proposal
+      obtainCommonConstraints eon $
+        shelleyBasedEraConstraints sbe $
+          writeFileTextEnvelope
+            outFile
+            (Just "New constitutional committee and/or threshold and/or terms proposal")
+            proposal
 
 runGovernanceActionCreateProtocolParametersUpdateCmd
   :: forall era


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use experimental `Era` type in `update-committee` command
  type:
  - refactoring
```

# Context

We are migrating to the new `Era` type to simplify implementation, since we are no longer supporting old eras.

Based on this `cardano-api` branch: https://github.com/IntersectMBO/cardano-api/tree/use-experimental-era

# How to trust this PR

Ensure it is a refactoring and the code style is good

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

