### PR TITLE
Fix metavars according to ADR-013

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Option.hs
@@ -62,7 +62,7 @@ pTxInOnly =
   Opt.option
     (readerFromParsecParser parseTxIn)
     ( Opt.long "tx-in"
-        <> Opt.metavar "TX-IN"
+        <> Opt.metavar "TX_IN"
         <> Opt.help "TxId#TxIx"
     )
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -1412,7 +1412,7 @@ pReferenceTxIn prefix scriptType =
   Opt.option (readerFromParsecParser parseTxIn) $
     mconcat
       [ Opt.long (prefix ++ "tx-in-reference")
-      , Opt.metavar "TX-IN"
+      , Opt.metavar "TX_IN"
       , Opt.help $
           mconcat
             [ "TxId#TxIx - Specify a reference input. The reference input must have"
@@ -1425,7 +1425,7 @@ pReadOnlyReferenceTxIn =
   Opt.option (readerFromParsecParser parseTxIn) $
     mconcat
       [ Opt.long "read-only-tx-in-reference"
-      , Opt.metavar "TX-IN"
+      , Opt.metavar "TX_IN"
       , Opt.help $
           mconcat
             [ "Specify a read only reference input. This reference input is not witnessing anything "
@@ -2069,7 +2069,7 @@ pTxIn sbe balance =
     <$> Opt.option
       (readerFromParsecParser parseTxIn)
       ( Opt.long "tx-in"
-          <> Opt.metavar "TX-IN"
+          <> Opt.metavar "TX_IN"
           <> Opt.help "TxId#TxIx"
       )
     <*> optional
@@ -2110,7 +2110,7 @@ pTxInCollateral =
   Opt.option
     (readerFromParsecParser parseTxIn)
     ( Opt.long "tx-in-collateral"
-        <> Opt.metavar "TX-IN"
+        <> Opt.metavar "TX_IN"
         <> Opt.help "TxId#TxIx"
     )
 
@@ -2544,7 +2544,7 @@ pQueryUTxOFilter =
     Opt.option (readerFromParsecParser parseTxIn) $
       mconcat
         [ Opt.long "tx-in"
-        , Opt.metavar "TX-IN"
+        , Opt.metavar "TX_IN"
         , Opt.help "Filter by transaction input (TxId#TxIx)."
         ]
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Option.hs
@@ -402,7 +402,7 @@ pMaybeSystemStart =
       Opt.strOption $
         mconcat
           [ Opt.long "start-time"
-          , Opt.metavar "UTC-TIME"
+          , Opt.metavar "UTC_TIME"
           , Opt.help
               "The genesis start time in YYYY-MM-DDThh:mm:ssZ format. If unspecified, will be the current time +30 seconds."
           ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -545,7 +545,7 @@ pQueryRefScriptSizeCmd era envCli =
     Opt.option (readerFromParsecParser parseTxIn) $
       mconcat
         [ Opt.long "tx-in"
-        , Opt.metavar "TX-IN"
+        , Opt.metavar "TX_IN"
         , Opt.help "Transaction input (TxId#TxIx)."
         ]
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Option.hs
@@ -323,7 +323,7 @@ pGenesisCmds envCli =
         Opt.strOption $
           mconcat
             [ Opt.long "start-time"
-            , Opt.metavar "UTC-TIME"
+            , Opt.metavar "UTC_TIME"
             , Opt.help
                 "The genesis start time in YYYY-MM-DDThh:mm:ssZ format. If unspecified, will be the current time +30 seconds."
             ]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -360,7 +360,7 @@ Usage: cardano-cli query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                 [--volatile-tip | --immutable-tip]
                                 ( --whole-utxo
                                 | (--address ADDRESS)
-                                | (--tx-in TX-IN)
+                                | (--tx-in TX_IN)
                                 )
                                 [--output-cbor | --output-json | --output-text]
                                 [--out-file FILEPATH]
@@ -697,7 +697,7 @@ Usage: cardano-cli legacy genesis create-cardano
                                                    --genesis-dir DIR
                                                    [--gen-genesis-keys INT]
                                                    [--gen-utxo-keys INT]
-                                                   [--start-time UTC-TIME]
+                                                   [--start-time UTC_TIME]
                                                    [--supply LOVELACE]
                                                    [--security-param INT]
                                                    [--slot-length INT]
@@ -729,7 +729,7 @@ Usage: cardano-cli legacy genesis create
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]
-                                           [--start-time UTC-TIME]
+                                           [--start-time UTC_TIME]
                                            [--supply LOVELACE]
                                            (--mainnet | --testnet-magic NATURAL)
 
@@ -753,7 +753,7 @@ Usage: cardano-cli legacy genesis create-staked
                                                   [--gen-utxo-keys INT]
                                                   [--gen-pools INT]
                                                   [--gen-stake-delegs INT]
-                                                  [--start-time UTC-TIME]
+                                                  [--start-time UTC_TIME]
                                                   [--supply LOVELACE]
                                                   [--supply-delegated LOVELACE]
                                                   ( --mainnet
@@ -1280,7 +1280,7 @@ Usage: cardano-cli conway genesis initial-txin --verification-key-file FILEPATH
 Usage: cardano-cli conway genesis create-cardano --genesis-dir DIR
                                                    [--gen-genesis-keys INT]
                                                    [--gen-utxo-keys INT]
-                                                   [--start-time UTC-TIME]
+                                                   [--start-time UTC_TIME]
                                                    [--supply LOVELACE]
                                                    [--security-param NON_ZERO_WORD64]
                                                    [--slot-length INT]
@@ -1305,7 +1305,7 @@ Usage: cardano-cli conway genesis create
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]
-                                           [--start-time UTC-TIME]
+                                           [--start-time UTC_TIME]
                                            [--supply LOVELACE]
                                            (--mainnet | --testnet-magic NATURAL)
 
@@ -1322,7 +1322,7 @@ Usage: cardano-cli conway genesis create-staked
                                                   [--gen-utxo-keys INT]
                                                   [--gen-pools INT]
                                                   [--gen-stake-delegs INT]
-                                                  [--start-time UTC-TIME]
+                                                  [--start-time UTC_TIME]
                                                   [--supply LOVELACE]
                                                   [--supply-delegated LOVELACE]
                                                   ( --mainnet
@@ -1354,7 +1354,7 @@ Usage: cardano-cli conway genesis create-testnet-data [--spec-shelley FILEPATH]
                                                         [--delegated-supply LOVELACE]
                                                         [--testnet-magic NATURAL]
                                                         [--relays FILEPATH]
-                                                        [--start-time UTC-TIME]
+                                                        [--start-time UTC_TIME]
                                                         --out-dir DIR
 
   Create data to use for starting a testnet.
@@ -2165,7 +2165,7 @@ Usage: cardano-cli conway query ref-script-size
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
-                                                  (--tx-in TX-IN)
+                                                  (--tx-in TX_IN)
                                                   [ --output-json
                                                   | --output-text
                                                   ]
@@ -2334,7 +2334,7 @@ Usage: cardano-cli conway query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        [--volatile-tip | --immutable-tip]
                                        ( --whole-utxo
                                        | (--address ADDRESS)
-                                       | (--tx-in TX-IN)
+                                       | (--tx-in TX_IN)
                                        )
                                        [ --output-cbor
                                        | --output-json
@@ -2651,8 +2651,8 @@ Usage: cardano-cli conway transaction build-raw
                                                   [ --script-valid
                                                   | --script-invalid
                                                   ]
-                                                  (--tx-in TX-IN
-                                                    [ --spending-tx-in-reference TX-IN
+                                                  (--tx-in TX_IN
+                                                    [ --spending-tx-in-reference TX_IN
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
@@ -2666,7 +2666,7 @@ Usage: cardano-cli conway transaction build-raw
                                                       | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --spending-reference-tx-in-execution-units (INT, INT)
-                                                    | --simple-script-tx-in-reference TX-IN
+                                                    | --simple-script-tx-in-reference TX_IN
                                                     | --tx-in-script-file FILEPATH
                                                       [
                                                         [ --tx-in-datum-cbor-file CBOR_FILE
@@ -2680,8 +2680,8 @@ Usage: cardano-cli conway transaction build-raw
                                                         )
                                                         --tx-in-execution-units (INT, INT)]
                                                     ])
-                                                  [--read-only-tx-in-reference TX-IN]
-                                                  [--tx-in-collateral TX-IN]
+                                                  [--read-only-tx-in-reference TX_IN]
+                                                  [--tx-in-collateral TX_IN]
                                                   [--tx-out-return-collateral ADDRESS VALUE]
                                                   [--tx-total-collateral INTEGER]
                                                   [ --required-signer FILEPATH
@@ -2708,9 +2708,9 @@ Usage: cardano-cli conway transaction build-raw
                                                         | --mint-redeemer-value JSON_VALUE
                                                         )
                                                         --mint-execution-units (INT, INT)]
-                                                    | --simple-minting-script-tx-in-reference TX-IN
+                                                    | --simple-minting-script-tx-in-reference TX_IN
                                                       --policy-id HASH
-                                                    | --mint-tx-in-reference TX-IN
+                                                    | --mint-tx-in-reference TX_IN
                                                       ( --mint-plutus-script-v2
                                                       | --mint-plutus-script-v3
                                                       )
@@ -2732,7 +2732,7 @@ Usage: cardano-cli conway transaction build-raw
                                                         | --certificate-redeemer-value JSON_VALUE
                                                         )
                                                         --certificate-execution-units (INT, INT)]
-                                                    | --certificate-tx-in-reference TX-IN
+                                                    | --certificate-tx-in-reference TX_IN
                                                       ( --certificate-plutus-script-v2
                                                       | --certificate-plutus-script-v3
                                                       )
@@ -2750,7 +2750,7 @@ Usage: cardano-cli conway transaction build-raw
                                                         | --withdrawal-redeemer-value JSON_VALUE
                                                         )
                                                         --withdrawal-execution-units (INT, INT)]
-                                                    | --withdrawal-tx-in-reference TX-IN
+                                                    | --withdrawal-tx-in-reference TX_IN
                                                       ( --withdrawal-plutus-script-v2
                                                       | --withdrawal-plutus-script-v3
                                                       )
@@ -2776,7 +2776,7 @@ Usage: cardano-cli conway transaction build-raw
                                                         | --vote-redeemer-value JSON_VALUE
                                                         )
                                                         --vote-execution-units (INT, INT)]
-                                                    | --vote-tx-in-reference TX-IN
+                                                    | --vote-tx-in-reference TX_IN
                                                       --vote-plutus-script-v3
                                                       ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                       | --vote-reference-tx-in-redeemer-file JSON_FILE
@@ -2792,7 +2792,7 @@ Usage: cardano-cli conway transaction build-raw
                                                         | --proposal-redeemer-value JSON_VALUE
                                                         )
                                                         --proposal-execution-units (INT, INT)]
-                                                    | --proposal-tx-in-reference TX-IN
+                                                    | --proposal-tx-in-reference TX_IN
                                                       --proposal-plutus-script-v3
                                                       ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                       | --proposal-reference-tx-in-redeemer-file JSON_FILE
@@ -2820,8 +2820,8 @@ Usage: cardano-cli conway transaction build
                                               | --script-invalid
                                               ]
                                               [--witness-override WORD]
