### PR TITLE
Consistent output for `text-view decode-cbor` command

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/TextView/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/TextView/Command.hs
@@ -3,6 +3,7 @@
 
 module Cardano.CLI.EraBased.TextView.Command
   ( TextViewCmds (..)
+  , TextViewInfoCmdArgs (..)
   , renderTextViewCmds
   )
 where
@@ -11,12 +12,17 @@ import Cardano.Api.Shelley
 
 import Data.Text (Text)
 
-data TextViewCmds era
-  = TextViewInfo
-      !FilePath
-      (Maybe (File () Out))
+newtype TextViewCmds era
+  = TextViewInfoCmd TextViewInfoCmdArgs
+  deriving Show
+
+data TextViewInfoCmdArgs
+  = TextViewInfoCmdArgs
+  { inputFile :: !FilePath
+  , mOutFile :: Maybe (File () Out)
+  }
   deriving Show
 
 renderTextViewCmds :: TextViewCmds era -> Text
 renderTextViewCmds = \case
-  TextViewInfo _ _ -> "text-view decode-cbor"
+  TextViewInfoCmd _ -> "text-view decode-cbor"

--- a/cardano-cli/src/Cardano/CLI/EraBased/TextView/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/TextView/Command.hs
@@ -3,26 +3,30 @@
 
 module Cardano.CLI.EraBased.TextView.Command
   ( TextViewCmds (..)
-  , TextViewInfoCmdArgs (..)
+  , TextViewDecodeCborCmdArgs (..)
   , renderTextViewCmds
   )
 where
 
 import Cardano.Api.Shelley
 
+import Cardano.CLI.Type.Common (FormatCbor, FormatText)
+
 import Data.Text (Text)
+import Vary
 
 newtype TextViewCmds era
-  = TextViewInfoCmd TextViewInfoCmdArgs
+  = TextViewDecodeCborCmd TextViewDecodeCborCmdArgs
   deriving Show
 
-data TextViewInfoCmdArgs
-  = TextViewInfoCmdArgs
+data TextViewDecodeCborCmdArgs
+  = TextViewDecodeCborCmdArgs
   { inputFile :: !FilePath
+  , outputFormat :: !(Vary [FormatCbor, FormatText])
   , mOutFile :: Maybe (File () Out)
   }
   deriving Show
 
 renderTextViewCmds :: TextViewCmds era -> Text
 renderTextViewCmds = \case
-  TextViewInfoCmd _ -> "text-view decode-cbor"
+  TextViewDecodeCborCmd _ -> "text-view decode-cbor"

--- a/cardano-cli/src/Cardano/CLI/EraBased/TextView/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/TextView/Option.hs
@@ -31,6 +31,6 @@ pTextViewCmds =
     [ Just $
         Opt.hsubparser $
           commandWithMetavar "decode-cbor" $
-            Opt.info (TextViewInfo <$> pCBORInFile <*> pMaybeOutputFile) $
+            Opt.info (fmap TextViewInfoCmd (TextViewInfoCmdArgs <$> pCBORInFile <*> pMaybeOutputFile)) $
               Opt.progDesc "Print a TextView file as decoded CBOR."
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/TextView/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/TextView/Option.hs
@@ -10,8 +10,10 @@ where
 
 import Cardano.CLI.EraBased.Common.Option
 import Cardano.CLI.EraBased.TextView.Command
+import Cardano.CLI.Option.Flag
 import Cardano.CLI.Parser
 
+import Data.Function ((&))
 import Options.Applicative hiding (help, str)
 import Options.Applicative qualified as Opt
 
@@ -28,9 +30,20 @@ pTextViewCmds =
           , "are stored on disk as TextView files."
           ]
     )
