### PR TITLE
Standardise bech32 hex output flag

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -1785,14 +1785,27 @@ pKeyOutputFormat =
 
 pPoolIdOutputFormat :: Parser (Vary [FormatBech32, FormatHex])
 pPoolIdOutputFormat =
+  asum
+    [ pFormatFlags
+        "pool-id output"
+        [ flagFormatBech32 & setDefault
+        , flagFormatHex
+        ]
+    , pDeprecatedPoolIdOutputFormat
+    ]
+
+pDeprecatedPoolIdOutputFormat :: Parser (Vary [FormatBech32, FormatHex])
+pDeprecatedPoolIdOutputFormat =
   Opt.option readIdOutputFormat $
     mconcat
       [ Opt.long "output-format"
       , Opt.metavar "STRING"
+      , Opt.hidden
       , Opt.help $
           mconcat
             [ "Optional pool id output format. Accepted output formats are \"hex\" "
-            , "and \"bech32\" (default is \"bech32\")."
+            , "and \"bech32\" (default is \"bech32\").  The --output-format flag is "
+            , "deprecated and will be removed in a future version."
             ]
       , Opt.value (Vary.from FormatBech32)
       ]
@@ -1848,11 +1861,23 @@ flagKeyOutputTextEnvelope
 flagKeyOutputTextEnvelope =
   mkFlag "key-output-text-envelope" "TEXT_ENVELOPE" FormatTextEnvelope
 
+flagFormatBech32
+  :: FormatBech32 :| fs
+  => Flag (Vary fs)
+flagFormatBech32 =
+  mkFlag "output-bech32" "BECH32" FormatBech32
+
 flagFormatCbor
   :: FormatCbor :| fs
   => Flag (Vary fs)
 flagFormatCbor =
   mkFlag "output-cbor" "BASE16 CBOR" FormatCbor
+
+flagFormatHex
+  :: FormatHex :| fs
+  => Flag (Vary fs)
+flagFormatHex =
+  mkFlag "output-hex" "HEX" FormatHex
 
 flagFormatJson
   :: FormatJson :| fs

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -2600,7 +2600,7 @@ Usage: cardano-cli conway stake-pool id
                                           | --stake-pool-verification-extended-key STRING
                                           | --cold-verification-key-file FILEPATH
                                           )
-                                          [--output-format STRING]
+                                          [--output-bech32 | --output-hex]
                                           [--out-file FILEPATH]
 
   Build pool id from the offline key
@@ -4833,7 +4833,7 @@ Usage: cardano-cli latest stake-pool id
                                           | --stake-pool-verification-extended-key STRING
                                           | --cold-verification-key-file FILEPATH
                                           )
-                                          [--output-format STRING]
+                                          [--output-bech32 | --output-hex]
                                           [--out-file FILEPATH]
 
   Build pool id from the offline key

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_id.cli
@@ -3,7 +3,7 @@ Usage: cardano-cli conway stake-pool id
                                           | --stake-pool-verification-extended-key STRING
                                           | --cold-verification-key-file FILEPATH
                                           )
-                                          [--output-format STRING]
+                                          [--output-bech32 | --output-hex]
                                           [--out-file FILEPATH]
 
   Build pool id from the offline key
@@ -16,7 +16,11 @@ Available options:
                            hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
+  --output-bech32          Format pool-id output to BECH32 (default).
+  --output-hex             Format pool-id output to HEX.
   --output-format STRING   Optional pool id output format. Accepted output
                            formats are "hex" and "bech32" (default is "bech32").
+                           The --output-format flag is deprecated and will be
+                           removed in a future version.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_id.cli
@@ -3,7 +3,7 @@ Usage: cardano-cli latest stake-pool id
                                           | --stake-pool-verification-extended-key STRING
                                           | --cold-verification-key-file FILEPATH
                                           )
-                                          [--output-format STRING]
+                                          [--output-bech32 | --output-hex]
                                           [--out-file FILEPATH]
 
   Build pool id from the offline key
@@ -16,7 +16,11 @@ Available options:
                            hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
+  --output-bech32          Format pool-id output to BECH32 (default).
+  --output-hex             Format pool-id output to HEX.
   --output-format STRING   Optional pool id output format. Accepted output
                            formats are "hex" and "bech32" (default is "bech32").
+                           The --output-format flag is deprecated and will be
+                           removed in a future version.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    New `--output-bech32` and `--output-hex` flags.
    Deprecate `--output-format [bech32|hex]` flag.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Progression towards https://github.com/input-output-hk/cardano-node-wiki/pull/72

Depends on https://github.com/IntersectMBO/cardano-cli/pull/1146

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