-                                              (--tx-in TX-IN
-                                                [ --spending-tx-in-reference TX-IN
+                                              (--tx-in TX_IN
+                                                [ --spending-tx-in-reference TX_IN
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
@@ -2834,7 +2834,7 @@ Usage: cardano-cli conway transaction build
                                                   | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                   | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
-                                                | --simple-script-tx-in-reference TX-IN
+                                                | --simple-script-tx-in-reference TX_IN
                                                 | --tx-in-script-file FILEPATH
                                                   [
                                                     [ --tx-in-datum-cbor-file CBOR_FILE
@@ -2847,11 +2847,11 @@ Usage: cardano-cli conway transaction build
                                                     | --tx-in-redeemer-value JSON_VALUE
                                                     )]
                                                 ])
-                                              [--read-only-tx-in-reference TX-IN]
+                                              [--read-only-tx-in-reference TX_IN]
                                               [ --required-signer FILEPATH
                                               | --required-signer-hash HASH
                                               ]
-                                              [--tx-in-collateral TX-IN]
+                                              [--tx-in-collateral TX_IN]
                                               [--tx-out-return-collateral ADDRESS VALUE]
                                               [--tx-total-collateral INTEGER]
                                               [--tx-out ADDRESS VALUE
@@ -2874,9 +2874,9 @@ Usage: cardano-cli conway transaction build
                                                   | --mint-redeemer-file JSON_FILE
                                                   | --mint-redeemer-value JSON_VALUE
                                                   ]
-                                                | --simple-minting-script-tx-in-reference TX-IN
+                                                | --simple-minting-script-tx-in-reference TX_IN
                                                   --policy-id HASH
-                                                | --mint-tx-in-reference TX-IN
+                                                | --mint-tx-in-reference TX_IN
                                                   ( --mint-plutus-script-v2
                                                   | --mint-plutus-script-v3
                                                   )
@@ -2894,7 +2894,7 @@ Usage: cardano-cli conway transaction build
                                                   | --certificate-redeemer-file JSON_FILE
                                                   | --certificate-redeemer-value JSON_VALUE
                                                   ]
-                                                | --certificate-tx-in-reference TX-IN
+                                                | --certificate-tx-in-reference TX_IN
                                                   ( --certificate-plutus-script-v2
                                                   | --certificate-plutus-script-v3
                                                   )
@@ -2909,7 +2909,7 @@ Usage: cardano-cli conway transaction build
                                                   | --withdrawal-redeemer-file JSON_FILE
                                                   | --withdrawal-redeemer-value JSON_VALUE
                                                   ]
-                                                | --withdrawal-tx-in-reference TX-IN
+                                                | --withdrawal-tx-in-reference TX_IN
                                                   ( --withdrawal-plutus-script-v2
                                                   | --withdrawal-plutus-script-v3
                                                   )
@@ -2931,7 +2931,7 @@ Usage: cardano-cli conway transaction build
                                                   | --vote-redeemer-file JSON_FILE
                                                   | --vote-redeemer-value JSON_VALUE
                                                   ]
-                                                | --vote-tx-in-reference TX-IN
+                                                | --vote-tx-in-reference TX_IN
                                                   --vote-plutus-script-v3
                                                   ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                   | --vote-reference-tx-in-redeemer-file JSON_FILE
@@ -2944,7 +2944,7 @@ Usage: cardano-cli conway transaction build
                                                   | --proposal-redeemer-file JSON_FILE
                                                   | --proposal-redeemer-value JSON_VALUE
                                                   ]
-                                                | --proposal-tx-in-reference TX-IN
+                                                | --proposal-tx-in-reference TX_IN
                                                   --proposal-plutus-script-v3
                                                   ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                   | --proposal-reference-tx-in-redeemer-file JSON_FILE
@@ -2969,8 +2969,8 @@ Usage: cardano-cli conway transaction build-estimate
                                                        [--byron-key-witnesses Int]
                                                        --protocol-params-file FILEPATH
                                                        --total-utxo-value VALUE
-                                                       (--tx-in TX-IN
-                                                         [ --spending-tx-in-reference TX-IN
+                                                       (--tx-in TX_IN
+                                                         [ --spending-tx-in-reference TX_IN
                                                            ( --spending-plutus-script-v2
                                                            | --spending-plutus-script-v3
                                                            )
@@ -2984,7 +2984,7 @@ Usage: cardano-cli conway transaction build-estimate
                                                            | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --spending-reference-tx-in-execution-units (INT, INT)
-                                                         | --simple-script-tx-in-reference TX-IN
+                                                         | --simple-script-tx-in-reference TX_IN
                                                          | --tx-in-script-file FILEPATH
                                                            [
                                                              [ --tx-in-datum-cbor-file CBOR_FILE
@@ -2998,11 +2998,11 @@ Usage: cardano-cli conway transaction build-estimate
                                                              )
                                                              --tx-in-execution-units (INT, INT)]
                                                          ])
-                                                       [--read-only-tx-in-reference TX-IN]
+                                                       [--read-only-tx-in-reference TX_IN]
                                                        [ --required-signer FILEPATH
                                                        | --required-signer-hash HASH
                                                        ]
-                                                       [--tx-in-collateral TX-IN]
+                                                       [--tx-in-collateral TX_IN]
                                                        [--tx-out-return-collateral ADDRESS VALUE]
                                                        [--tx-out ADDRESS VALUE
                                                          [ --tx-out-datum-hash HASH
@@ -3026,9 +3026,9 @@ Usage: cardano-cli conway transaction build-estimate
                                                              | --mint-redeemer-value JSON_VALUE
                                                              )
                                                              --mint-execution-units (INT, INT)]
-                                                         | --simple-minting-script-tx-in-reference TX-IN
+                                                         | --simple-minting-script-tx-in-reference TX_IN
                                                            --policy-id HASH
-                                                         | --mint-tx-in-reference TX-IN
+                                                         | --mint-tx-in-reference TX_IN
                                                            ( --mint-plutus-script-v2
                                                            | --mint-plutus-script-v3
                                                            )
@@ -3050,7 +3050,7 @@ Usage: cardano-cli conway transaction build-estimate
                                                              | --certificate-redeemer-value JSON_VALUE
                                                              )
                                                              --certificate-execution-units (INT, INT)]
-                                                         | --certificate-tx-in-reference TX-IN
+                                                         | --certificate-tx-in-reference TX_IN
                                                            ( --certificate-plutus-script-v2
                                                            | --certificate-plutus-script-v3
                                                            )
@@ -3068,7 +3068,7 @@ Usage: cardano-cli conway transaction build-estimate
                                                              | --withdrawal-redeemer-value JSON_VALUE
                                                              )
                                                              --withdrawal-execution-units (INT, INT)]
-                                                         | --withdrawal-tx-in-reference TX-IN
+                                                         | --withdrawal-tx-in-reference TX_IN
                                                            ( --withdrawal-plutus-script-v2
                                                            | --withdrawal-plutus-script-v3
                                                            )
@@ -3095,7 +3095,7 @@ Usage: cardano-cli conway transaction build-estimate
                                                              | --vote-redeemer-value JSON_VALUE
                                                              )
                                                              --vote-execution-units (INT, INT)]
-                                                         | --vote-tx-in-reference TX-IN
+                                                         | --vote-tx-in-reference TX_IN
                                                            --vote-plutus-script-v3
                                                            ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                            | --vote-reference-tx-in-redeemer-file JSON_FILE
@@ -3111,7 +3111,7 @@ Usage: cardano-cli conway transaction build-estimate
                                                              | --proposal-redeemer-value JSON_VALUE
                                                              )
                                                              --proposal-execution-units (INT, INT)]
-                                                         | --proposal-tx-in-reference TX-IN
+                                                         | --proposal-tx-in-reference TX_IN
                                                            --proposal-plutus-script-v3
                                                            ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                            | --proposal-reference-tx-in-redeemer-file JSON_FILE
@@ -3516,7 +3516,7 @@ Usage: cardano-cli latest genesis initial-txin --verification-key-file FILEPATH
 Usage: cardano-cli latest genesis create-cardano --genesis-dir DIR
                                                    [--gen-genesis-keys INT]
                                                    [--gen-utxo-keys INT]
-                                                   [--start-time UTC-TIME]
+                                                   [--start-time UTC_TIME]
                                                    [--supply LOVELACE]
                                                    [--security-param NON_ZERO_WORD64]
                                                    [--slot-length INT]
@@ -3541,7 +3541,7 @@ Usage: cardano-cli latest genesis create
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]
-                                           [--start-time UTC-TIME]
+                                           [--start-time UTC_TIME]
                                            [--supply LOVELACE]
                                            (--mainnet | --testnet-magic NATURAL)
 
@@ -3558,7 +3558,7 @@ Usage: cardano-cli latest genesis create-staked
                                                   [--gen-utxo-keys INT]
                                                   [--gen-pools INT]
                                                   [--gen-stake-delegs INT]
-                                                  [--start-time UTC-TIME]
+                                                  [--start-time UTC_TIME]
                                                   [--supply LOVELACE]
                                                   [--supply-delegated LOVELACE]
                                                   ( --mainnet
@@ -3590,7 +3590,7 @@ Usage: cardano-cli latest genesis create-testnet-data [--spec-shelley FILEPATH]
                                                         [--delegated-supply LOVELACE]
                                                         [--testnet-magic NATURAL]
                                                         [--relays FILEPATH]
-                                                        [--start-time UTC-TIME]
+                                                        [--start-time UTC_TIME]
                                                         --out-dir DIR
 
   Create data to use for starting a testnet.
@@ -4401,7 +4401,7 @@ Usage: cardano-cli latest query ref-script-size
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
-                                                  (--tx-in TX-IN)
+                                                  (--tx-in TX_IN)
                                                   [ --output-json
                                                   | --output-text
                                                   ]
@@ -4570,7 +4570,7 @@ Usage: cardano-cli latest query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        [--volatile-tip | --immutable-tip]
                                        ( --whole-utxo
                                        | (--address ADDRESS)
-                                       | (--tx-in TX-IN)
+                                       | (--tx-in TX_IN)
                                        )
                                        [ --output-cbor
                                        | --output-json
@@ -4887,8 +4887,8 @@ Usage: cardano-cli latest transaction build-raw
                                                   [ --script-valid
                                                   | --script-invalid
                                                   ]
-                                                  (--tx-in TX-IN
-                                                    [ --spending-tx-in-reference TX-IN
+                                                  (--tx-in TX_IN
+                                                    [ --spending-tx-in-reference TX_IN
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
@@ -4902,7 +4902,7 @@ Usage: cardano-cli latest transaction build-raw
                                                       | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --spending-reference-tx-in-execution-units (INT, INT)
-                                                    | --simple-script-tx-in-reference TX-IN
+                                                    | --simple-script-tx-in-reference TX_IN
                                                     | --tx-in-script-file FILEPATH
                                                       [
                                                         [ --tx-in-datum-cbor-file CBOR_FILE
@@ -4916,8 +4916,8 @@ Usage: cardano-cli latest transaction build-raw
                                                         )
                                                         --tx-in-execution-units (INT, INT)]
                                                     ])
-                                                  [--read-only-tx-in-reference TX-IN]
-                                                  [--tx-in-collateral TX-IN]
+                                                  [--read-only-tx-in-reference TX_IN]
+                                                  [--tx-in-collateral TX_IN]
                                                   [--tx-out-return-collateral ADDRESS VALUE]
                                                   [--tx-total-collateral INTEGER]
                                                   [ --required-signer FILEPATH
@@ -4944,9 +4944,9 @@ Usage: cardano-cli latest transaction build-raw
                                                         | --mint-redeemer-value JSON_VALUE
                                                         )
                                                         --mint-execution-units (INT, INT)]
-                                                    | --simple-minting-script-tx-in-reference TX-IN
+                                                    | --simple-minting-script-tx-in-reference TX_IN
                                                       --policy-id HASH
-                                                    | --mint-tx-in-reference TX-IN
+                                                    | --mint-tx-in-reference TX_IN
                                                       ( --mint-plutus-script-v2
                                                       | --mint-plutus-script-v3
                                                       )
@@ -4968,7 +4968,7 @@ Usage: cardano-cli latest transaction build-raw
                                                         | --certificate-redeemer-value JSON_VALUE
                                                         )
                                                         --certificate-execution-units (INT, INT)]
-                                                    | --certificate-tx-in-reference TX-IN
+                                                    | --certificate-tx-in-reference TX_IN
                                                       ( --certificate-plutus-script-v2
                                                       | --certificate-plutus-script-v3
                                                       )
@@ -4986,7 +4986,7 @@ Usage: cardano-cli latest transaction build-raw
                                                         | --withdrawal-redeemer-value JSON_VALUE
                                                         )
                                                         --withdrawal-execution-units (INT, INT)]
-                                                    | --withdrawal-tx-in-reference TX-IN
+                                                    | --withdrawal-tx-in-reference TX_IN
                                                       ( --withdrawal-plutus-script-v2
                                                       | --withdrawal-plutus-script-v3
                                                       )