-    [ Just $
-        Opt.hsubparser $
-          commandWithMetavar "decode-cbor" $
-            Opt.info (fmap TextViewInfoCmd (TextViewInfoCmdArgs <$> pCBORInFile <*> pMaybeOutputFile)) $
-              Opt.progDesc "Print a TextView file as decoded CBOR."
+    [ Just
+        . Opt.hsubparser
+        . commandWithMetavar "decode-cbor"
+        $ Opt.info
+          ( fmap
+              TextViewDecodeCborCmd
+              $ TextViewDecodeCborCmdArgs
+                <$> pCBORInFile
+                <*> pFormatFlags
+                  "text view info output format"
+                  [ flagFormatCbor
+                  , flagFormatText & setDefault
+                  ]
+                <*> pMaybeOutputFile
+          )
+        $ Opt.progDesc "Print a TextView file as decoded CBOR."
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/TextView/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/TextView/Run.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 module Cardano.CLI.EraBased.TextView.Run
   ( runTextViewCmds
@@ -17,16 +18,19 @@ import Data.ByteString.Lazy.Char8 qualified as LBS
 
 runTextViewCmds :: TextViewCmds era -> ExceptT TextViewFileError IO ()
 runTextViewCmds = \case
-  TextViewInfo fpath mOutfile -> runTextViewInfoCmd fpath mOutfile
+  TextViewInfoCmd cmd -> runTextViewInfoCmd cmd
 
 runTextViewInfoCmd
   :: ()
-  => FilePath
-  -> Maybe (File () Out)
+  => TextViewInfoCmdArgs
   -> ExceptT TextViewFileError IO ()
-runTextViewInfoCmd fpath mOutFile = do
-  tv <- firstExceptT TextViewReadFileError $ newExceptT (readTextEnvelopeFromFile fpath)
-  let lbCBOR = LBS.fromStrict (textEnvelopeRawCBOR tv)
-  case mOutFile of
-    Just (File oFpath) -> liftIO $ LBS.writeFile oFpath lbCBOR
-    Nothing -> firstExceptT TextViewCBORPrettyPrintError $ pPrintCBOR lbCBOR
+runTextViewInfoCmd
+  TextViewInfoCmdArgs
+    { inputFile
+    , mOutFile
+    } = do
+    tv <- firstExceptT TextViewReadFileError $ newExceptT (readTextEnvelopeFromFile inputFile)
+    let lbCBOR = LBS.fromStrict (textEnvelopeRawCBOR tv)
+    case mOutFile of
+      Just (File oFpath) -> liftIO $ LBS.writeFile oFpath lbCBOR
+      Nothing -> firstExceptT TextViewCBORPrettyPrintError $ pPrintCBOR lbCBOR

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextView/DecodeCbor.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextView/DecodeCbor.hs
@@ -22,6 +22,7 @@ hprop_golden_shelleyTextViewDecodeCbor = propertyOnce $ H.moduleWorkspace "tmp" 
       [ "latest"
       , "text-view"
       , "decode-cbor"
+      , "--output-text"
       , "--file"
       , unsignedTxFile
       ]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -2622,6 +2622,9 @@ Usage: cardano-cli conway text-view decode-cbor
   are stored on disk as TextView files.
 
 Usage: cardano-cli conway text-view decode-cbor --in-file FILEPATH
+                                                  [ --output-cbor
+                                                  | --output-text
+                                                  ]
                                                   [--out-file FILEPATH]
 
   Print a TextView file as decoded CBOR.
@@ -4855,6 +4858,9 @@ Usage: cardano-cli latest text-view decode-cbor
   are stored on disk as TextView files.
 
 Usage: cardano-cli latest text-view decode-cbor --in-file FILEPATH
+                                                  [ --output-cbor
+                                                  | --output-text
+                                                  ]
                                                   [--out-file FILEPATH]
 
   Print a TextView file as decoded CBOR.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_text-view_decode-cbor.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_text-view_decode-cbor.cli
@@ -1,9 +1,15 @@
 Usage: cardano-cli conway text-view decode-cbor --in-file FILEPATH
+                                                  [ --output-cbor
+                                                  | --output-text
+                                                  ]
                                                   [--out-file FILEPATH]
 
   Print a TextView file as decoded CBOR.
 
 Available options:
   --in-file FILEPATH       CBOR input file.
+  --output-cbor            Format text view info output format to BASE16 CBOR.
+  --output-text            Format text view info output format to TEXT
+                           (default).
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_text-view_decode-cbor.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_text-view_decode-cbor.cli
@@ -1,9 +1,15 @@
 Usage: cardano-cli latest text-view decode-cbor --in-file FILEPATH
+                                                  [ --output-cbor
+                                                  | --output-text
+                                                  ]
                                                   [--out-file FILEPATH]
 
   Print a TextView file as decoded CBOR.
 
 Available options:
   --in-file FILEPATH       CBOR input file.
+  --output-cbor            Format text view info output format to BASE16 CBOR.
+  --output-text            Format text view info output format to TEXT
+                           (default).
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Consistent output for `text-view decode-cbor ` command
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Standardises on [ADR-12](https://github.com/input-output-hk/cardano-node-wiki/blob/main/docs/ADR-012-standardise-CLI-multiple-choice-flags-construction.md)

The default output format for `text-view decode-cbor ` will be `text` because `cbor` output to `stdout` is not practical.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
