### PR TITLE
Standard output format for `query ledger-peer-snapshot` command

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -149,6 +149,7 @@ data QueryLedgerStateCmdArgs = QueryLedgerStateCmdArgs
 
 data QueryLedgerPeerSnapshotCmdArgs = QueryLedgerPeerSnapshotCmdArgs
   { commons :: !QueryCommons
+  , outputFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -149,7 +149,7 @@ data QueryLedgerStateCmdArgs = QueryLedgerStateCmdArgs
 
 data QueryLedgerPeerSnapshotCmdArgs = QueryLedgerPeerSnapshotCmdArgs
   { commons :: !QueryCommons
-  , outFile :: !(Maybe (File () Out))
+  , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -427,6 +427,11 @@ pQueryLedgerPeerSnapshotCmd era envCli =
   fmap QueryLedgerPeerSnapshotCmd $
     QueryLedgerPeerSnapshotCmdArgs
       <$> pQueryCommons era envCli
+      <*> pFormatFlags
+        "ledger-peer-snapshot output"
+        [ flagFormatJson & setDefault
+        , flagFormatYaml
+        ]
       <*> pMaybeOutputFile
 
 pQueryProtocolStateCmd :: ShelleyBasedEra era -> EnvCli -> Parser (QueryCmds era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -852,7 +852,7 @@ runQueryLedgerPeerSnapshot
         { Cmd.nodeConnInfo
         , Cmd.target
         }
-    , Cmd.outFile
+    , Cmd.mOutFile
     } = do
     join $
       lift
@@ -867,7 +867,7 @@ runQueryLedgerPeerSnapshot
 
             result <- easyRunQuery (queryLedgerPeerSnapshot sbe)
 
-            pure $ shelleyBasedEraConstraints sbe (writeLedgerPeerSnapshot outFile) result
+            pure $ shelleyBasedEraConstraints sbe (writeLedgerPeerSnapshot mOutFile) result
         )
         & onLeft (left . QueryCmdAcquireFailure)
         & onLeft left

--- a/cardano-cli/src/Cardano/CLI/Helper.hs
+++ b/cardano-cli/src/Cardano/CLI/Helper.hs
@@ -8,6 +8,7 @@ module Cardano.CLI.Helper
   ( HelpersError (..)
   , cborToText
   , cborToTextByteString
+  , cborToTextLazyByteString
   , printWarning
   , deprecationWarning
   , ensureNewFile
@@ -35,11 +36,14 @@ import Data.Bifunctor (Bifunctor (..))
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LB
+import Data.ByteString.Lazy qualified as LBS
 import Data.Functor (void)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.Text.IO qualified as Text
+import Data.Text.Lazy qualified as LT
+import Data.Text.Lazy.Encoding qualified as LT
 import Data.Typeable (Typeable)
 import System.Console.ANSI
 import System.Console.ANSI qualified as ANSI
@@ -113,6 +117,10 @@ cborToTextByteString :: LB.ByteString -> ExceptT HelpersError IO LB.ByteString
 cborToTextByteString bs = do
   text <- cborToText bs
   pure $ LB.fromStrict $ Text.encodeUtf8 text
+
+cborToTextLazyByteString :: LB.ByteString -> ExceptT HelpersError IO LBS.ByteString
+cborToTextLazyByteString =
+  fmap (LT.encodeUtf8 . LT.fromStrict) . cborToText
 
 cborToText :: LB.ByteString -> ExceptT HelpersError IO Text
 cborToText bs = do

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -493,6 +493,7 @@ Usage: cardano-cli query ledger-peer-snapshot
                                                 [ --volatile-tip
                                                 | --immutable-tip
                                                 ]
+                                                [--output-json | --output-yaml]
                                                 [--out-file FILEPATH]
 
   Dump the current snapshot of big ledger peers. These are the largest pools
@@ -2047,6 +2048,9 @@ Usage: cardano-cli conway query ledger-peer-snapshot
                                                        --socket-path SOCKET_PATH
                                                        [ --volatile-tip
                                                        | --immutable-tip
+                                                       ]
+                                                       [ --output-json
+                                                       | --output-yaml
                                                        ]
                                                        [--out-file FILEPATH]
 
@@ -4284,6 +4288,9 @@ Usage: cardano-cli latest query ledger-peer-snapshot
                                                        --socket-path SOCKET_PATH
                                                        [ --volatile-tip
                                                        | --immutable-tip
+                                                       ]
+                                                       [ --output-json
+                                                       | --output-yaml
                                                        ]
                                                        [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ledger-peer-snapshot.cli
@@ -8,6 +8,9 @@ Usage: cardano-cli conway query ledger-peer-snapshot
                                                        [ --volatile-tip
                                                        | --immutable-tip
                                                        ]
+                                                       [ --output-json
+                                                       | --output-yaml
+                                                       ]
                                                        [--out-file FILEPATH]
 
   Dump the current snapshot of ledger peers.These are the largest pools that
@@ -30,5 +33,7 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format ledger-peer-snapshot output to JSON (default).
+  --output-yaml            Format ledger-peer-snapshot output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ledger-peer-snapshot.cli
@@ -8,6 +8,9 @@ Usage: cardano-cli latest query ledger-peer-snapshot
                                                        [ --volatile-tip
                                                        | --immutable-tip
                                                        ]
+                                                       [ --output-json
+                                                       | --output-yaml
+                                                       ]
                                                        [--out-file FILEPATH]
 
   Dump the current snapshot of ledger peers.These are the largest pools that
@@ -30,5 +33,7 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format ledger-peer-snapshot output to JSON (default).
+  --output-yaml            Format ledger-peer-snapshot output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_ledger-peer-snapshot.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli query ledger-peer-snapshot
                                                 [ --volatile-tip
                                                 | --immutable-tip
                                                 ]
+                                                [--output-json | --output-yaml]
                                                 [--out-file FILEPATH]
 
   Dump the current snapshot of big ledger peers. These are the largest pools
@@ -30,5 +31,7 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format ledger-peer-snapshot output to JSON (default).
+  --output-yaml            Format ledger-peer-snapshot output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Standard output format for `query ledger-peer-snapshot` command
    Supports `--output-json`, `--output-json-pretty` and `--output-yaml`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Follows [ADR-012](https://github.com/input-output-hk/cardano-node-wiki/blob/main/docs/ADR-012-standardise-CLI-multiple-choice-flags-construction.md)

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