@@ -5012,7 +5012,7 @@ Usage: cardano-cli latest transaction build-raw
                                                         | --vote-redeemer-value JSON_VALUE
                                                         )
                                                         --vote-execution-units (INT, INT)]
-                                                    | --vote-tx-in-reference TX-IN
+                                                    | --vote-tx-in-reference TX_IN
                                                       --vote-plutus-script-v3
                                                       ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                       | --vote-reference-tx-in-redeemer-file JSON_FILE
@@ -5028,7 +5028,7 @@ Usage: cardano-cli latest transaction build-raw
                                                         | --proposal-redeemer-value JSON_VALUE
                                                         )
                                                         --proposal-execution-units (INT, INT)]
-                                                    | --proposal-tx-in-reference TX-IN
+                                                    | --proposal-tx-in-reference TX_IN
                                                       --proposal-plutus-script-v3
                                                       ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                       | --proposal-reference-tx-in-redeemer-file JSON_FILE
@@ -5056,8 +5056,8 @@ Usage: cardano-cli latest transaction build
                                               | --script-invalid
                                               ]
                                               [--witness-override WORD]
-                                              (--tx-in TX-IN
-                                                [ --spending-tx-in-reference TX-IN
+                                              (--tx-in TX_IN
+                                                [ --spending-tx-in-reference TX_IN
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
@@ -5070,7 +5070,7 @@ Usage: cardano-cli latest transaction build
                                                   | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                   | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
-                                                | --simple-script-tx-in-reference TX-IN
+                                                | --simple-script-tx-in-reference TX_IN
                                                 | --tx-in-script-file FILEPATH
                                                   [
                                                     [ --tx-in-datum-cbor-file CBOR_FILE
@@ -5083,11 +5083,11 @@ Usage: cardano-cli latest transaction build
                                                     | --tx-in-redeemer-value JSON_VALUE
                                                     )]
                                                 ])
-                                              [--read-only-tx-in-reference TX-IN]
+                                              [--read-only-tx-in-reference TX_IN]
                                               [ --required-signer FILEPATH
                                               | --required-signer-hash HASH
                                               ]
-                                              [--tx-in-collateral TX-IN]
+                                              [--tx-in-collateral TX_IN]
                                               [--tx-out-return-collateral ADDRESS VALUE]
                                               [--tx-total-collateral INTEGER]
                                               [--tx-out ADDRESS VALUE
@@ -5110,9 +5110,9 @@ Usage: cardano-cli latest transaction build
                                                   | --mint-redeemer-file JSON_FILE
                                                   | --mint-redeemer-value JSON_VALUE
                                                   ]
-                                                | --simple-minting-script-tx-in-reference TX-IN
+                                                | --simple-minting-script-tx-in-reference TX_IN
                                                   --policy-id HASH
-                                                | --mint-tx-in-reference TX-IN
+                                                | --mint-tx-in-reference TX_IN
                                                   ( --mint-plutus-script-v2
                                                   | --mint-plutus-script-v3
                                                   )
@@ -5130,7 +5130,7 @@ Usage: cardano-cli latest transaction build
                                                   | --certificate-redeemer-file JSON_FILE
                                                   | --certificate-redeemer-value JSON_VALUE
                                                   ]
-                                                | --certificate-tx-in-reference TX-IN
+                                                | --certificate-tx-in-reference TX_IN
                                                   ( --certificate-plutus-script-v2
                                                   | --certificate-plutus-script-v3
                                                   )
@@ -5145,7 +5145,7 @@ Usage: cardano-cli latest transaction build
                                                   | --withdrawal-redeemer-file JSON_FILE
                                                   | --withdrawal-redeemer-value JSON_VALUE
                                                   ]
-                                                | --withdrawal-tx-in-reference TX-IN
+                                                | --withdrawal-tx-in-reference TX_IN
                                                   ( --withdrawal-plutus-script-v2
                                                   | --withdrawal-plutus-script-v3
                                                   )
@@ -5167,7 +5167,7 @@ Usage: cardano-cli latest transaction build
                                                   | --vote-redeemer-file JSON_FILE
                                                   | --vote-redeemer-value JSON_VALUE
                                                   ]
-                                                | --vote-tx-in-reference TX-IN
+                                                | --vote-tx-in-reference TX_IN
                                                   --vote-plutus-script-v3
                                                   ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                   | --vote-reference-tx-in-redeemer-file JSON_FILE
@@ -5180,7 +5180,7 @@ Usage: cardano-cli latest transaction build
                                                   | --proposal-redeemer-file JSON_FILE
                                                   | --proposal-redeemer-value JSON_VALUE
                                                   ]
-                                                | --proposal-tx-in-reference TX-IN
+                                                | --proposal-tx-in-reference TX_IN
                                                   --proposal-plutus-script-v3
                                                   ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                   | --proposal-reference-tx-in-redeemer-file JSON_FILE
@@ -5205,8 +5205,8 @@ Usage: cardano-cli latest transaction build-estimate
                                                        [--byron-key-witnesses Int]
                                                        --protocol-params-file FILEPATH
                                                        --total-utxo-value VALUE
-                                                       (--tx-in TX-IN
-                                                         [ --spending-tx-in-reference TX-IN
+                                                       (--tx-in TX_IN
+                                                         [ --spending-tx-in-reference TX_IN
                                                            ( --spending-plutus-script-v2
                                                            | --spending-plutus-script-v3
                                                            )
@@ -5220,7 +5220,7 @@ Usage: cardano-cli latest transaction build-estimate
                                                            | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --spending-reference-tx-in-execution-units (INT, INT)
-                                                         | --simple-script-tx-in-reference TX-IN
+                                                         | --simple-script-tx-in-reference TX_IN
                                                          | --tx-in-script-file FILEPATH
                                                            [
                                                              [ --tx-in-datum-cbor-file CBOR_FILE
@@ -5234,11 +5234,11 @@ Usage: cardano-cli latest transaction build-estimate
                                                              )
                                                              --tx-in-execution-units (INT, INT)]
                                                          ])
-                                                       [--read-only-tx-in-reference TX-IN]
+                                                       [--read-only-tx-in-reference TX_IN]
                                                        [ --required-signer FILEPATH
                                                        | --required-signer-hash HASH
                                                        ]
-                                                       [--tx-in-collateral TX-IN]
+                                                       [--tx-in-collateral TX_IN]
                                                        [--tx-out-return-collateral ADDRESS VALUE]
                                                        [--tx-out ADDRESS VALUE
                                                          [ --tx-out-datum-hash HASH
@@ -5262,9 +5262,9 @@ Usage: cardano-cli latest transaction build-estimate
                                                              | --mint-redeemer-value JSON_VALUE
                                                              )
                                                              --mint-execution-units (INT, INT)]
-                                                         | --simple-minting-script-tx-in-reference TX-IN
+                                                         | --simple-minting-script-tx-in-reference TX_IN
                                                            --policy-id HASH
-                                                         | --mint-tx-in-reference TX-IN
+                                                         | --mint-tx-in-reference TX_IN
                                                            ( --mint-plutus-script-v2
                                                            | --mint-plutus-script-v3
                                                            )
@@ -5286,7 +5286,7 @@ Usage: cardano-cli latest transaction build-estimate
                                                              | --certificate-redeemer-value JSON_VALUE
                                                              )
                                                              --certificate-execution-units (INT, INT)]
-                                                         | --certificate-tx-in-reference TX-IN
+                                                         | --certificate-tx-in-reference TX_IN
                                                            ( --certificate-plutus-script-v2
                                                            | --certificate-plutus-script-v3
                                                            )
@@ -5304,7 +5304,7 @@ Usage: cardano-cli latest transaction build-estimate
                                                              | --withdrawal-redeemer-value JSON_VALUE
                                                              )
                                                              --withdrawal-execution-units (INT, INT)]
-                                                         | --withdrawal-tx-in-reference TX-IN
+                                                         | --withdrawal-tx-in-reference TX_IN
                                                            ( --withdrawal-plutus-script-v2
                                                            | --withdrawal-plutus-script-v3
                                                            )
@@ -5331,7 +5331,7 @@ Usage: cardano-cli latest transaction build-estimate
                                                              | --vote-redeemer-value JSON_VALUE
                                                              )
                                                              --vote-execution-units (INT, INT)]
-                                                         | --vote-tx-in-reference TX-IN
+                                                         | --vote-tx-in-reference TX_IN
                                                            --vote-plutus-script-v3
                                                            ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                            | --vote-reference-tx-in-redeemer-file JSON_FILE
@@ -5347,7 +5347,7 @@ Usage: cardano-cli latest transaction build-estimate
                                                              | --proposal-redeemer-value JSON_VALUE
                                                              )
                                                              --proposal-execution-units (INT, INT)]
-                                                         | --proposal-tx-in-reference TX-IN
+                                                         | --proposal-tx-in-reference TX_IN
                                                            --proposal-plutus-script-v3
                                                            ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                            | --proposal-reference-tx-in-redeemer-file JSON_FILE
@@ -5694,7 +5694,7 @@ Usage: cardano-cli compatible shelley transaction signed-transaction
   Transaction commands.
 
 Usage: cardano-cli compatible shelley transaction signed-transaction 
-                                                                       [--tx-in TX-IN]
+                                                                       [--tx-in TX_IN]
                                                                        [--tx-out ADDRESS VALUE]
                                                                        [--update-proposal-file FILEPATH]
                                                                        [--signing-key-file FILEPATH
@@ -5712,7 +5712,7 @@ Usage: cardano-cli compatible shelley transaction signed-transaction
                                                                              | --certificate-redeemer-value JSON_VALUE
                                                                              )
                                                                              --certificate-execution-units (INT, INT)]
-                                                                         | --certificate-tx-in-reference TX-IN
+                                                                         | --certificate-tx-in-reference TX_IN
                                                                            ( --certificate-plutus-script-v2
                                                                            | --certificate-plutus-script-v3
                                                                            )
@@ -5905,7 +5905,7 @@ Usage: cardano-cli compatible allegra transaction signed-transaction
   Transaction commands.
 
 Usage: cardano-cli compatible allegra transaction signed-transaction 
-                                                                       [--tx-in TX-IN]
+                                                                       [--tx-in TX_IN]
                                                                        [--tx-out ADDRESS VALUE]
                                                                        [--update-proposal-file FILEPATH]
                                                                        [--signing-key-file FILEPATH
@@ -5923,7 +5923,7 @@ Usage: cardano-cli compatible allegra transaction signed-transaction
                                                                              | --certificate-redeemer-value JSON_VALUE
                                                                              )
                                                                              --certificate-execution-units (INT, INT)]
-                                                                         | --certificate-tx-in-reference TX-IN
+                                                                         | --certificate-tx-in-reference TX_IN
                                                                            ( --certificate-plutus-script-v2
                                                                            | --certificate-plutus-script-v3
                                                                            )
@@ -6116,7 +6116,7 @@ Usage: cardano-cli compatible mary transaction signed-transaction
   Transaction commands.
 
 Usage: cardano-cli compatible mary transaction signed-transaction 
-                                                                    [--tx-in TX-IN]
+                                                                    [--tx-in TX_IN]
                                                                     [--tx-out ADDRESS VALUE]
                                                                     [--update-proposal-file FILEPATH]
                                                                     [--signing-key-file FILEPATH
@@ -6134,7 +6134,7 @@ Usage: cardano-cli compatible mary transaction signed-transaction
                                                                           | --certificate-redeemer-value JSON_VALUE
                                                                           )
                                                                           --certificate-execution-units (INT, INT)]
-                                                                      | --certificate-tx-in-reference TX-IN
+                                                                      | --certificate-tx-in-reference TX_IN
                                                                         ( --certificate-plutus-script-v2
                                                                         | --certificate-plutus-script-v3
                                                                         )
@@ -6327,7 +6327,7 @@ Usage: cardano-cli compatible alonzo transaction signed-transaction
   Transaction commands.
 
 Usage: cardano-cli compatible alonzo transaction signed-transaction 
