### PR TITLE
Rollout `--output-json` and `--output-yaml` part 1

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -164,6 +164,7 @@ library
     Cardano.CLI.EraIndependent.Ping.Run
     Cardano.CLI.Helper
     Cardano.CLI.IO.Lazy
+    Cardano.CLI.Json.Encode
     Cardano.CLI.Json.Friendly
     Cardano.CLI.Legacy.Command
     Cardano.CLI.Legacy.Genesis.Command

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -94,7 +94,7 @@ data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
   , poolColdVerKeyFile :: !StakePoolKeyHashSource
   , vrkSkeyFp :: !(SigningKeyFile In)
   , whichSchedule :: !EpochLeadershipSchedule
-  , format :: !(Vary [FormatJson, FormatText])
+  , format :: !(Vary [FormatJson, FormatText, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -512,6 +512,7 @@ pLeadershipScheduleCmd era envCli =
         "leadership-schedule query output"
         [ flagFormatJson & setDefault
         , flagFormatText
+        , flagFormatYaml
         ]
       <*> pMaybeOutputFile
 

--- a/cardano-cli/src/Cardano/CLI/Json/Encode.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Encode.hs
@@ -1,0 +1,30 @@
+module Cardano.CLI.Json.Encode
+  ( encodeJson
+  , encodeYaml
+  )
+where
+
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Encode.Pretty qualified as Aeson
+import Data.ByteString.Lazy qualified as LBS
+import Data.Yaml.Pretty qualified as Yaml
+
+-- | Encode JSON with pretty printing.
+encodeJson :: Aeson.ToJSON a => a -> LBS.ByteString
+encodeJson =
+  Aeson.encodePretty' jsonConfig
+
+-- | Encode YAML with pretty printing.
+encodeYaml :: Aeson.ToJSON a => a -> LBS.ByteString
+encodeYaml =
+  LBS.fromStrict . Yaml.encodePretty yamlConfig
+
+jsonConfig :: Aeson.Config
+jsonConfig =
+  Aeson.defConfig
+    { Aeson.confCompare = compare
+    }
+
+yamlConfig :: Yaml.Config
+yamlConfig =
+  Yaml.setConfCompare compare Yaml.defConfig

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
@@ -229,6 +229,6 @@ hprop_golden_view_conway_proposal =
 
     result <-
       execCardanoCLI
-        ["debug", "transaction", "view", "--tx-file", input </> "tx-proposal.json", "--output-json"]
+        ["debug", "transaction", "view", "--tx-file", input </> "tx-proposal.json"]
 
     H.diffVsGoldenFile result (golden </> "tx-proposal.out.json")

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -429,7 +429,10 @@ Usage: cardano-cli query leadership-schedule
                                                )
                                                --vrf-signing-key-file FILEPATH
                                                (--current | --next)
-                                               [--output-json | --output-text]
+                                               [ --output-json
+                                               | --output-text
+                                               | --output-yaml
+                                               ]
                                                [--out-file FILEPATH]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -2034,6 +2037,7 @@ Usage: cardano-cli conway query leadership-schedule
                                                       (--current | --next)
                                                       [ --output-json
                                                       | --output-text
+                                                      | --output-yaml
                                                       ]
                                                       [--out-file FILEPATH]
 
@@ -4274,6 +4278,7 @@ Usage: cardano-cli latest query leadership-schedule
                                                       (--current | --next)
                                                       [ --output-json
                                                       | --output-text
+                                                      | --output-yaml
                                                       ]
                                                       [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_leadership-schedule.cli
@@ -18,6 +18,7 @@ Usage: cardano-cli conway query leadership-schedule
                                                       (--current | --next)
                                                       [ --output-json
                                                       | --output-text
+                                                      | --output-yaml
                                                       ]
                                                       [--out-file FILEPATH]
 
@@ -58,5 +59,6 @@ Available options:
   --output-json            Format leadership-schedule query output to JSON
                            (default).
   --output-text            Format leadership-schedule query output to TEXT.
+  --output-yaml            Format leadership-schedule query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_leadership-schedule.cli
@@ -18,6 +18,7 @@ Usage: cardano-cli latest query leadership-schedule
                                                       (--current | --next)
                                                       [ --output-json
                                                       | --output-text
+                                                      | --output-yaml
                                                       ]
                                                       [--out-file FILEPATH]
 
@@ -58,5 +59,6 @@ Available options:
   --output-json            Format leadership-schedule query output to JSON
                            (default).
   --output-text            Format leadership-schedule query output to TEXT.
+  --output-yaml            Format leadership-schedule query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_leadership-schedule.cli
@@ -16,7 +16,10 @@ Usage: cardano-cli query leadership-schedule
                                                )
                                                --vrf-signing-key-file FILEPATH
                                                (--current | --next)
-                                               [--output-json | --output-text]
+                                               [ --output-json
+                                               | --output-text
+                                               | --output-yaml
+                                               ]
                                                [--out-file FILEPATH]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -56,5 +59,6 @@ Available options:
   --output-json            Format leadership-schedule query output to JSON
                            (default).
   --output-text            Format leadership-schedule query output to TEXT.
+  --output-yaml            Format leadership-schedule query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Rollout `--output-json` and `--output-yaml` to various commands:
    * `compatible conway governance action view`
    * `compatible conway governance vote view`
    * `conway governance action view`
    * `conway governance vote view`
    * `conway query leadership-schedule`
    * `debug transaction view`
    * `latest governance action view`
    * `latest governance vote view`
    * `latest query leadership-schedule`
    * `query leadership-schedule`
    Ensure we encode json the same way in each command.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This helps keep output options of commands consistent.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
