### PR TITLE
Use lazy ByteString for writing out result of utxo query

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -71,7 +71,7 @@ import Data.Aeson as Aeson
 import Data.Aeson qualified as A
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Bifunctor (Bifunctor (..))
-import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Base16.Lazy qualified as Base16
 import Data.ByteString.Char8 qualified as C8
 import Data.ByteString.Lazy qualified as BS
 import Data.ByteString.Lazy.Char8 qualified as LBS
@@ -1189,7 +1189,7 @@ writeFilteredUTxOs sbe format mOutFile utxo =
       . writeLazyByteStringOutput mOutFile
     $ format
       & ( id
-            . Vary.on (\FormatCbor -> LBS.fromStrict . Base16.encode . CBOR.serialize' $ toLedgerUTxO sbe utxo)
+            . Vary.on (\FormatCbor -> Base16.encode . CBOR.serialize $ toLedgerUTxO sbe utxo)
             . Vary.on (\FormatJson -> encodePretty utxo)
             . Vary.on (\FormatText -> strictTextToLazyBytestring $ filteredUTxOsToText sbe utxo)
             $ Vary.exhaustiveCase


### PR DESCRIPTION
This greatly reduces the amount of memory needed for the whole UTxO case

# Changelog

```yaml
- description: |
    Use lazy ByteString for writing out result of utxo query
  type:
  - optimisation   # measurable performance improvements
```

# Context

Running `cardano-cli query utxo --whole-utxo --output-cbor` takes up a large amount of memory as the UTxO is fetched and then serialized to hex cbor.

# How to trust this PR

The previous code was encoding to a lazy BS, converting it to strict, converting it back to lazy, and then writing it out as lazy. This just removes the intermediate strict BS by using the lazy variant of `Base16`.

The benefit is seen when doing `cardano-cli query utxo --whole-utxo --output-cbor`: the memory footprint is quite a bit less.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