-                                                                      [--tx-in TX-IN]
+                                                                      [--tx-in TX_IN]
                                                                       [--tx-out ADDRESS VALUE
                                                                         [ --tx-out-datum-hash HASH
                                                                         | --tx-out-datum-hash-cbor-file CBOR_FILE
@@ -6353,7 +6353,7 @@ Usage: cardano-cli compatible alonzo transaction signed-transaction
                                                                             | --certificate-redeemer-value JSON_VALUE
                                                                             )
                                                                             --certificate-execution-units (INT, INT)]
-                                                                        | --certificate-tx-in-reference TX-IN
+                                                                        | --certificate-tx-in-reference TX_IN
                                                                           ( --certificate-plutus-script-v2
                                                                           | --certificate-plutus-script-v3
                                                                           )
@@ -6553,7 +6553,7 @@ Usage: cardano-cli compatible babbage transaction signed-transaction
   Transaction commands.
 
 Usage: cardano-cli compatible babbage transaction signed-transaction 
-                                                                       [--tx-in TX-IN]
+                                                                       [--tx-in TX_IN]
                                                                        [--tx-out ADDRESS VALUE
                                                                          [ --tx-out-datum-hash HASH
                                                                          | --tx-out-datum-hash-cbor-file CBOR_FILE
@@ -6582,7 +6582,7 @@ Usage: cardano-cli compatible babbage transaction signed-transaction
                                                                              | --certificate-redeemer-value JSON_VALUE
                                                                              )
                                                                              --certificate-execution-units (INT, INT)]
-                                                                         | --certificate-tx-in-reference TX-IN
+                                                                         | --certificate-tx-in-reference TX_IN
                                                                            ( --certificate-plutus-script-v2
                                                                            | --certificate-plutus-script-v3
                                                                            )
@@ -6801,7 +6801,7 @@ Usage: cardano-cli compatible conway transaction signed-transaction
   Transaction commands.
 
 Usage: cardano-cli compatible conway transaction signed-transaction 
-                                                                      [--tx-in TX-IN]
+                                                                      [--tx-in TX_IN]
                                                                       [--tx-out ADDRESS VALUE
                                                                         [ --tx-out-datum-hash HASH
                                                                         | --tx-out-datum-hash-cbor-file CBOR_FILE
@@ -6823,7 +6823,7 @@ Usage: cardano-cli compatible conway transaction signed-transaction
                                                                             | --proposal-redeemer-value JSON_VALUE
                                                                             )
                                                                             --proposal-execution-units (INT, INT)]
-                                                                        | --proposal-tx-in-reference TX-IN
+                                                                        | --proposal-tx-in-reference TX_IN
                                                                           --proposal-plutus-script-v3
                                                                           ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                                           | --proposal-reference-tx-in-redeemer-file JSON_FILE
@@ -6839,7 +6839,7 @@ Usage: cardano-cli compatible conway transaction signed-transaction
                                                                             | --vote-redeemer-value JSON_VALUE
                                                                             )
                                                                             --vote-execution-units (INT, INT)]
-                                                                        | --vote-tx-in-reference TX-IN
+                                                                        | --vote-tx-in-reference TX_IN
                                                                           --vote-plutus-script-v3
                                                                           ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                                           | --vote-reference-tx-in-redeemer-file JSON_FILE
@@ -6862,7 +6862,7 @@ Usage: cardano-cli compatible conway transaction signed-transaction
                                                                             | --certificate-redeemer-value JSON_VALUE
                                                                             )
                                                                             --certificate-execution-units (INT, INT)]
-                                                                        | --certificate-tx-in-reference TX-IN
+                                                                        | --certificate-tx-in-reference TX_IN
                                                                           ( --certificate-plutus-script-v2
                                                                           | --certificate-plutus-script-v3
                                                                           )

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_transaction_signed-transaction.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli compatible allegra transaction signed-transaction 
-                                                                       [--tx-in TX-IN]
+                                                                       [--tx-in TX_IN]
                                                                        [--tx-out ADDRESS VALUE]
                                                                        [--update-proposal-file FILEPATH]
                                                                        [--signing-key-file FILEPATH
@@ -17,7 +17,7 @@ Usage: cardano-cli compatible allegra transaction signed-transaction
                                                                              | --certificate-redeemer-value JSON_VALUE
                                                                              )
                                                                              --certificate-execution-units (INT, INT)]
-                                                                         | --certificate-tx-in-reference TX-IN
+                                                                         | --certificate-tx-in-reference TX_IN
                                                                            ( --certificate-plutus-script-v2
                                                                            | --certificate-plutus-script-v3
                                                                            )
@@ -32,7 +32,7 @@ Usage: cardano-cli compatible allegra transaction signed-transaction
   Create a simple signed transaction.
 
 Available options:
-  --tx-in TX-IN            TxId#TxIx
+  --tx-in TX_IN            TxId#TxIx
   --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
                            is the Bech32-encoded address followed by the value
                            in the multi-asset syntax (including simply
@@ -67,7 +67,7 @@ Available options:
                            top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --certificate-tx-in-reference TX-IN
+  --certificate-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --certificate-plutus-script-v2

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_transaction_signed-transaction.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli compatible alonzo transaction signed-transaction 
-                                                                      [--tx-in TX-IN]
+                                                                      [--tx-in TX_IN]
                                                                       [--tx-out ADDRESS VALUE
                                                                         [ --tx-out-datum-hash HASH
                                                                         | --tx-out-datum-hash-cbor-file CBOR_FILE
@@ -25,7 +25,7 @@ Usage: cardano-cli compatible alonzo transaction signed-transaction
                                                                             | --certificate-redeemer-value JSON_VALUE
                                                                             )
                                                                             --certificate-execution-units (INT, INT)]
-                                                                        | --certificate-tx-in-reference TX-IN
+                                                                        | --certificate-tx-in-reference TX_IN
                                                                           ( --certificate-plutus-script-v2
                                                                           | --certificate-plutus-script-v3
                                                                           )
@@ -40,7 +40,7 @@ Usage: cardano-cli compatible alonzo transaction signed-transaction
   Create a simple signed transaction.
 
 Available options:
-  --tx-in TX-IN            TxId#TxIx
+  --tx-in TX_IN            TxId#TxIx
   --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
                            is the Bech32-encoded address followed by the value
                            in the multi-asset syntax (including simply
@@ -102,7 +102,7 @@ Available options:
                            top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --certificate-tx-in-reference TX-IN
+  --certificate-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --certificate-plutus-script-v2

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_transaction_signed-transaction.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli compatible babbage transaction signed-transaction 
-                                                                       [--tx-in TX-IN]
+                                                                       [--tx-in TX_IN]
                                                                        [--tx-out ADDRESS VALUE
                                                                          [ --tx-out-datum-hash HASH
                                                                          | --tx-out-datum-hash-cbor-file CBOR_FILE
@@ -28,7 +28,7 @@ Usage: cardano-cli compatible babbage transaction signed-transaction
                                                                              | --certificate-redeemer-value JSON_VALUE
                                                                              )
                                                                              --certificate-execution-units (INT, INT)]
-                                                                         | --certificate-tx-in-reference TX-IN
+                                                                         | --certificate-tx-in-reference TX_IN
                                                                            ( --certificate-plutus-script-v2
                                                                            | --certificate-plutus-script-v3
                                                                            )
@@ -43,7 +43,7 @@ Usage: cardano-cli compatible babbage transaction signed-transaction
   Create a simple signed transaction.
 
 Available options:
-  --tx-in TX-IN            TxId#TxIx
+  --tx-in TX_IN            TxId#TxIx
   --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
                            is the Bech32-encoded address followed by the value
                            in the multi-asset syntax (including simply
@@ -118,7 +118,7 @@ Available options:
                            top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --certificate-tx-in-reference TX-IN
+  --certificate-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --certificate-plutus-script-v2

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_transaction_signed-transaction.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli compatible conway transaction signed-transaction 
-                                                                      [--tx-in TX-IN]
+                                                                      [--tx-in TX_IN]
                                                                       [--tx-out ADDRESS VALUE
                                                                         [ --tx-out-datum-hash HASH
                                                                         | --tx-out-datum-hash-cbor-file CBOR_FILE
@@ -21,7 +21,7 @@ Usage: cardano-cli compatible conway transaction signed-transaction
                                                                             | --proposal-redeemer-value JSON_VALUE
                                                                             )
                                                                             --proposal-execution-units (INT, INT)]
-                                                                        | --proposal-tx-in-reference TX-IN
+                                                                        | --proposal-tx-in-reference TX_IN
                                                                           --proposal-plutus-script-v3
                                                                           ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                                           | --proposal-reference-tx-in-redeemer-file JSON_FILE
@@ -37,7 +37,7 @@ Usage: cardano-cli compatible conway transaction signed-transaction
                                                                             | --vote-redeemer-value JSON_VALUE
                                                                             )
                                                                             --vote-execution-units (INT, INT)]
-                                                                        | --vote-tx-in-reference TX-IN
+                                                                        | --vote-tx-in-reference TX_IN
                                                                           --vote-plutus-script-v3
                                                                           ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                                           | --vote-reference-tx-in-redeemer-file JSON_FILE
@@ -60,7 +60,7 @@ Usage: cardano-cli compatible conway transaction signed-transaction
                                                                             | --certificate-redeemer-value JSON_VALUE
                                                                             )
                                                                             --certificate-execution-units (INT, INT)]
-                                                                        | --certificate-tx-in-reference TX-IN
+                                                                        | --certificate-tx-in-reference TX_IN
                                                                           ( --certificate-plutus-script-v2
                                                                           | --certificate-plutus-script-v3
                                                                           )
@@ -75,7 +75,7 @@ Usage: cardano-cli compatible conway transaction signed-transaction
   Create a simple signed transaction.
 
 Available options:
-  --tx-in TX-IN            TxId#TxIx
+  --tx-in TX_IN            TxId#TxIx
   --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
                            is the Bech32-encoded address followed by the value
                            in the multi-asset syntax (including simply
@@ -137,7 +137,7 @@ Available options:
                            top-level strings and numbers.
   --proposal-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --proposal-tx-in-reference TX-IN
+  --proposal-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --proposal-plutus-script-v3
@@ -169,7 +169,7 @@ Available options:
                            top-level strings and numbers.
   --vote-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --vote-tx-in-reference TX-IN
+  --vote-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --vote-plutus-script-v3  Specify a plutus script v3 reference script.
@@ -213,7 +213,7 @@ Available options:
                            top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --certificate-tx-in-reference TX-IN
+  --certificate-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --certificate-plutus-script-v2

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_transaction_signed-transaction.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli compatible mary transaction signed-transaction 
-                                                                    [--tx-in TX-IN]
+                                                                    [--tx-in TX_IN]
                                                                     [--tx-out ADDRESS VALUE]
                                                                     [--update-proposal-file FILEPATH]
                                                                     [--signing-key-file FILEPATH
@@ -17,7 +17,7 @@ Usage: cardano-cli compatible mary transaction signed-transaction
                                                                           | --certificate-redeemer-value JSON_VALUE
                                                                           )
                                                                           --certificate-execution-units (INT, INT)]
-                                                                      | --certificate-tx-in-reference TX-IN
+                                                                      | --certificate-tx-in-reference TX_IN
                                                                         ( --certificate-plutus-script-v2
                                                                         | --certificate-plutus-script-v3
                                                                         )
@@ -32,7 +32,7 @@ Usage: cardano-cli compatible mary transaction signed-transaction
   Create a simple signed transaction.
 
 Available options:
-  --tx-in TX-IN            TxId#TxIx
+  --tx-in TX_IN            TxId#TxIx
   --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
                            is the Bech32-encoded address followed by the value
                            in the multi-asset syntax (including simply
@@ -67,7 +67,7 @@ Available options:
                            top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --certificate-tx-in-reference TX-IN
+  --certificate-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --certificate-plutus-script-v2

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_transaction_signed-transaction.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli compatible shelley transaction signed-transaction 
-                                                                       [--tx-in TX-IN]
+                                                                       [--tx-in TX_IN]
                                                                        [--tx-out ADDRESS VALUE]
                                                                        [--update-proposal-file FILEPATH]
                                                                        [--signing-key-file FILEPATH
@@ -17,7 +17,7 @@ Usage: cardano-cli compatible shelley transaction signed-transaction
                                                                              | --certificate-redeemer-value JSON_VALUE
                                                                              )
                                                                              --certificate-execution-units (INT, INT)]
-                                                                         | --certificate-tx-in-reference TX-IN
+                                                                         | --certificate-tx-in-reference TX_IN
                                                                            ( --certificate-plutus-script-v2
                                                                            | --certificate-plutus-script-v3
                                                                            )
@@ -32,7 +32,7 @@ Usage: cardano-cli compatible shelley transaction signed-transaction
   Create a simple signed transaction.
 
 Available options:
-  --tx-in TX-IN            TxId#TxIx
+  --tx-in TX_IN            TxId#TxIx
   --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
                            is the Bech32-encoded address followed by the value
                            in the multi-asset syntax (including simply
@@ -67,7 +67,7 @@ Available options:
                            top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --certificate-tx-in-reference TX-IN
+  --certificate-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --certificate-plutus-script-v2

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-cardano.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-cardano.cli
@@ -1,7 +1,7 @@
 Usage: cardano-cli conway genesis create-cardano --genesis-dir DIR
                                                    [--gen-genesis-keys INT]
                                                    [--gen-utxo-keys INT]
-                                                   [--start-time UTC-TIME]
+                                                   [--start-time UTC_TIME]
                                                    [--supply LOVELACE]
                                                    [--security-param NON_ZERO_WORD64]
                                                    [--slot-length INT]
@@ -23,7 +23,7 @@ Available options:
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
   --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
-  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.
   --supply LOVELACE        The initial coin supply in Lovelace which will be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-staked.cli
@@ -8,7 +8,7 @@ Usage: cardano-cli conway genesis create-staked
                                                   [--gen-utxo-keys INT]
                                                   [--gen-pools INT]
                                                   [--gen-stake-delegs INT]
-                                                  [--start-time UTC-TIME]
+                                                  [--start-time UTC_TIME]
                                                   [--supply LOVELACE]
                                                   [--supply-delegated LOVELACE]
                                                   ( --mainnet
@@ -39,7 +39,7 @@ Available options:
                            [default is 0].
   --gen-stake-delegs INT   The number of stake delegator credential sets to make
                            [default is 0].
-  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.
   --supply LOVELACE        The initial coin supply in Lovelace which will be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-testnet-data.cli
@@ -16,7 +16,7 @@ Usage: cardano-cli conway genesis create-testnet-data [--spec-shelley FILEPATH]
                                                         [--delegated-supply LOVELACE]
                                                         [--testnet-magic NATURAL]
                                                         [--relays FILEPATH]
-                                                        [--start-time UTC-TIME]
+                                                        [--start-time UTC_TIME]
                                                         --out-dir DIR
 
   Create data to use for starting a testnet.
@@ -61,7 +61,7 @@ Available options:
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.
   --relays FILEPATH        JSON file specifying the relays of each stake pool.
-  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.
   --out-dir DIR            The directory where to generate the data. Created if

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create.cli
@@ -6,7 +6,7 @@ Usage: cardano-cli conway genesis create
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]
-                                           [--start-time UTC-TIME]
+                                           [--start-time UTC_TIME]
                                            [--supply LOVELACE]
                                            (--mainnet | --testnet-magic NATURAL)
 
@@ -26,7 +26,7 @@ Available options:
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
   --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
-  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.
   --supply LOVELACE        The initial coin supply in Lovelace which will be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ref-script-size.cli
@@ -8,7 +8,7 @@ Usage: cardano-cli conway query ref-script-size
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
-                                                  (--tx-in TX-IN)
+                                                  (--tx-in TX_IN)
                                                   [ --output-json
                                                   | --output-text
                                                   ]
@@ -34,7 +34,7 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
-  --tx-in TX-IN            Transaction input (TxId#TxIx).
+  --tx-in TX_IN            Transaction input (TxId#TxIx).
   --output-json            Format reference inputs query output to JSON
                            (default).
   --output-text            Format reference inputs query output to TEXT.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
@@ -4,7 +4,7 @@ Usage: cardano-cli conway query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        [--volatile-tip | --immutable-tip]
                                        ( --whole-utxo
                                        | (--address ADDRESS)
-                                       | (--tx-in TX-IN)
+                                       | (--tx-in TX_IN)
                                        )
                                        [ --output-cbor
                                        | --output-json
@@ -34,7 +34,7 @@ Available options:
   --whole-utxo             Return the whole UTxO (only appropriate on small
                            testnets).
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
-  --tx-in TX-IN            Filter by transaction input (TxId#TxIx).
+  --tx-in TX_IN            Filter by transaction input (TxId#TxIx).
   --output-cbor            Format utxo query output to BASE16 CBOR.
   --output-json            Format utxo query output to JSON (default).
   --output-text            Format utxo query output to TEXT.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-estimate.cli
@@ -6,8 +6,8 @@ Usage: cardano-cli conway transaction build-estimate
                                                        [--byron-key-witnesses Int]
                                                        --protocol-params-file FILEPATH
                                                        --total-utxo-value VALUE
-                                                       (--tx-in TX-IN
-                                                         [ --spending-tx-in-reference TX-IN
+                                                       (--tx-in TX_IN
+                                                         [ --spending-tx-in-reference TX_IN
                                                            ( --spending-plutus-script-v2
                                                            | --spending-plutus-script-v3
                                                            )
@@ -21,7 +21,7 @@ Usage: cardano-cli conway transaction build-estimate
                                                            | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --spending-reference-tx-in-execution-units (INT, INT)
-                                                         | --simple-script-tx-in-reference TX-IN
+                                                         | --simple-script-tx-in-reference TX_IN
                                                          | --tx-in-script-file FILEPATH
                                                            [
                                                              [ --tx-in-datum-cbor-file CBOR_FILE
@@ -35,11 +35,11 @@ Usage: cardano-cli conway transaction build-estimate
                                                              )
                                                              --tx-in-execution-units (INT, INT)]
                                                          ])
-                                                       [--read-only-tx-in-reference TX-IN]
+                                                       [--read-only-tx-in-reference TX_IN]
                                                        [ --required-signer FILEPATH
                                                        | --required-signer-hash HASH
                                                        ]
-                                                       [--tx-in-collateral TX-IN]
+                                                       [--tx-in-collateral TX_IN]
                                                        [--tx-out-return-collateral ADDRESS VALUE]
                                                        [--tx-out ADDRESS VALUE
                                                          [ --tx-out-datum-hash HASH
@@ -63,9 +63,9 @@ Usage: cardano-cli conway transaction build-estimate
                                                              | --mint-redeemer-value JSON_VALUE
                                                              )
                                                              --mint-execution-units (INT, INT)]
-                                                         | --simple-minting-script-tx-in-reference TX-IN
+                                                         | --simple-minting-script-tx-in-reference TX_IN
                                                            --policy-id HASH
-                                                         | --mint-tx-in-reference TX-IN
+                                                         | --mint-tx-in-reference TX_IN
                                                            ( --mint-plutus-script-v2
                                                            | --mint-plutus-script-v3
                                                            )
@@ -87,7 +87,7 @@ Usage: cardano-cli conway transaction build-estimate
                                                              | --certificate-redeemer-value JSON_VALUE
                                                              )
                                                              --certificate-execution-units (INT, INT)]
-                                                         | --certificate-tx-in-reference TX-IN
+                                                         | --certificate-tx-in-reference TX_IN
                                                            ( --certificate-plutus-script-v2
                                                            | --certificate-plutus-script-v3
                                                            )
@@ -105,7 +105,7 @@ Usage: cardano-cli conway transaction build-estimate
                                                              | --withdrawal-redeemer-value JSON_VALUE
                                                              )
                                                              --withdrawal-execution-units (INT, INT)]
-                                                         | --withdrawal-tx-in-reference TX-IN
+                                                         | --withdrawal-tx-in-reference TX_IN
                                                            ( --withdrawal-plutus-script-v2
                                                            | --withdrawal-plutus-script-v3
                                                            )
@@ -132,7 +132,7 @@ Usage: cardano-cli conway transaction build-estimate
                                                              | --vote-redeemer-value JSON_VALUE
                                                              )
                                                              --vote-execution-units (INT, INT)]
-                                                         | --vote-tx-in-reference TX-IN
+                                                         | --vote-tx-in-reference TX_IN
                                                            --vote-plutus-script-v3
                                                            ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                            | --vote-reference-tx-in-redeemer-file JSON_FILE
@@ -148,7 +148,7 @@ Usage: cardano-cli conway transaction build-estimate
                                                              | --proposal-redeemer-value JSON_VALUE
                                                              )
                                                              --proposal-execution-units (INT, INT)]
-                                                         | --proposal-tx-in-reference TX-IN
+                                                         | --proposal-tx-in-reference TX_IN
                                                            --proposal-plutus-script-v3
                                                            ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                            | --proposal-reference-tx-in-redeemer-file JSON_FILE
@@ -180,8 +180,8 @@ Available options:
                            Filepath of the JSON-encoded protocol parameters file
   --total-utxo-value VALUE The total value of the UTxO that exists at the tx
                            inputs being spent.
-  --tx-in TX-IN            TxId#TxIx
-  --spending-tx-in-reference TX-IN
+  --tx-in TX_IN            TxId#TxIx
+  --spending-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --spending-plutus-script-v2
@@ -212,7 +212,7 @@ Available options:
                            top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --simple-script-tx-in-reference TX-IN
+  --simple-script-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --tx-in-script-file FILEPATH
@@ -242,7 +242,7 @@ Available options:
                            top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --read-only-tx-in-reference TX-IN
+  --read-only-tx-in-reference TX_IN
                            Specify a read only reference input. This reference
                            input is not witnessing anything it is simply
                            provided in the plutus script context.
@@ -252,7 +252,7 @@ Available options:
   --required-signer-hash HASH
                            Hash of the verification key (zero or more) whose
                            signature is required.
-  --tx-in-collateral TX-IN TxId#TxIx
+  --tx-in-collateral TX_IN TxId#TxIx
   --tx-out-return-collateral ADDRESS VALUE
                            The transaction output as ADDRESS VALUE where ADDRESS
                            is the Bech32-encoded address followed by the value
@@ -324,11 +324,11 @@ Available options:
                            top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --simple-minting-script-tx-in-reference TX-IN
+  --simple-minting-script-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --policy-id HASH         Policy id of minting script.
-  --mint-tx-in-reference TX-IN
+  --mint-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
@@ -368,7 +368,7 @@ Available options:
                            top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --certificate-tx-in-reference TX-IN
+  --certificate-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --certificate-plutus-script-v2
@@ -406,7 +406,7 @@ Available options:
                            top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --withdrawal-tx-in-reference TX-IN
+  --withdrawal-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --withdrawal-plutus-script-v2
@@ -460,7 +460,7 @@ Available options:
                            top-level strings and numbers.
   --vote-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --vote-tx-in-reference TX-IN
+  --vote-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --vote-plutus-script-v3  Specify a plutus script v3 reference script.
@@ -491,7 +491,7 @@ Available options:
                            top-level strings and numbers.
   --proposal-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --proposal-tx-in-reference TX-IN
+  --proposal-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --proposal-plutus-script-v3

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
@@ -2,8 +2,8 @@ Usage: cardano-cli conway transaction build-raw
                                                   [ --script-valid
                                                   | --script-invalid
                                                   ]
-                                                  (--tx-in TX-IN
-                                                    [ --spending-tx-in-reference TX-IN
+                                                  (--tx-in TX_IN
+                                                    [ --spending-tx-in-reference TX_IN
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
@@ -17,7 +17,7 @@ Usage: cardano-cli conway transaction build-raw
                                                       | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --spending-reference-tx-in-execution-units (INT, INT)
-                                                    | --simple-script-tx-in-reference TX-IN
+                                                    | --simple-script-tx-in-reference TX_IN
                                                     | --tx-in-script-file FILEPATH
                                                       [
                                                         [ --tx-in-datum-cbor-file CBOR_FILE
@@ -31,8 +31,8 @@ Usage: cardano-cli conway transaction build-raw
                                                         )
                                                         --tx-in-execution-units (INT, INT)]
                                                     ])
-                                                  [--read-only-tx-in-reference TX-IN]
-                                                  [--tx-in-collateral TX-IN]
+                                                  [--read-only-tx-in-reference TX_IN]
+                                                  [--tx-in-collateral TX_IN]
                                                   [--tx-out-return-collateral ADDRESS VALUE]
                                                   [--tx-total-collateral INTEGER]
                                                   [ --required-signer FILEPATH
@@ -59,9 +59,9 @@ Usage: cardano-cli conway transaction build-raw
                                                         | --mint-redeemer-value JSON_VALUE
                                                         )
                                                         --mint-execution-units (INT, INT)]
-                                                    | --simple-minting-script-tx-in-reference TX-IN
+                                                    | --simple-minting-script-tx-in-reference TX_IN
                                                       --policy-id HASH
-                                                    | --mint-tx-in-reference TX-IN
+                                                    | --mint-tx-in-reference TX_IN
                                                       ( --mint-plutus-script-v2
                                                       | --mint-plutus-script-v3
                                                       )
@@ -83,7 +83,7 @@ Usage: cardano-cli conway transaction build-raw
                                                         | --certificate-redeemer-value JSON_VALUE
                                                         )
                                                         --certificate-execution-units (INT, INT)]
-                                                    | --certificate-tx-in-reference TX-IN
+                                                    | --certificate-tx-in-reference TX_IN
                                                       ( --certificate-plutus-script-v2
                                                       | --certificate-plutus-script-v3
                                                       )
@@ -101,7 +101,7 @@ Usage: cardano-cli conway transaction build-raw
                                                         | --withdrawal-redeemer-value JSON_VALUE
                                                         )
                                                         --withdrawal-execution-units (INT, INT)]
-                                                    | --withdrawal-tx-in-reference TX-IN
+                                                    | --withdrawal-tx-in-reference TX_IN
                                                       ( --withdrawal-plutus-script-v2
                                                       | --withdrawal-plutus-script-v3
                                                       )
@@ -127,7 +127,7 @@ Usage: cardano-cli conway transaction build-raw
                                                         | --vote-redeemer-value JSON_VALUE
                                                         )
                                                         --vote-execution-units (INT, INT)]
-                                                    | --vote-tx-in-reference TX-IN
+                                                    | --vote-tx-in-reference TX_IN
                                                       --vote-plutus-script-v3
                                                       ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                       | --vote-reference-tx-in-redeemer-file JSON_FILE
@@ -143,7 +143,7 @@ Usage: cardano-cli conway transaction build-raw
                                                         | --proposal-redeemer-value JSON_VALUE
                                                         )
                                                         --proposal-execution-units (INT, INT)]
-                                                    | --proposal-tx-in-reference TX-IN
+                                                    | --proposal-tx-in-reference TX_IN
                                                       --proposal-plutus-script-v3
                                                       ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                       | --proposal-reference-tx-in-redeemer-file JSON_FILE
@@ -165,8 +165,8 @@ Available options:
   --script-invalid         Assertion that the script is invalid. If a
                            transaction is submitted with such a script, the
                            script will fail and the collateral will be taken.
-  --tx-in TX-IN            TxId#TxIx
-  --spending-tx-in-reference TX-IN
+  --tx-in TX_IN            TxId#TxIx
+  --spending-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --spending-plutus-script-v2
@@ -197,7 +197,7 @@ Available options:
                            top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --simple-script-tx-in-reference TX-IN
+  --simple-script-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --tx-in-script-file FILEPATH
@@ -227,11 +227,11 @@ Available options:
                            top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --read-only-tx-in-reference TX-IN
+  --read-only-tx-in-reference TX_IN
                            Specify a read only reference input. This reference
                            input is not witnessing anything it is simply
                            provided in the plutus script context.
-  --tx-in-collateral TX-IN TxId#TxIx
+  --tx-in-collateral TX_IN TxId#TxIx
   --tx-out-return-collateral ADDRESS VALUE
                            The transaction output as ADDRESS VALUE where ADDRESS
                            is the Bech32-encoded address followed by the value
@@ -313,11 +313,11 @@ Available options:
                            top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --simple-minting-script-tx-in-reference TX-IN
+  --simple-minting-script-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --policy-id HASH         Policy id of minting script.
-  --mint-tx-in-reference TX-IN
+  --mint-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
@@ -358,7 +358,7 @@ Available options:
                            top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --certificate-tx-in-reference TX-IN
+  --certificate-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --certificate-plutus-script-v2
@@ -396,7 +396,7 @@ Available options:
                            top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --withdrawal-tx-in-reference TX-IN
+  --withdrawal-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --withdrawal-plutus-script-v2
@@ -444,7 +444,7 @@ Available options:
                            top-level strings and numbers.
   --vote-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --vote-tx-in-reference TX-IN
+  --vote-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --vote-plutus-script-v3  Specify a plutus script v3 reference script.
@@ -475,7 +475,7 @@ Available options:
                            top-level strings and numbers.
   --proposal-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --proposal-tx-in-reference TX-IN
+  --proposal-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --proposal-plutus-script-v3

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
@@ -9,8 +9,8 @@ Usage: cardano-cli conway transaction build
                                               | --script-invalid
                                               ]
                                               [--witness-override WORD]
-                                              (--tx-in TX-IN
-                                                [ --spending-tx-in-reference TX-IN
+                                              (--tx-in TX_IN
+                                                [ --spending-tx-in-reference TX_IN
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
@@ -23,7 +23,7 @@ Usage: cardano-cli conway transaction build
                                                   | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                   | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
-                                                | --simple-script-tx-in-reference TX-IN
+                                                | --simple-script-tx-in-reference TX_IN
                                                 | --tx-in-script-file FILEPATH
                                                   [
                                                     [ --tx-in-datum-cbor-file CBOR_FILE
@@ -36,11 +36,11 @@ Usage: cardano-cli conway transaction build
                                                     | --tx-in-redeemer-value JSON_VALUE
                                                     )]
                                                 ])
-                                              [--read-only-tx-in-reference TX-IN]
+                                              [--read-only-tx-in-reference TX_IN]
                                               [ --required-signer FILEPATH
                                               | --required-signer-hash HASH
                                               ]
-                                              [--tx-in-collateral TX-IN]
+                                              [--tx-in-collateral TX_IN]
                                               [--tx-out-return-collateral ADDRESS VALUE]
                                               [--tx-total-collateral INTEGER]
                                               [--tx-out ADDRESS VALUE
@@ -63,9 +63,9 @@ Usage: cardano-cli conway transaction build
                                                   | --mint-redeemer-file JSON_FILE
                                                   | --mint-redeemer-value JSON_VALUE
                                                   ]
-                                                | --simple-minting-script-tx-in-reference TX-IN
+                                                | --simple-minting-script-tx-in-reference TX_IN
                                                   --policy-id HASH
-                                                | --mint-tx-in-reference TX-IN
+                                                | --mint-tx-in-reference TX_IN
                                                   ( --mint-plutus-script-v2
                                                   | --mint-plutus-script-v3
                                                   )
@@ -83,7 +83,7 @@ Usage: cardano-cli conway transaction build
                                                   | --certificate-redeemer-file JSON_FILE
                                                   | --certificate-redeemer-value JSON_VALUE
                                                   ]
-                                                | --certificate-tx-in-reference TX-IN
+                                                | --certificate-tx-in-reference TX_IN
                                                   ( --certificate-plutus-script-v2
                                                   | --certificate-plutus-script-v3
                                                   )
@@ -98,7 +98,7 @@ Usage: cardano-cli conway transaction build
                                                   | --withdrawal-redeemer-file JSON_FILE
                                                   | --withdrawal-redeemer-value JSON_VALUE
                                                   ]
-                                                | --withdrawal-tx-in-reference TX-IN
+                                                | --withdrawal-tx-in-reference TX_IN
                                                   ( --withdrawal-plutus-script-v2
                                                   | --withdrawal-plutus-script-v3
                                                   )
@@ -120,7 +120,7 @@ Usage: cardano-cli conway transaction build
                                                   | --vote-redeemer-file JSON_FILE
                                                   | --vote-redeemer-value JSON_VALUE
                                                   ]
-                                                | --vote-tx-in-reference TX-IN
+                                                | --vote-tx-in-reference TX_IN
                                                   --vote-plutus-script-v3
                                                   ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                   | --vote-reference-tx-in-redeemer-file JSON_FILE
@@ -133,7 +133,7 @@ Usage: cardano-cli conway transaction build
                                                   | --proposal-redeemer-file JSON_FILE
                                                   | --proposal-redeemer-value JSON_VALUE
                                                   ]
-                                                | --proposal-tx-in-reference TX-IN
+                                                | --proposal-tx-in-reference TX_IN
                                                   --proposal-plutus-script-v3
                                                   ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                   | --proposal-reference-tx-in-redeemer-file JSON_FILE
@@ -170,8 +170,8 @@ Available options:
                            script will fail and the collateral will be taken.
   --witness-override WORD  Specify and override the number of witnesses the
                            transaction requires.
-  --tx-in TX-IN            TxId#TxIx
-  --spending-tx-in-reference TX-IN
+  --tx-in TX_IN            TxId#TxIx
+  --spending-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --spending-plutus-script-v2
@@ -200,7 +200,7 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --simple-script-tx-in-reference TX-IN
+  --simple-script-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --tx-in-script-file FILEPATH
@@ -228,7 +228,7 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --read-only-tx-in-reference TX-IN
+  --read-only-tx-in-reference TX_IN
                            Specify a read only reference input. This reference
                            input is not witnessing anything it is simply
                            provided in the plutus script context.
@@ -238,7 +238,7 @@ Available options:
   --required-signer-hash HASH
                            Hash of the verification key (zero or more) whose
                            signature is required.
-  --tx-in-collateral TX-IN TxId#TxIx
+  --tx-in-collateral TX_IN TxId#TxIx
   --tx-out-return-collateral ADDRESS VALUE
                            The transaction output as ADDRESS VALUE where ADDRESS
                            is the Bech32-encoded address followed by the value
@@ -313,11 +313,11 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --simple-minting-script-tx-in-reference TX-IN
+  --simple-minting-script-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --policy-id HASH         Policy id of minting script.
-  --mint-tx-in-reference TX-IN
+  --mint-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
@@ -353,7 +353,7 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --certificate-tx-in-reference TX-IN
+  --certificate-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --certificate-plutus-script-v2
@@ -387,7 +387,7 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --withdrawal-tx-in-reference TX-IN
+  --withdrawal-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --withdrawal-plutus-script-v2
@@ -429,7 +429,7 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --vote-tx-in-reference TX-IN
+  --vote-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --vote-plutus-script-v3  Specify a plutus script v3 reference script.
@@ -456,7 +456,7 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --proposal-tx-in-reference TX-IN
+  --proposal-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --proposal-plutus-script-v3

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-cardano.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-cardano.cli
@@ -1,7 +1,7 @@
 Usage: cardano-cli latest genesis create-cardano --genesis-dir DIR
                                                    [--gen-genesis-keys INT]
                                                    [--gen-utxo-keys INT]
-                                                   [--start-time UTC-TIME]
+                                                   [--start-time UTC_TIME]
                                                    [--supply LOVELACE]
                                                    [--security-param NON_ZERO_WORD64]
                                                    [--slot-length INT]
@@ -23,7 +23,7 @@ Available options:
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
   --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
-  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.
   --supply LOVELACE        The initial coin supply in Lovelace which will be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-staked.cli
@@ -8,7 +8,7 @@ Usage: cardano-cli latest genesis create-staked
                                                   [--gen-utxo-keys INT]
                                                   [--gen-pools INT]
                                                   [--gen-stake-delegs INT]
-                                                  [--start-time UTC-TIME]
+                                                  [--start-time UTC_TIME]
                                                   [--supply LOVELACE]
                                                   [--supply-delegated LOVELACE]
                                                   ( --mainnet
@@ -39,7 +39,7 @@ Available options:
                            [default is 0].
   --gen-stake-delegs INT   The number of stake delegator credential sets to make
                            [default is 0].
-  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.
   --supply LOVELACE        The initial coin supply in Lovelace which will be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-testnet-data.cli
@@ -16,7 +16,7 @@ Usage: cardano-cli latest genesis create-testnet-data [--spec-shelley FILEPATH]
                                                         [--delegated-supply LOVELACE]
                                                         [--testnet-magic NATURAL]
                                                         [--relays FILEPATH]
-                                                        [--start-time UTC-TIME]
+                                                        [--start-time UTC_TIME]
                                                         --out-dir DIR
 
   Create data to use for starting a testnet.
@@ -61,7 +61,7 @@ Available options:
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.
   --relays FILEPATH        JSON file specifying the relays of each stake pool.
-  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.
   --out-dir DIR            The directory where to generate the data. Created if

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create.cli
@@ -6,7 +6,7 @@ Usage: cardano-cli latest genesis create
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]
-                                           [--start-time UTC-TIME]
+                                           [--start-time UTC_TIME]
                                            [--supply LOVELACE]
                                            (--mainnet | --testnet-magic NATURAL)
 
@@ -26,7 +26,7 @@ Available options:
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
   --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
-  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.
   --supply LOVELACE        The initial coin supply in Lovelace which will be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ref-script-size.cli
@@ -8,7 +8,7 @@ Usage: cardano-cli latest query ref-script-size
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
-                                                  (--tx-in TX-IN)
+                                                  (--tx-in TX_IN)
                                                   [ --output-json
                                                   | --output-text
                                                   ]
@@ -34,7 +34,7 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
-  --tx-in TX-IN            Transaction input (TxId#TxIx).
+  --tx-in TX_IN            Transaction input (TxId#TxIx).
   --output-json            Format reference inputs query output to JSON
                            (default).
   --output-text            Format reference inputs query output to TEXT.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_utxo.cli
@@ -4,7 +4,7 @@ Usage: cardano-cli latest query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        [--volatile-tip | --immutable-tip]
                                        ( --whole-utxo
                                        | (--address ADDRESS)
-                                       | (--tx-in TX-IN)
+                                       | (--tx-in TX_IN)
                                        )
                                        [ --output-cbor
                                        | --output-json
@@ -34,7 +34,7 @@ Available options:
   --whole-utxo             Return the whole UTxO (only appropriate on small
                            testnets).
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
-  --tx-in TX-IN            Filter by transaction input (TxId#TxIx).
+  --tx-in TX_IN            Filter by transaction input (TxId#TxIx).
   --output-cbor            Format utxo query output to BASE16 CBOR.
   --output-json            Format utxo query output to JSON (default).
   --output-text            Format utxo query output to TEXT.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-estimate.cli
@@ -6,8 +6,8 @@ Usage: cardano-cli latest transaction build-estimate
                                                        [--byron-key-witnesses Int]
                                                        --protocol-params-file FILEPATH
                                                        --total-utxo-value VALUE
-                                                       (--tx-in TX-IN
-                                                         [ --spending-tx-in-reference TX-IN
+                                                       (--tx-in TX_IN
+                                                         [ --spending-tx-in-reference TX_IN
                                                            ( --spending-plutus-script-v2
                                                            | --spending-plutus-script-v3
                                                            )
@@ -21,7 +21,7 @@ Usage: cardano-cli latest transaction build-estimate
                                                            | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --spending-reference-tx-in-execution-units (INT, INT)
-                                                         | --simple-script-tx-in-reference TX-IN
+                                                         | --simple-script-tx-in-reference TX_IN
                                                          | --tx-in-script-file FILEPATH
                                                            [
                                                              [ --tx-in-datum-cbor-file CBOR_FILE
@@ -35,11 +35,11 @@ Usage: cardano-cli latest transaction build-estimate
                                                              )
                                                              --tx-in-execution-units (INT, INT)]
                                                          ])
-                                                       [--read-only-tx-in-reference TX-IN]
+                                                       [--read-only-tx-in-reference TX_IN]
                                                        [ --required-signer FILEPATH
                                                        | --required-signer-hash HASH
                                                        ]
-                                                       [--tx-in-collateral TX-IN]
+                                                       [--tx-in-collateral TX_IN]
                                                        [--tx-out-return-collateral ADDRESS VALUE]
                                                        [--tx-out ADDRESS VALUE
                                                          [ --tx-out-datum-hash HASH
@@ -63,9 +63,9 @@ Usage: cardano-cli latest transaction build-estimate
                                                              | --mint-redeemer-value JSON_VALUE
                                                              )
                                                              --mint-execution-units (INT, INT)]
-                                                         | --simple-minting-script-tx-in-reference TX-IN
+                                                         | --simple-minting-script-tx-in-reference TX_IN
                                                            --policy-id HASH
-                                                         | --mint-tx-in-reference TX-IN
+                                                         | --mint-tx-in-reference TX_IN
                                                            ( --mint-plutus-script-v2
                                                            | --mint-plutus-script-v3
                                                            )
@@ -87,7 +87,7 @@ Usage: cardano-cli latest transaction build-estimate
                                                              | --certificate-redeemer-value JSON_VALUE
                                                              )
                                                              --certificate-execution-units (INT, INT)]
-                                                         | --certificate-tx-in-reference TX-IN
+                                                         | --certificate-tx-in-reference TX_IN
                                                            ( --certificate-plutus-script-v2
                                                            | --certificate-plutus-script-v3
                                                            )
@@ -105,7 +105,7 @@ Usage: cardano-cli latest transaction build-estimate
                                                              | --withdrawal-redeemer-value JSON_VALUE
                                                              )
                                                              --withdrawal-execution-units (INT, INT)]
-                                                         | --withdrawal-tx-in-reference TX-IN
+                                                         | --withdrawal-tx-in-reference TX_IN
                                                            ( --withdrawal-plutus-script-v2
                                                            | --withdrawal-plutus-script-v3
                                                            )
@@ -132,7 +132,7 @@ Usage: cardano-cli latest transaction build-estimate
                                                              | --vote-redeemer-value JSON_VALUE
                                                              )
                                                              --vote-execution-units (INT, INT)]
-                                                         | --vote-tx-in-reference TX-IN
+                                                         | --vote-tx-in-reference TX_IN
                                                            --vote-plutus-script-v3
                                                            ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                            | --vote-reference-tx-in-redeemer-file JSON_FILE
@@ -148,7 +148,7 @@ Usage: cardano-cli latest transaction build-estimate
                                                              | --proposal-redeemer-value JSON_VALUE
                                                              )
                                                              --proposal-execution-units (INT, INT)]
-                                                         | --proposal-tx-in-reference TX-IN
+                                                         | --proposal-tx-in-reference TX_IN
                                                            --proposal-plutus-script-v3
                                                            ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                            | --proposal-reference-tx-in-redeemer-file JSON_FILE
@@ -180,8 +180,8 @@ Available options:
                            Filepath of the JSON-encoded protocol parameters file
   --total-utxo-value VALUE The total value of the UTxO that exists at the tx
                            inputs being spent.
-  --tx-in TX-IN            TxId#TxIx
-  --spending-tx-in-reference TX-IN
+  --tx-in TX_IN            TxId#TxIx
+  --spending-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --spending-plutus-script-v2
@@ -212,7 +212,7 @@ Available options:
                            top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --simple-script-tx-in-reference TX-IN
+  --simple-script-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --tx-in-script-file FILEPATH
@@ -242,7 +242,7 @@ Available options:
                            top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --read-only-tx-in-reference TX-IN
+  --read-only-tx-in-reference TX_IN
                            Specify a read only reference input. This reference
                            input is not witnessing anything it is simply
                            provided in the plutus script context.
@@ -252,7 +252,7 @@ Available options:
   --required-signer-hash HASH
                            Hash of the verification key (zero or more) whose
                            signature is required.
-  --tx-in-collateral TX-IN TxId#TxIx
+  --tx-in-collateral TX_IN TxId#TxIx
   --tx-out-return-collateral ADDRESS VALUE
                            The transaction output as ADDRESS VALUE where ADDRESS
                            is the Bech32-encoded address followed by the value
@@ -324,11 +324,11 @@ Available options:
                            top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --simple-minting-script-tx-in-reference TX-IN
+  --simple-minting-script-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --policy-id HASH         Policy id of minting script.
-  --mint-tx-in-reference TX-IN
+  --mint-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
@@ -368,7 +368,7 @@ Available options:
                            top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --certificate-tx-in-reference TX-IN
+  --certificate-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --certificate-plutus-script-v2
@@ -406,7 +406,7 @@ Available options:
                            top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --withdrawal-tx-in-reference TX-IN
+  --withdrawal-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --withdrawal-plutus-script-v2
@@ -460,7 +460,7 @@ Available options:
                            top-level strings and numbers.
   --vote-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --vote-tx-in-reference TX-IN
+  --vote-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --vote-plutus-script-v3  Specify a plutus script v3 reference script.
@@ -491,7 +491,7 @@ Available options:
                            top-level strings and numbers.
   --proposal-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --proposal-tx-in-reference TX-IN
+  --proposal-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --proposal-plutus-script-v3

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-raw.cli
@@ -2,8 +2,8 @@ Usage: cardano-cli latest transaction build-raw
                                                   [ --script-valid
                                                   | --script-invalid
                                                   ]
-                                                  (--tx-in TX-IN
-                                                    [ --spending-tx-in-reference TX-IN
+                                                  (--tx-in TX_IN
+                                                    [ --spending-tx-in-reference TX_IN
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
@@ -17,7 +17,7 @@ Usage: cardano-cli latest transaction build-raw
                                                       | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --spending-reference-tx-in-execution-units (INT, INT)
-                                                    | --simple-script-tx-in-reference TX-IN
+                                                    | --simple-script-tx-in-reference TX_IN
                                                     | --tx-in-script-file FILEPATH
                                                       [
                                                         [ --tx-in-datum-cbor-file CBOR_FILE
@@ -31,8 +31,8 @@ Usage: cardano-cli latest transaction build-raw
                                                         )
                                                         --tx-in-execution-units (INT, INT)]
                                                     ])
-                                                  [--read-only-tx-in-reference TX-IN]
-                                                  [--tx-in-collateral TX-IN]
+                                                  [--read-only-tx-in-reference TX_IN]
+                                                  [--tx-in-collateral TX_IN]
                                                   [--tx-out-return-collateral ADDRESS VALUE]
                                                   [--tx-total-collateral INTEGER]
                                                   [ --required-signer FILEPATH
@@ -59,9 +59,9 @@ Usage: cardano-cli latest transaction build-raw
                                                         | --mint-redeemer-value JSON_VALUE
                                                         )
                                                         --mint-execution-units (INT, INT)]
-                                                    | --simple-minting-script-tx-in-reference TX-IN
+                                                    | --simple-minting-script-tx-in-reference TX_IN
                                                       --policy-id HASH
-                                                    | --mint-tx-in-reference TX-IN
+                                                    | --mint-tx-in-reference TX_IN
                                                       ( --mint-plutus-script-v2
                                                       | --mint-plutus-script-v3
                                                       )
@@ -83,7 +83,7 @@ Usage: cardano-cli latest transaction build-raw
                                                         | --certificate-redeemer-value JSON_VALUE
                                                         )
                                                         --certificate-execution-units (INT, INT)]
-                                                    | --certificate-tx-in-reference TX-IN
+                                                    | --certificate-tx-in-reference TX_IN
                                                       ( --certificate-plutus-script-v2
                                                       | --certificate-plutus-script-v3
                                                       )
@@ -101,7 +101,7 @@ Usage: cardano-cli latest transaction build-raw
                                                         | --withdrawal-redeemer-value JSON_VALUE
                                                         )
                                                         --withdrawal-execution-units (INT, INT)]
-                                                    | --withdrawal-tx-in-reference TX-IN
+                                                    | --withdrawal-tx-in-reference TX_IN
                                                       ( --withdrawal-plutus-script-v2
                                                       | --withdrawal-plutus-script-v3
                                                       )
@@ -127,7 +127,7 @@ Usage: cardano-cli latest transaction build-raw
                                                         | --vote-redeemer-value JSON_VALUE
                                                         )
                                                         --vote-execution-units (INT, INT)]
-                                                    | --vote-tx-in-reference TX-IN
+                                                    | --vote-tx-in-reference TX_IN
                                                       --vote-plutus-script-v3
                                                       ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                       | --vote-reference-tx-in-redeemer-file JSON_FILE
@@ -143,7 +143,7 @@ Usage: cardano-cli latest transaction build-raw
                                                         | --proposal-redeemer-value JSON_VALUE
                                                         )
                                                         --proposal-execution-units (INT, INT)]
-                                                    | --proposal-tx-in-reference TX-IN
+                                                    | --proposal-tx-in-reference TX_IN
                                                       --proposal-plutus-script-v3
                                                       ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                       | --proposal-reference-tx-in-redeemer-file JSON_FILE
@@ -165,8 +165,8 @@ Available options:
   --script-invalid         Assertion that the script is invalid. If a
                            transaction is submitted with such a script, the
                            script will fail and the collateral will be taken.
-  --tx-in TX-IN            TxId#TxIx
-  --spending-tx-in-reference TX-IN
+  --tx-in TX_IN            TxId#TxIx
+  --spending-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --spending-plutus-script-v2
@@ -197,7 +197,7 @@ Available options:
                            top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --simple-script-tx-in-reference TX-IN
+  --simple-script-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --tx-in-script-file FILEPATH
@@ -227,11 +227,11 @@ Available options:
                            top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --read-only-tx-in-reference TX-IN
+  --read-only-tx-in-reference TX_IN
                            Specify a read only reference input. This reference
                            input is not witnessing anything it is simply
                            provided in the plutus script context.
-  --tx-in-collateral TX-IN TxId#TxIx
+  --tx-in-collateral TX_IN TxId#TxIx
   --tx-out-return-collateral ADDRESS VALUE
                            The transaction output as ADDRESS VALUE where ADDRESS
                            is the Bech32-encoded address followed by the value
@@ -313,11 +313,11 @@ Available options:
                            top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --simple-minting-script-tx-in-reference TX-IN
+  --simple-minting-script-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --policy-id HASH         Policy id of minting script.
-  --mint-tx-in-reference TX-IN
+  --mint-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
@@ -358,7 +358,7 @@ Available options:
                            top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --certificate-tx-in-reference TX-IN
+  --certificate-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --certificate-plutus-script-v2
@@ -396,7 +396,7 @@ Available options:
                            top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --withdrawal-tx-in-reference TX-IN
+  --withdrawal-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --withdrawal-plutus-script-v2
@@ -444,7 +444,7 @@ Available options:
                            top-level strings and numbers.
   --vote-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --vote-tx-in-reference TX-IN
+  --vote-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --vote-plutus-script-v3  Specify a plutus script v3 reference script.
@@ -475,7 +475,7 @@ Available options:
                            top-level strings and numbers.
   --proposal-execution-units (INT, INT)
                            The time and space units needed by the script.
-  --proposal-tx-in-reference TX-IN
+  --proposal-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --proposal-plutus-script-v3

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build.cli
@@ -9,8 +9,8 @@ Usage: cardano-cli latest transaction build
                                               | --script-invalid
                                               ]
                                               [--witness-override WORD]
-                                              (--tx-in TX-IN
-                                                [ --spending-tx-in-reference TX-IN
+                                              (--tx-in TX_IN
+                                                [ --spending-tx-in-reference TX_IN
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
@@ -23,7 +23,7 @@ Usage: cardano-cli latest transaction build
                                                   | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                   | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
-                                                | --simple-script-tx-in-reference TX-IN
+                                                | --simple-script-tx-in-reference TX_IN
                                                 | --tx-in-script-file FILEPATH
                                                   [
                                                     [ --tx-in-datum-cbor-file CBOR_FILE
@@ -36,11 +36,11 @@ Usage: cardano-cli latest transaction build
                                                     | --tx-in-redeemer-value JSON_VALUE
                                                     )]
                                                 ])
-                                              [--read-only-tx-in-reference TX-IN]
+                                              [--read-only-tx-in-reference TX_IN]
                                               [ --required-signer FILEPATH
                                               | --required-signer-hash HASH
                                               ]
-                                              [--tx-in-collateral TX-IN]
+                                              [--tx-in-collateral TX_IN]
                                               [--tx-out-return-collateral ADDRESS VALUE]
                                               [--tx-total-collateral INTEGER]
                                               [--tx-out ADDRESS VALUE
@@ -63,9 +63,9 @@ Usage: cardano-cli latest transaction build
                                                   | --mint-redeemer-file JSON_FILE
                                                   | --mint-redeemer-value JSON_VALUE
                                                   ]
-                                                | --simple-minting-script-tx-in-reference TX-IN
+                                                | --simple-minting-script-tx-in-reference TX_IN
                                                   --policy-id HASH
-                                                | --mint-tx-in-reference TX-IN
+                                                | --mint-tx-in-reference TX_IN
                                                   ( --mint-plutus-script-v2
                                                   | --mint-plutus-script-v3
                                                   )
@@ -83,7 +83,7 @@ Usage: cardano-cli latest transaction build
                                                   | --certificate-redeemer-file JSON_FILE
                                                   | --certificate-redeemer-value JSON_VALUE
                                                   ]
-                                                | --certificate-tx-in-reference TX-IN
+                                                | --certificate-tx-in-reference TX_IN
                                                   ( --certificate-plutus-script-v2
                                                   | --certificate-plutus-script-v3
                                                   )
@@ -98,7 +98,7 @@ Usage: cardano-cli latest transaction build
                                                   | --withdrawal-redeemer-file JSON_FILE
                                                   | --withdrawal-redeemer-value JSON_VALUE
                                                   ]
-                                                | --withdrawal-tx-in-reference TX-IN
+                                                | --withdrawal-tx-in-reference TX_IN
                                                   ( --withdrawal-plutus-script-v2
                                                   | --withdrawal-plutus-script-v3
                                                   )
@@ -120,7 +120,7 @@ Usage: cardano-cli latest transaction build
                                                   | --vote-redeemer-file JSON_FILE
                                                   | --vote-redeemer-value JSON_VALUE
                                                   ]
-                                                | --vote-tx-in-reference TX-IN
+                                                | --vote-tx-in-reference TX_IN
                                                   --vote-plutus-script-v3
                                                   ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                   | --vote-reference-tx-in-redeemer-file JSON_FILE
@@ -133,7 +133,7 @@ Usage: cardano-cli latest transaction build
                                                   | --proposal-redeemer-file JSON_FILE
                                                   | --proposal-redeemer-value JSON_VALUE
                                                   ]
-                                                | --proposal-tx-in-reference TX-IN
+                                                | --proposal-tx-in-reference TX_IN
                                                   --proposal-plutus-script-v3
                                                   ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                   | --proposal-reference-tx-in-redeemer-file JSON_FILE
@@ -170,8 +170,8 @@ Available options:
                            script will fail and the collateral will be taken.
   --witness-override WORD  Specify and override the number of witnesses the
                            transaction requires.
-  --tx-in TX-IN            TxId#TxIx
-  --spending-tx-in-reference TX-IN
+  --tx-in TX_IN            TxId#TxIx
+  --spending-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --spending-plutus-script-v2
@@ -200,7 +200,7 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --simple-script-tx-in-reference TX-IN
+  --simple-script-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --tx-in-script-file FILEPATH
@@ -228,7 +228,7 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --read-only-tx-in-reference TX-IN
+  --read-only-tx-in-reference TX_IN
                            Specify a read only reference input. This reference
                            input is not witnessing anything it is simply
                            provided in the plutus script context.
@@ -238,7 +238,7 @@ Available options:
   --required-signer-hash HASH
                            Hash of the verification key (zero or more) whose
                            signature is required.
-  --tx-in-collateral TX-IN TxId#TxIx
+  --tx-in-collateral TX_IN TxId#TxIx
   --tx-out-return-collateral ADDRESS VALUE
                            The transaction output as ADDRESS VALUE where ADDRESS
                            is the Bech32-encoded address followed by the value
@@ -313,11 +313,11 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --simple-minting-script-tx-in-reference TX-IN
+  --simple-minting-script-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --policy-id HASH         Policy id of minting script.
-  --mint-tx-in-reference TX-IN
+  --mint-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
@@ -353,7 +353,7 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --certificate-tx-in-reference TX-IN
+  --certificate-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --certificate-plutus-script-v2
@@ -387,7 +387,7 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --withdrawal-tx-in-reference TX-IN
+  --withdrawal-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --withdrawal-plutus-script-v2
@@ -429,7 +429,7 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --vote-tx-in-reference TX-IN
+  --vote-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --vote-plutus-script-v3  Specify a plutus script v3 reference script.
@@ -456,7 +456,7 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --proposal-tx-in-reference TX-IN
+  --proposal-tx-in-reference TX_IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
   --proposal-plutus-script-v3

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create-cardano.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create-cardano.cli
@@ -9,7 +9,7 @@ Usage: cardano-cli legacy genesis create-cardano
                                                    --genesis-dir DIR
                                                    [--gen-genesis-keys INT]
                                                    [--gen-utxo-keys INT]
-                                                   [--start-time UTC-TIME]
+                                                   [--start-time UTC_TIME]
                                                    [--supply LOVELACE]
                                                    [--security-param INT]
                                                    [--slot-length INT]
@@ -42,7 +42,7 @@ Available options:
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
   --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
-  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.
   --supply LOVELACE        The initial coin supply in Lovelace which will be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create-staked.cli
@@ -15,7 +15,7 @@ Usage: cardano-cli legacy genesis create-staked
                                                   [--gen-utxo-keys INT]
                                                   [--gen-pools INT]
                                                   [--gen-stake-delegs INT]
-                                                  [--start-time UTC-TIME]
+                                                  [--start-time UTC_TIME]
                                                   [--supply LOVELACE]
                                                   [--supply-delegated LOVELACE]
                                                   ( --mainnet
@@ -57,7 +57,7 @@ Available options:
                            [default is 0].
   --gen-stake-delegs INT   The number of stake delegator credential sets to make
                            [default is 0].
-  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.
   --supply LOVELACE        The initial coin supply in Lovelace which will be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli legacy genesis create
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]
-                                           [--start-time UTC-TIME]
+                                           [--start-time UTC_TIME]
                                            [--supply LOVELACE]
                                            (--mainnet | --testnet-magic NATURAL)
 
@@ -44,7 +44,7 @@ Available options:
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
   --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
-  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.
   --supply LOVELACE        The initial coin supply in Lovelace which will be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_utxo.cli
@@ -4,7 +4,7 @@ Usage: cardano-cli query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                 [--volatile-tip | --immutable-tip]
                                 ( --whole-utxo
                                 | (--address ADDRESS)
-                                | (--tx-in TX-IN)
+                                | (--tx-in TX_IN)
                                 )
                                 [--output-cbor | --output-json | --output-text]
                                 [--out-file FILEPATH]
@@ -31,7 +31,7 @@ Available options:
   --whole-utxo             Return the whole UTxO (only appropriate on small
                            testnets).
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
-  --tx-in TX-IN            Filter by transaction input (TxId#TxIx).
+  --tx-in TX_IN            Filter by transaction input (TxId#TxIx).
   --output-cbor            Format utxo query output to BASE16 CBOR.
   --output-json            Format utxo query output to JSON (default).
   --output-text            Format utxo query output to TEXT.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Changed formatting of some metavars to conform to screaming snake case and follow ADR-013
  type:
  - documentation  # change in code docs, haddocks...
```

# Context

See: https://github.com/input-output-hk/cardano-node-wiki/blob/main/docs/ADR-013-Metavars-must-follow-screaming-snake-case.md

# How to trust this PR

Make sure this only changes the name of metavars that didn't follow ADR-013, that it does it consistently and comprehensively, and it doesn't introduce any issues.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
