### PR TITLE
Rollout json pretty and yaml output 2

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
@@ -158,7 +158,7 @@ data GovernanceActionViewCmdArgs era
   = GovernanceActionViewCmdArgs
   { eon :: !(ConwayEraOnwards era)
   , actionFile :: !(ProposalFile In)
-  , outFormat :: !(Vary [FormatJson, FormatYaml])
+  , outputFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
@@ -64,8 +64,8 @@ runGovernanceActionViewCmd
   -> CIO e ()
 runGovernanceActionViewCmd
   Cmd.GovernanceActionViewCmdArgs
-    { Cmd.outFormat
-    , Cmd.actionFile
+    { Cmd.actionFile
+    , Cmd.outputFormat
     , Cmd.mOutFile
     , Cmd.eon
     } = do
@@ -73,7 +73,7 @@ runGovernanceActionViewCmd
       fromEitherIOCli $
         readProposal eon (actionFile, Nothing)
 
-    void $ friendlyProposal outFormat mOutFile eon $ fst proposal
+    void $ friendlyProposal outputFormat mOutFile eon $ fst proposal
 
 runGovernanceActionInfoCmd
   :: forall era e

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Command.hs
@@ -45,8 +45,8 @@ data GovernanceVoteCreateCmdArgs era
 data GovernanceVoteViewCmdArgs era
   = GovernanceVoteViewCmdArgs
   { eon :: ConwayEraOnwards era
-  , outFormat :: !(Vary [FormatJson, FormatYaml])
   , voteFile :: VoteFile In
+  , outputFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: Maybe (File () Out)
   }
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Option.hs
@@ -91,10 +91,10 @@ pGovernanceVoteViewCmd era = do
 pGovernanceVoteViewCmdArgs :: ConwayEraOnwards era -> Parser (GovernanceVoteViewCmdArgs era)
 pGovernanceVoteViewCmdArgs cOnwards =
   GovernanceVoteViewCmdArgs cOnwards
-    <$> pFormatFlags
+    <$> pFileInDirection "vote-file" "Input filepath of the vote."
+    <*> pFormatFlags
       "governance vote view output"
       [ flagFormatJson & setDefault
       , flagFormatYaml
       ]
-    <*> pFileInDirection "vote-file" "Input filepath of the vote."
     <*> pMaybeOutputFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Run.hs
@@ -124,4 +124,6 @@ runGovernanceVoteViewCmd
                 )
               $ unVotingProcedures voteProcedures
 
-      firstExceptT GovernanceVoteCmdWriteError $ newExceptT $ writeLazyByteStringOutput mOutFile output
+      firstExceptT GovernanceVoteCmdWriteError
+        . newExceptT
+        $ writeLazyByteStringOutput mOutFile output

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Run.hs
@@ -103,8 +103,8 @@ runGovernanceVoteViewCmd
 runGovernanceVoteViewCmd
   Cmd.GovernanceVoteViewCmdArgs
     { eon
-    , outFormat
     , voteFile
+    , outputFormat
     , mOutFile
     } = do
     let sbe :: ShelleyBasedEra era = convert eon
@@ -116,7 +116,7 @@ runGovernanceVoteViewCmd
             readVoteScriptWitness eon (voteFile, Nothing)
 
       let output =
-            outFormat
+            outputFormat
               & ( id
                     . Vary.on (\FormatJson -> Json.encodeJson)
                     . Vary.on (\FormatYaml -> Json.encodeYaml)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -101,12 +101,14 @@ data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
 
 data QueryProtocolParametersCmdArgs = QueryProtocolParametersCmdArgs
   { nodeConnInfo :: !LocalNodeConnectInfo
+  , outFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
 
 data QueryTipCmdArgs = QueryTipCmdArgs
   { commons :: !QueryCommons
+  , outFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -128,6 +130,7 @@ data QueryStakeDistributionCmdArgs = QueryStakeDistributionCmdArgs
 data QueryStakeAddressInfoCmdArgs = QueryStakeAddressInfoCmdArgs
   { commons :: !QueryCommons
   , addr :: !StakeAddress
+  , outputFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -163,6 +166,7 @@ data QueryProtocolStateCmdArgs = QueryProtocolStateCmdArgs
 data QueryStakeSnapshotCmdArgs = QueryStakeSnapshotCmdArgs
   { commons :: !QueryCommons
   , allOrOnlyPoolIds :: !(AllOrOnly (Hash StakePoolKey))
+  , outputFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -171,6 +175,7 @@ data QueryKesPeriodInfoCmdArgs = QueryKesPeriodInfoCmdArgs
   { commons :: !QueryCommons
   , nodeOpCertFp :: !(File () In)
   -- ^ Node operational certificate
+  , outFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -178,6 +183,7 @@ data QueryKesPeriodInfoCmdArgs = QueryKesPeriodInfoCmdArgs
 data QueryPoolStateCmdArgs = QueryPoolStateCmdArgs
   { commons :: !QueryCommons
   , allOrOnlyPoolIds :: !(AllOrOnly (Hash StakePoolKey))
+  , outputFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -185,6 +191,7 @@ data QueryPoolStateCmdArgs = QueryPoolStateCmdArgs
 data QueryTxMempoolCmdArgs = QueryTxMempoolCmdArgs
   { nodeConnInfo :: !LocalNodeConnectInfo
   , query :: !TxMempoolQuery
+  , outFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -239,6 +246,7 @@ data QuerySPOStakeDistributionCmdArgs era = QuerySPOStakeDistributionCmdArgs
   { eon :: !(ConwayEraOnwards era)
   , commons :: !QueryCommons
   , spoHashSources :: !(AllOrOnly SPOHashSource)
+  , outputFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving Show
@@ -264,6 +272,7 @@ data QueryStakePoolDefaultVoteCmdArgs era = QueryStakePoolDefaultVoteCmdArgs
   { eon :: !(ConwayEraOnwards era)
   , commons :: !QueryCommons
   , spoHashSources :: !SPOHashSource
+  , outputFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving Show
@@ -302,7 +311,7 @@ renderQueryCmds = \case
     "query kes-period-info"
   QueryPoolStateCmd{} ->
     "query pool-state"
-  QueryTxMempoolCmd (QueryTxMempoolCmdArgs _ q _) ->
+  QueryTxMempoolCmd (QueryTxMempoolCmdArgs _ q _ _) ->
     "query tx-mempool" <> renderTxMempoolQuery q
   QuerySlotNumberCmd{} ->
     "query slot-number"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -94,35 +94,35 @@ data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
   , poolColdVerKeyFile :: !StakePoolKeyHashSource
   , vrkSkeyFp :: !(SigningKeyFile In)
   , whichSchedule :: !EpochLeadershipSchedule
-  , format :: !(Vary [FormatJson, FormatText, FormatYaml])
+  , outputFormat :: !(Vary [FormatJson, FormatText, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
 
 data QueryProtocolParametersCmdArgs = QueryProtocolParametersCmdArgs
   { nodeConnInfo :: !LocalNodeConnectInfo
-  , outFormat :: !(Vary [FormatJson, FormatYaml])
+  , outputFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
 
 data QueryTipCmdArgs = QueryTipCmdArgs
   { commons :: !QueryCommons
-  , outFormat :: !(Vary [FormatJson, FormatYaml])
+  , outputFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
 
 data QueryStakePoolsCmdArgs = QueryStakePoolsCmdArgs
   { commons :: !QueryCommons
-  , format :: !(Vary [FormatJson, FormatText])
+  , outputFormat :: !(Vary [FormatJson, FormatText])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
 
 data QueryStakeDistributionCmdArgs = QueryStakeDistributionCmdArgs
   { commons :: !QueryCommons
-  , format :: !(Vary [FormatJson, FormatText])
+  , outputFormat :: !(Vary [FormatJson, FormatText])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -138,7 +138,7 @@ data QueryStakeAddressInfoCmdArgs = QueryStakeAddressInfoCmdArgs
 data QueryUTxOCmdArgs = QueryUTxOCmdArgs
   { commons :: !QueryCommons
   , queryFilter :: !QueryUTxOFilter
-  , format :: !(Vary [FormatCbor, FormatJson, FormatText])
+  , outputFormat :: !(Vary [FormatCbor, FormatJson, FormatText])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -175,7 +175,7 @@ data QueryKesPeriodInfoCmdArgs = QueryKesPeriodInfoCmdArgs
   { commons :: !QueryCommons
   , nodeOpCertFp :: !(File () In)
   -- ^ Node operational certificate
-  , outFormat :: !(Vary [FormatJson, FormatYaml])
+  , outputFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -191,7 +191,7 @@ data QueryPoolStateCmdArgs = QueryPoolStateCmdArgs
 data QueryTxMempoolCmdArgs = QueryTxMempoolCmdArgs
   { nodeConnInfo :: !LocalNodeConnectInfo
   , query :: !TxMempoolQuery
-  , outFormat :: !(Vary [FormatJson, FormatYaml])
+  , outputFormat :: !(Vary [FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -205,7 +205,7 @@ data QuerySlotNumberCmdArgs = QuerySlotNumberCmdArgs
 data QueryRefScriptSizeCmdArgs = QueryRefScriptSizeCmdArgs
   { commons :: !QueryCommons
   , transactionInputs :: !(Set TxIn)
-  , format :: !(Vary [FormatJson, FormatText])
+  , outputFormat :: !(Vary [FormatJson, FormatText])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -355,6 +355,11 @@ pQueryProtocolParametersCmd envCli =
               <*> pNetworkId envCli
               <*> pSocketPath envCli
           )
+      <*> pFormatFlags
+        "protocol-parameters query output"
+        [ flagFormatJson & setDefault
+        , flagFormatYaml
+        ]
       <*> pMaybeOutputFile
 
 pQueryTipCmd :: ShelleyBasedEra era -> EnvCli -> Parser (QueryCmds era)
@@ -362,6 +367,11 @@ pQueryTipCmd era envCli =
   fmap QueryTipCmd $
     QueryTipCmdArgs
       <$> pQueryCommons era envCli
+      <*> pFormatFlags
+        "tip query output"
+        [ flagFormatJson & setDefault
+        , flagFormatYaml
+        ]
       <*> pMaybeOutputFile
 
 pQueryUTxOCmd :: ShelleyBasedEra era -> EnvCli -> Parser (QueryCmds era)
@@ -408,6 +418,11 @@ pQueryStakeAddressInfoCmd era envCli =
     QueryStakeAddressInfoCmdArgs
       <$> pQueryCommons era envCli
       <*> pFilterByStakeAddress
+      <*> pFormatFlags
+        "stake-address-info query output"
+        [ flagFormatJson & setDefault
+        , flagFormatYaml
+        ]
       <*> pMaybeOutputFile
 
 pQueryLedgerStateCmd :: ShelleyBasedEra era -> EnvCli -> Parser (QueryCmds era)
@@ -428,7 +443,7 @@ pQueryLedgerPeerSnapshotCmd era envCli =
     QueryLedgerPeerSnapshotCmdArgs
       <$> pQueryCommons era envCli
       <*> pFormatFlags
-        "ledger-peer-snapshot output"
+        "ledger-peer-snapshot query output"
         [ flagFormatJson & setDefault
         , flagFormatYaml
         ]
@@ -460,6 +475,11 @@ pQueryStakeSnapshotCmd era envCli =
     QueryStakeSnapshotCmdArgs
       <$> pQueryCommons era envCli
       <*> pAllStakePoolsOrSome
+      <*> pFormatFlags
+        "stake-snapshot query output"
+        [ flagFormatJson & setDefault
+        , flagFormatYaml
+        ]
       <*> pMaybeOutputFile
 
 pQueryPoolStateCmd :: ShelleyBasedEra era -> EnvCli -> Parser (QueryCmds era)
@@ -468,6 +488,11 @@ pQueryPoolStateCmd era envCli =
     QueryPoolStateCmdArgs
       <$> pQueryCommons era envCli
       <*> pAllStakePoolsOrSome
+      <*> pFormatFlags
+        "pool-state query output"
+        [ flagFormatJson & setDefault
+        , flagFormatYaml
+        ]
       <*> pMaybeOutputFile
 
 pQueryTxMempoolCmd :: EnvCli -> Parser (QueryCmds era)
@@ -480,6 +505,11 @@ pQueryTxMempoolCmd envCli =
               <*> pSocketPath envCli
           )
       <*> pTxMempoolQuery
+      <*> pFormatFlags
+        "tx-mempool query output"
+        [ flagFormatJson & setDefault
+        , flagFormatYaml
+        ]
       <*> pMaybeOutputFile
  where
   pTxMempoolQuery :: Parser TxMempoolQuery
@@ -522,6 +552,11 @@ pKesPeriodInfoCmd era envCli =
     QueryKesPeriodInfoCmdArgs
       <$> pQueryCommons era envCli
       <*> pOperationalCertificateFile
+      <*> pFormatFlags
+        "kes-period-info query output"
+        [ flagFormatJson & setDefault
+        , flagFormatYaml
+        ]
       <*> pMaybeOutputFile
 
 pQuerySlotNumberCmd :: ShelleyBasedEra era -> EnvCli -> Parser (QueryCmds era)
@@ -715,6 +750,11 @@ pQuerySPOStakeDistributionCmd era envCli = do
     QuerySPOStakeDistributionCmdArgs w
       <$> pQueryCommons era envCli
       <*> pAllOrOnlySPOHashSource
+      <*> pFormatFlags
+        "spo-stake-distribution query output"
+        [ flagFormatJson & setDefault
+        , flagFormatYaml
+        ]
       <*> pMaybeOutputFile
 
 pQueryGetCommitteeStateCmd
@@ -821,6 +861,11 @@ pQueryStakePoolDefaultVote era envCli = do
     QueryStakePoolDefaultVoteCmdArgs w
       <$> pQueryCommons era envCli
       <*> pSPOHashSource
+      <*> pFormatFlags
+        "stake-pool-default-vote query output"
+        [ flagFormatJson & setDefault
+        , flagFormatYaml
+        ]
       <*> pMaybeOutputFile
 
 pQueryNoArgCmdArgs

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -145,22 +145,18 @@ runQueryProtocolParametersCmd
     } = do
     AnyCardanoEra era <- firstExceptT QueryCmdAcquireFailure $ determineEra nodeConnInfo
     sbe <- forEraInEon @ShelleyBasedEra era (left QueryCmdByronEra) pure
+
     let qInMode = QueryInEra $ QueryInShelleyBasedEra sbe Api.QueryProtocolParameters
-    pp <-
+
+    pparams <-
       executeQueryAnyMode nodeConnInfo qInMode
         & modifyError QueryCmdConvenienceError
-    writeProtocolParameters sbe mOutFile pp
-   where
-    writeProtocolParameters
-      :: ShelleyBasedEra era
-      -> Maybe (File () Out)
-      -> L.PParams (ShelleyLedgerEra era)
-      -> ExceptT QueryCmdError IO ()
-    writeProtocolParameters sbe mOutFile' pparams =
-      firstExceptT QueryCmdWriteFileError . newExceptT $
-        writeLazyByteStringOutput mOutFile' $
-          shelleyBasedEraConstraints sbe $
-            Aeson.encodePretty pparams
+
+    firstExceptT QueryCmdWriteFileError
+      . newExceptT
+      . writeLazyByteStringOutput mOutFile
+      $ shelleyBasedEraConstraints sbe
+      $ Json.encodeJson pparams
 
 -- | Calculate the percentage sync rendered as text: @min 1 (tipTime/nowTime)@
 percentage

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -140,7 +140,7 @@ runQueryProtocolParametersCmd
 runQueryProtocolParametersCmd
   Cmd.QueryProtocolParametersCmdArgs
     { Cmd.nodeConnInfo
-    , Cmd.outFormat
+    , Cmd.outputFormat
     , Cmd.mOutFile
     } = do
     AnyCardanoEra era <- firstExceptT QueryCmdAcquireFailure $ determineEra nodeConnInfo
@@ -154,7 +154,7 @@ runQueryProtocolParametersCmd
 
     let output =
           shelleyBasedEraConstraints sbe
-            $ outFormat
+            $ outputFormat
               & ( id
                     . Vary.on (\FormatJson -> Json.encodeJson)
                     . Vary.on (\FormatYaml -> Json.encodeYaml)
@@ -212,7 +212,7 @@ runQueryTipCmd
           { Cmd.nodeConnInfo
           , Cmd.target
           }
-      , Cmd.outFormat
+      , Cmd.outputFormat
       , Cmd.mOutFile
       }
     ) = do
@@ -294,7 +294,7 @@ runQueryTipCmd
               }
 
     let output =
-          outFormat
+          outputFormat
             & ( id
                   . Vary.on (\FormatJson -> Json.encodeJson)
                   . Vary.on (\FormatYaml -> Json.encodeYaml)
@@ -320,7 +320,7 @@ runQueryUTxOCmd
           , Cmd.target
           }
       , Cmd.queryFilter
-      , Cmd.format
+      , Cmd.outputFormat
       , Cmd.mOutFile
       }
     ) = do
@@ -336,7 +336,7 @@ runQueryUTxOCmd
             utxo <- easyRunQuery (queryUtxo sbe queryFilter)
 
             pure $ do
-              writeFilteredUTxOs sbe format mOutFile utxo
+              writeFilteredUTxOs sbe outputFormat mOutFile utxo
         )
         & onLeft (left . QueryCmdAcquireFailure)
         & onLeft left
@@ -353,7 +353,7 @@ runQueryKesPeriodInfoCmd
         , Cmd.target
         }
     , Cmd.nodeOpCertFp
-    , Cmd.outFormat
+    , Cmd.outputFormat
     , Cmd.mOutFile
     } = do
     opCert <-
@@ -403,7 +403,7 @@ runQueryKesPeriodInfoCmd
 
               let qKesInfoOutput = createQueryKesPeriodInfoOutput opCertIntervalInformation counterInformation eInfo gParams
                   output =
-                    outFormat
+                    outputFormat
                       & ( id
                             . Vary.on (\FormatJson -> Json.encodeJson)
                             . Vary.on (\FormatYaml -> Json.encodeYaml)
@@ -686,7 +686,7 @@ runQueryTxMempoolCmd
   Cmd.QueryTxMempoolCmdArgs
     { Cmd.nodeConnInfo
     , Cmd.query
-    , Cmd.outFormat
+    , Cmd.outputFormat
     , Cmd.mOutFile
     } = do
     localQuery <- case query of
@@ -701,7 +701,7 @@ runQueryTxMempoolCmd
     result <- liftIO $ queryTxMonitoringLocal nodeConnInfo localQuery
 
     let output =
-          outFormat
+          outputFormat
             & ( id
                   . Vary.on (\FormatJson -> Json.encodeJson)
                   . Vary.on (\FormatYaml -> Json.encodeYaml)
@@ -741,7 +741,7 @@ runQueryRefScriptSizeCmd
         , Cmd.target
         }
     , Cmd.transactionInputs
-    , Cmd.format
+    , Cmd.outputFormat
     , Cmd.mOutFile
     } = do
     join $
@@ -758,7 +758,7 @@ runQueryRefScriptSizeCmd
             utxo <- easyRunQuery (queryUtxo sbe $ QueryUTxOByTxIn transactionInputs)
 
             pure $
-              writeFormattedOutput format mOutFile $
+              writeFormattedOutput outputFormat mOutFile $
                 RefInputScriptSize $
                   getReferenceInputsSizeForTxIds beo (toLedgerUTxO sbe utxo) transactionInputs
         )
@@ -1373,7 +1373,7 @@ runQueryStakePoolsCmd
         { Cmd.nodeConnInfo
         , Cmd.target
         }
-    , Cmd.format
+    , Cmd.outputFormat
     , Cmd.mOutFile
     } = do
     join $
@@ -1387,7 +1387,7 @@ runQueryStakePoolsCmd
 
             poolIds <- easyRunQuery (queryStakePools sbe)
 
-            pure $ writeStakePools format mOutFile poolIds
+            pure $ writeStakePools outputFormat mOutFile poolIds
         )
         & onLeft (left . QueryCmdAcquireFailure)
         & onLeft left
@@ -1450,7 +1450,7 @@ runQueryStakeDistributionCmd
         { Cmd.nodeConnInfo
         , Cmd.target
         }
-    , Cmd.format
+    , Cmd.outputFormat
     , Cmd.mOutFile
     } = do
     join $
@@ -1465,7 +1465,7 @@ runQueryStakeDistributionCmd
             result <- easyRunQuery (queryStakeDistribution sbe)
 
             pure $ do
-              writeStakeDistribution format mOutFile result
+              writeStakeDistribution outputFormat mOutFile result
         )
         & onLeft (left . QueryCmdAcquireFailure)
         & onLeft left
@@ -1520,7 +1520,7 @@ runQueryLeadershipScheduleCmd
     , Cmd.poolColdVerKeyFile
     , Cmd.vrkSkeyFp
     , Cmd.whichSchedule
-    , Cmd.format
+    , Cmd.outputFormat
     , Cmd.mOutFile
     } = do
     poolid <- getHashFromStakePoolKeyHashSource poolColdVerKeyFile
@@ -1603,7 +1603,7 @@ runQueryLeadershipScheduleCmd
     writeSchedule mOutFile' eInfo shelleyGenesis schedule = do
       let start = SystemStart $ sgSystemStart shelleyGenesis
           output =
-            format
+            outputFormat
               & ( id
                     . Vary.on (\FormatJson -> Json.encodeJson $ leadershipScheduleToJson schedule eInfo start)
                     . Vary.on (\FormatText -> strictTextToLazyBytestring $ leadershipScheduleToText schedule eInfo start)

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Run.hs
@@ -25,7 +25,6 @@ import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Error.NodeCmdError
 import Cardano.CLI.Type.Key
 
-import Data.ByteString.Char8 qualified as BS
 import Data.Function ((&))
 import Data.String (fromString)
 import Data.Word (Word64)
@@ -248,9 +247,9 @@ runNodeKeyHashVrfCmd
 
     let hexKeyHash = serialiseToRawBytesHex (verificationKeyHash vkey)
 
-    case mOutFile of
-      Just fpath -> liftIO $ BS.writeFile (unFile fpath) hexKeyHash
-      Nothing -> liftIO $ BS.putStrLn hexKeyHash
+    firstExceptT NodeCmdWriteFileError
+      . newExceptT
+      $ writeByteStringOutput mOutFile hexKeyHash
 
 runNodeNewCounterCmd
   :: ()

--- a/cardano-cli/src/Cardano/CLI/Type/Error/TextViewFileError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/TextViewFileError.hs
@@ -13,12 +13,15 @@ import Cardano.CLI.Helper (HelpersError, renderHelpersError)
 
 data TextViewFileError
   = TextViewReadFileError (FileError TextEnvelopeError)
+  | TextViewWriteFileError (FileError TextEnvelopeError)
   | TextViewCBORPrettyPrintError !HelpersError
   deriving Show
 
 renderTextViewFileError :: TextViewFileError -> Doc ann
 renderTextViewFileError = \case
   TextViewReadFileError fileErr ->
+    prettyError fileErr
+  TextViewWriteFileError fileErr ->
     prettyError fileErr
   TextViewCBORPrettyPrintError hlprsErr ->
     "Error pretty printing CBOR: " <> renderHelpersError hlprsErr

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -294,6 +294,7 @@ Usage: cardano-cli query protocol-parameters
                                                | --testnet-magic NATURAL
                                                )
                                                --socket-path SOCKET_PATH
+                                               [--output-json | --output-yaml]
                                                [--out-file FILEPATH]
 
   Get the node's current protocol parameters
@@ -302,6 +303,7 @@ Usage: cardano-cli query tip [--cardano-mode [--epoch-slots SLOTS]]
                                (--mainnet | --testnet-magic NATURAL)
                                --socket-path SOCKET_PATH
                                [--volatile-tip | --immutable-tip]
+                               [--output-json | --output-yaml]
                                [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
@@ -337,6 +339,7 @@ Usage: cardano-cli query stake-address-info
                                               --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               --address ADDRESS
+                                              [--output-json | --output-yaml]
                                               [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
@@ -393,6 +396,7 @@ Usage: cardano-cli query stake-snapshot [--cardano-mode [--epoch-slots SLOTS]]
                                           ( --all-stake-pools
                                           | (--stake-pool-id STAKE_POOL_ID)
                                           )
+                                          [--output-json | --output-yaml]
                                           [--out-file FILEPATH]
 
   Obtain the three stake snapshots for a pool, plus the total active stake
@@ -405,6 +409,7 @@ Usage: cardano-cli query pool-params [--cardano-mode [--epoch-slots SLOTS]]
                                        ( --all-stake-pools
                                        | (--stake-pool-id STAKE_POOL_ID)
                                        )
+                                       [--output-json | --output-yaml]
                                        [--out-file FILEPATH]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
@@ -442,6 +447,7 @@ Usage: cardano-cli query kes-period-info [--cardano-mode [--epoch-slots SLOTS]]
                                            --socket-path SOCKET_PATH
                                            [--volatile-tip | --immutable-tip]
                                            --op-cert-file FILEPATH
+                                           [--output-json | --output-yaml]
                                            [--out-file FILEPATH]
 
   Get information about the current KES period and your node's operational
@@ -454,6 +460,7 @@ Usage: cardano-cli query pool-state [--cardano-mode [--epoch-slots SLOTS]]
                                       ( --all-stake-pools
                                       | (--stake-pool-id STAKE_POOL_ID)
                                       )
+                                      [--output-json | --output-yaml]
                                       [--out-file FILEPATH]
 
   Dump the pool state
@@ -462,6 +469,7 @@ Usage: cardano-cli query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
                                       --socket-path SOCKET_PATH
                                       (info | next-tx | tx-exists)
+                                      [--output-json | --output-yaml]
                                       [--out-file FILEPATH]
 
   Local Mempool info
@@ -2012,6 +2020,9 @@ Usage: cardano-cli conway query kes-period-info
                                                   | --immutable-tip
                                                   ]
                                                   --op-cert-file FILEPATH
+                                                  [ --output-json
+                                                  | --output-yaml
+                                                  ]
                                                   [--out-file FILEPATH]
 
   Get information about the current KES period and your node's operational
@@ -2088,6 +2099,7 @@ Usage: cardano-cli conway query pool-params
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--output-json | --output-yaml]
                                               [--out-file FILEPATH]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
@@ -2105,6 +2117,7 @@ Usage: cardano-cli conway query pool-state
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
+                                             [--output-json | --output-yaml]
                                              [--out-file FILEPATH]
 
   Dump the pool state
@@ -2132,6 +2145,9 @@ Usage: cardano-cli conway query protocol-parameters
                                                       | --testnet-magic NATURAL
                                                       )
                                                       --socket-path SOCKET_PATH
+                                                      [ --output-json
+                                                      | --output-yaml
+                                                      ]
                                                       [--out-file FILEPATH]
 
   Get the node's current protocol parameters
@@ -2213,6 +2229,9 @@ Usage: cardano-cli conway query spo-stake-distribution
                                                          | --spo-key-hash HASH
                                                          )
                                                          )
+                                                         [ --output-json
+                                                         | --output-yaml
+                                                         ]
                                                          [--out-file FILEPATH]
 
   Get the SPO stake distribution.
@@ -2228,6 +2247,9 @@ Usage: cardano-cli conway query stake-address-info
                                                      | --immutable-tip
                                                      ]
                                                      --address ADDRESS
+                                                     [ --output-json
+                                                     | --output-yaml
+                                                     ]
                                                      [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
@@ -2276,6 +2298,9 @@ Usage: cardano-cli conway query stake-pool-default-vote
                                                           | --spo-verification-key-file FILEPATH
                                                           | --spo-key-hash HASH
                                                           )
+                                                          [ --output-json
+                                                          | --output-yaml
+                                                          ]
                                                           [--out-file FILEPATH]
 
   Get the stake pool default vote.
@@ -2293,6 +2318,7 @@ Usage: cardano-cli conway query stake-snapshot
                                                  ( --all-stake-pools
                                                  | (--stake-pool-id STAKE_POOL_ID)
                                                  )
+                                                 [--output-json | --output-yaml]
                                                  [--out-file FILEPATH]
 
   Obtain the three stake snapshots for a pool, plus the total active stake
@@ -2302,6 +2328,7 @@ Usage: cardano-cli conway query tip [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
                                       --socket-path SOCKET_PATH
                                       [--volatile-tip | --immutable-tip]
+                                      [--output-json | --output-yaml]
                                       [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
@@ -2322,6 +2349,7 @@ Usage: cardano-cli conway query tx-mempool
                                              )
                                              --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
+                                             [--output-json | --output-yaml]
                                              [--out-file FILEPATH]
 
   Local Mempool info
@@ -4253,6 +4281,9 @@ Usage: cardano-cli latest query kes-period-info
                                                   | --immutable-tip
                                                   ]
                                                   --op-cert-file FILEPATH
+                                                  [ --output-json
+                                                  | --output-yaml
+                                                  ]
                                                   [--out-file FILEPATH]
 
   Get information about the current KES period and your node's operational
@@ -4329,6 +4360,7 @@ Usage: cardano-cli latest query pool-params
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--output-json | --output-yaml]
                                               [--out-file FILEPATH]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
@@ -4346,6 +4378,7 @@ Usage: cardano-cli latest query pool-state
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
+                                             [--output-json | --output-yaml]
                                              [--out-file FILEPATH]
 
   Dump the pool state
@@ -4373,6 +4406,9 @@ Usage: cardano-cli latest query protocol-parameters
                                                       | --testnet-magic NATURAL
                                                       )
                                                       --socket-path SOCKET_PATH
+                                                      [ --output-json
+                                                      | --output-yaml
+                                                      ]
                                                       [--out-file FILEPATH]
 
   Get the node's current protocol parameters
@@ -4454,6 +4490,9 @@ Usage: cardano-cli latest query spo-stake-distribution
                                                          | --spo-key-hash HASH
                                                          )
                                                          )
+                                                         [ --output-json
+                                                         | --output-yaml
+                                                         ]
                                                          [--out-file FILEPATH]
 
   Get the SPO stake distribution.
@@ -4469,6 +4508,9 @@ Usage: cardano-cli latest query stake-address-info
                                                      | --immutable-tip
                                                      ]
                                                      --address ADDRESS
+                                                     [ --output-json
+                                                     | --output-yaml
+                                                     ]
                                                      [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
@@ -4517,6 +4559,9 @@ Usage: cardano-cli latest query stake-pool-default-vote
                                                           | --spo-verification-key-file FILEPATH
                                                           | --spo-key-hash HASH
                                                           )
+                                                          [ --output-json
+                                                          | --output-yaml
+                                                          ]
                                                           [--out-file FILEPATH]
 
   Get the stake pool default vote.
@@ -4534,6 +4579,7 @@ Usage: cardano-cli latest query stake-snapshot
                                                  ( --all-stake-pools
                                                  | (--stake-pool-id STAKE_POOL_ID)
                                                  )
+                                                 [--output-json | --output-yaml]
                                                  [--out-file FILEPATH]
 
   Obtain the three stake snapshots for a pool, plus the total active stake
@@ -4543,6 +4589,7 @@ Usage: cardano-cli latest query tip [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
                                       --socket-path SOCKET_PATH
                                       [--volatile-tip | --immutable-tip]
+                                      [--output-json | --output-yaml]
                                       [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
@@ -4563,6 +4610,7 @@ Usage: cardano-cli latest query tx-mempool
                                              )
                                              --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
+                                             [--output-json | --output-yaml]
                                              [--out-file FILEPATH]
 
   Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -1770,8 +1770,8 @@ Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
 
   Vote creation.
 
-Usage: cardano-cli conway governance vote view [--output-json | --output-yaml]
-                                                 --vote-file FILEPATH
+Usage: cardano-cli conway governance vote view --vote-file FILEPATH
+                                                 [--output-json | --output-yaml]
                                                  [--out-file FILEPATH]
 
   Vote viewing.
@@ -4031,8 +4031,8 @@ Usage: cardano-cli latest governance vote create (--yes | --no | --abstain)
 
   Vote creation.
 
-Usage: cardano-cli latest governance vote view [--output-json | --output-yaml]
-                                                 --vote-file FILEPATH
+Usage: cardano-cli latest governance vote view --vote-file FILEPATH
+                                                 [--output-json | --output-yaml]
                                                  [--out-file FILEPATH]
 
   Vote viewing.
@@ -7323,11 +7323,10 @@ Usage: cardano-cli compatible conway governance vote create
 
   Vote creation.
 
-Usage: cardano-cli compatible conway governance vote view 
+Usage: cardano-cli compatible conway governance vote view --vote-file FILEPATH
                                                             [ --output-json
                                                             | --output-yaml
                                                             ]
-                                                            --vote-file FILEPATH
                                                             [--out-file FILEPATH]
 
   Vote viewing.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_vote_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_vote_view.cli
@@ -1,15 +1,14 @@
-Usage: cardano-cli compatible conway governance vote view 
+Usage: cardano-cli compatible conway governance vote view --vote-file FILEPATH
                                                             [ --output-json
                                                             | --output-yaml
                                                             ]
-                                                            --vote-file FILEPATH
                                                             [--out-file FILEPATH]
 
   Vote viewing.
 
 Available options:
+  --vote-file FILEPATH     Input filepath of the vote.
   --output-json            Format governance vote view output to JSON (default).
   --output-yaml            Format governance vote view output to YAML.
-  --vote-file FILEPATH     Input filepath of the vote.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_view.cli
@@ -1,12 +1,12 @@
-Usage: cardano-cli conway governance vote view [--output-json | --output-yaml]
-                                                 --vote-file FILEPATH
+Usage: cardano-cli conway governance vote view --vote-file FILEPATH
+                                                 [--output-json | --output-yaml]
                                                  [--out-file FILEPATH]
 
   Vote viewing.
 
 Available options:
+  --vote-file FILEPATH     Input filepath of the vote.
   --output-json            Format governance vote view output to JSON (default).
   --output-yaml            Format governance vote view output to YAML.
-  --vote-file FILEPATH     Input filepath of the vote.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_kes-period-info.cli
@@ -9,6 +9,9 @@ Usage: cardano-cli conway query kes-period-info
                                                   | --immutable-tip
                                                   ]
                                                   --op-cert-file FILEPATH
+                                                  [ --output-json
+                                                  | --output-yaml
+                                                  ]
                                                   [--out-file FILEPATH]
 
   Get information about the current KES period and your node's operational
@@ -32,5 +35,8 @@ Available options:
                            default)
   --immutable-tip          Use the immutable tip as a target.
   --op-cert-file FILEPATH  Filepath of the node's operational certificate.
+  --output-json            Format kes-period-info query output to JSON
+                           (default).
+  --output-yaml            Format kes-period-info query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ledger-peer-snapshot.cli
@@ -33,7 +33,8 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
-  --output-json            Format ledger-peer-snapshot output to JSON (default).
-  --output-yaml            Format ledger-peer-snapshot output to YAML.
+  --output-json            Format ledger-peer-snapshot query output to JSON
+                           (default).
+  --output-yaml            Format ledger-peer-snapshot query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-params.cli
@@ -9,6 +9,7 @@ Usage: cardano-cli conway query pool-params
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--output-json | --output-yaml]
                                               [--out-file FILEPATH]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
@@ -36,5 +37,7 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --output-json            Format pool-state query output to JSON (default).
+  --output-yaml            Format pool-state query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-state.cli
@@ -9,6 +9,7 @@ Usage: cardano-cli conway query pool-state
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
+                                             [--output-json | --output-yaml]
                                              [--out-file FILEPATH]
 
   Dump the pool state
@@ -34,5 +35,7 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --output-json            Format pool-state query output to JSON (default).
+  --output-yaml            Format pool-state query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_protocol-parameters.cli
@@ -5,6 +5,9 @@ Usage: cardano-cli conway query protocol-parameters
                                                       | --testnet-magic NATURAL
                                                       )
                                                       --socket-path SOCKET_PATH
+                                                      [ --output-json
+                                                      | --output-yaml
+                                                      ]
                                                       [--out-file FILEPATH]
 
   Get the node's current protocol parameters
@@ -23,5 +26,8 @@ Available options:
                            CARDANO_NODE_SOCKET_PATH environment variable. The
                            argument is optional if CARDANO_NODE_SOCKET_PATH is
                            defined and mandatory otherwise.
+  --output-json            Format protocol-parameters query output to JSON
+                           (default).
+  --output-yaml            Format protocol-parameters query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_spo-stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_spo-stake-distribution.cli
@@ -15,6 +15,9 @@ Usage: cardano-cli conway query spo-stake-distribution
                                                          | --spo-key-hash HASH
                                                          )
                                                          )
+                                                         [ --output-json
+                                                         | --output-yaml
+                                                         ]
                                                          [--out-file FILEPATH]
 
   Get the SPO stake distribution.
@@ -43,5 +46,8 @@ Available options:
                            Filepath of the SPO verification key.
   --spo-key-hash HASH      SPO verification key hash (either Bech32-encoded or
                            hex-encoded).
+  --output-json            Format spo-stake-distribution query output to JSON
+                           (default).
+  --output-yaml            Format spo-stake-distribution query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-address-info.cli
@@ -9,6 +9,9 @@ Usage: cardano-cli conway query stake-address-info
                                                      | --immutable-tip
                                                      ]
                                                      --address ADDRESS
+                                                     [ --output-json
+                                                     | --output-yaml
+                                                     ]
                                                      [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
@@ -31,5 +34,8 @@ Available options:
                            default)
   --immutable-tip          Use the immutable tip as a target.
   --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
+  --output-json            Format stake-address-info query output to JSON
+                           (default).
+  --output-yaml            Format stake-address-info query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-pool-default-vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-pool-default-vote.cli
@@ -12,6 +12,9 @@ Usage: cardano-cli conway query stake-pool-default-vote
                                                           | --spo-verification-key-file FILEPATH
                                                           | --spo-key-hash HASH
                                                           )
+                                                          [ --output-json
+                                                          | --output-yaml
+                                                          ]
                                                           [--out-file FILEPATH]
 
   Get the stake pool default vote.
@@ -39,5 +42,8 @@ Available options:
                            Filepath of the SPO verification key.
   --spo-key-hash HASH      SPO verification key hash (either Bech32-encoded or
                            hex-encoded).
+  --output-json            Format stake-pool-default-vote query output to JSON
+                           (default).
+  --output-yaml            Format stake-pool-default-vote query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-snapshot.cli
@@ -11,6 +11,7 @@ Usage: cardano-cli conway query stake-snapshot
                                                  ( --all-stake-pools
                                                  | (--stake-pool-id STAKE_POOL_ID)
                                                  )
+                                                 [--output-json | --output-yaml]
                                                  [--out-file FILEPATH]
 
   Obtain the three stake snapshots for a pool, plus the total active stake
@@ -37,5 +38,7 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --output-json            Format stake-snapshot query output to JSON (default).
+  --output-yaml            Format stake-snapshot query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tip.cli
@@ -2,6 +2,7 @@ Usage: cardano-cli conway query tip [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
                                       --socket-path SOCKET_PATH
                                       [--volatile-tip | --immutable-tip]
+                                      [--output-json | --output-yaml]
                                       [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
@@ -23,5 +24,7 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format tip query output to JSON (default).
+  --output-yaml            Format tip query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli conway query tx-mempool
                                              )
                                              --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
+                                             [--output-json | --output-yaml]
                                              [--out-file FILEPATH]
 
   Local Mempool info
@@ -24,6 +25,8 @@ Available options:
                            CARDANO_NODE_SOCKET_PATH environment variable. The
                            argument is optional if CARDANO_NODE_SOCKET_PATH is
                            defined and mandatory otherwise.
+  --output-json            Format tx-mempool query output to JSON (default).
+  --output-yaml            Format tx-mempool query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_info.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli conway query tx-mempool
                                              )
                                              --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
+                                             [--output-json | --output-yaml]
                                              [--out-file FILEPATH]
 
   Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_next-tx.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli conway query tx-mempool
                                              )
                                              --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
+                                             [--output-json | --output-yaml]
                                              [--out-file FILEPATH]
 
   Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_tx-exists_TX_ID.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli conway query tx-mempool
                                              )
                                              --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
+                                             [--output-json | --output-yaml]
                                              [--out-file FILEPATH]
 
   Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_vote_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_vote_view.cli
@@ -1,12 +1,12 @@
-Usage: cardano-cli latest governance vote view [--output-json | --output-yaml]
-                                                 --vote-file FILEPATH
+Usage: cardano-cli latest governance vote view --vote-file FILEPATH
+                                                 [--output-json | --output-yaml]
                                                  [--out-file FILEPATH]
 
   Vote viewing.
 
 Available options:
+  --vote-file FILEPATH     Input filepath of the vote.
   --output-json            Format governance vote view output to JSON (default).
   --output-yaml            Format governance vote view output to YAML.
-  --vote-file FILEPATH     Input filepath of the vote.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_kes-period-info.cli
@@ -9,6 +9,9 @@ Usage: cardano-cli latest query kes-period-info
                                                   | --immutable-tip
                                                   ]
                                                   --op-cert-file FILEPATH
+                                                  [ --output-json
+                                                  | --output-yaml
+                                                  ]
                                                   [--out-file FILEPATH]
 
   Get information about the current KES period and your node's operational
@@ -32,5 +35,8 @@ Available options:
                            default)
   --immutable-tip          Use the immutable tip as a target.
   --op-cert-file FILEPATH  Filepath of the node's operational certificate.
+  --output-json            Format kes-period-info query output to JSON
+                           (default).
+  --output-yaml            Format kes-period-info query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ledger-peer-snapshot.cli
@@ -33,7 +33,8 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
-  --output-json            Format ledger-peer-snapshot output to JSON (default).
-  --output-yaml            Format ledger-peer-snapshot output to YAML.
+  --output-json            Format ledger-peer-snapshot query output to JSON
+                           (default).
+  --output-yaml            Format ledger-peer-snapshot query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-params.cli
@@ -9,6 +9,7 @@ Usage: cardano-cli latest query pool-params
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--output-json | --output-yaml]
                                               [--out-file FILEPATH]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
@@ -36,5 +37,7 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --output-json            Format pool-state query output to JSON (default).
+  --output-yaml            Format pool-state query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-state.cli
@@ -9,6 +9,7 @@ Usage: cardano-cli latest query pool-state
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
+                                             [--output-json | --output-yaml]
                                              [--out-file FILEPATH]
 
   Dump the pool state
@@ -34,5 +35,7 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --output-json            Format pool-state query output to JSON (default).
+  --output-yaml            Format pool-state query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_protocol-parameters.cli
@@ -5,6 +5,9 @@ Usage: cardano-cli latest query protocol-parameters
                                                       | --testnet-magic NATURAL
                                                       )
                                                       --socket-path SOCKET_PATH
+                                                      [ --output-json
+                                                      | --output-yaml
+                                                      ]
                                                       [--out-file FILEPATH]
 
   Get the node's current protocol parameters
@@ -23,5 +26,8 @@ Available options:
                            CARDANO_NODE_SOCKET_PATH environment variable. The
                            argument is optional if CARDANO_NODE_SOCKET_PATH is
                            defined and mandatory otherwise.
+  --output-json            Format protocol-parameters query output to JSON
+                           (default).
+  --output-yaml            Format protocol-parameters query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_spo-stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_spo-stake-distribution.cli
@@ -15,6 +15,9 @@ Usage: cardano-cli latest query spo-stake-distribution
                                                          | --spo-key-hash HASH
                                                          )
                                                          )
+                                                         [ --output-json
+                                                         | --output-yaml
+                                                         ]
                                                          [--out-file FILEPATH]
 
   Get the SPO stake distribution.
@@ -43,5 +46,8 @@ Available options:
                            Filepath of the SPO verification key.
   --spo-key-hash HASH      SPO verification key hash (either Bech32-encoded or
                            hex-encoded).
+  --output-json            Format spo-stake-distribution query output to JSON
+                           (default).
+  --output-yaml            Format spo-stake-distribution query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-address-info.cli
@@ -9,6 +9,9 @@ Usage: cardano-cli latest query stake-address-info
                                                      | --immutable-tip
                                                      ]
                                                      --address ADDRESS
+                                                     [ --output-json
+                                                     | --output-yaml
+                                                     ]
                                                      [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
@@ -31,5 +34,8 @@ Available options:
                            default)
   --immutable-tip          Use the immutable tip as a target.
   --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
+  --output-json            Format stake-address-info query output to JSON
+                           (default).
+  --output-yaml            Format stake-address-info query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-pool-default-vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-pool-default-vote.cli
@@ -12,6 +12,9 @@ Usage: cardano-cli latest query stake-pool-default-vote
                                                           | --spo-verification-key-file FILEPATH
                                                           | --spo-key-hash HASH
                                                           )
+                                                          [ --output-json
+                                                          | --output-yaml
+                                                          ]
                                                           [--out-file FILEPATH]
 
   Get the stake pool default vote.
@@ -39,5 +42,8 @@ Available options:
                            Filepath of the SPO verification key.
   --spo-key-hash HASH      SPO verification key hash (either Bech32-encoded or
                            hex-encoded).
+  --output-json            Format stake-pool-default-vote query output to JSON
+                           (default).
+  --output-yaml            Format stake-pool-default-vote query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-snapshot.cli
@@ -11,6 +11,7 @@ Usage: cardano-cli latest query stake-snapshot
                                                  ( --all-stake-pools
                                                  | (--stake-pool-id STAKE_POOL_ID)
                                                  )
+                                                 [--output-json | --output-yaml]
                                                  [--out-file FILEPATH]
 
   Obtain the three stake snapshots for a pool, plus the total active stake
@@ -37,5 +38,7 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --output-json            Format stake-snapshot query output to JSON (default).
+  --output-yaml            Format stake-snapshot query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tip.cli
@@ -2,6 +2,7 @@ Usage: cardano-cli latest query tip [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
                                       --socket-path SOCKET_PATH
                                       [--volatile-tip | --immutable-tip]
+                                      [--output-json | --output-yaml]
                                       [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
@@ -23,5 +24,7 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format tip query output to JSON (default).
+  --output-yaml            Format tip query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli latest query tx-mempool
                                              )
                                              --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
+                                             [--output-json | --output-yaml]
                                              [--out-file FILEPATH]
 
   Local Mempool info
@@ -24,6 +25,8 @@ Available options:
                            CARDANO_NODE_SOCKET_PATH environment variable. The
                            argument is optional if CARDANO_NODE_SOCKET_PATH is
                            defined and mandatory otherwise.
+  --output-json            Format tx-mempool query output to JSON (default).
+  --output-yaml            Format tx-mempool query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_info.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli latest query tx-mempool
                                              )
                                              --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
+                                             [--output-json | --output-yaml]
                                              [--out-file FILEPATH]
 
   Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_next-tx.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli latest query tx-mempool
                                              )
                                              --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
+                                             [--output-json | --output-yaml]
                                              [--out-file FILEPATH]
 
   Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_tx-exists_TX_ID.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli latest query tx-mempool
                                              )
                                              --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
+                                             [--output-json | --output-yaml]
                                              [--out-file FILEPATH]
 
   Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_kes-period-info.cli
@@ -3,6 +3,7 @@ Usage: cardano-cli query kes-period-info [--cardano-mode [--epoch-slots SLOTS]]
                                            --socket-path SOCKET_PATH
                                            [--volatile-tip | --immutable-tip]
                                            --op-cert-file FILEPATH
+                                           [--output-json | --output-yaml]
                                            [--out-file FILEPATH]
 
   Get information about the current KES period and your node's operational
@@ -26,5 +27,8 @@ Available options:
                            default)
   --immutable-tip          Use the immutable tip as a target.
   --op-cert-file FILEPATH  Filepath of the node's operational certificate.
+  --output-json            Format kes-period-info query output to JSON
+                           (default).
+  --output-yaml            Format kes-period-info query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_ledger-peer-snapshot.cli
@@ -31,7 +31,8 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
-  --output-json            Format ledger-peer-snapshot output to JSON (default).
-  --output-yaml            Format ledger-peer-snapshot output to YAML.
+  --output-json            Format ledger-peer-snapshot query output to JSON
+                           (default).
+  --output-yaml            Format ledger-peer-snapshot query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-params.cli
@@ -5,6 +5,7 @@ Usage: cardano-cli query pool-params [--cardano-mode [--epoch-slots SLOTS]]
                                        ( --all-stake-pools
                                        | (--stake-pool-id STAKE_POOL_ID)
                                        )
+                                       [--output-json | --output-yaml]
                                        [--out-file FILEPATH]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
@@ -32,5 +33,7 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --output-json            Format pool-state query output to JSON (default).
+  --output-yaml            Format pool-state query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-state.cli
@@ -5,6 +5,7 @@ Usage: cardano-cli query pool-state [--cardano-mode [--epoch-slots SLOTS]]
                                       ( --all-stake-pools
                                       | (--stake-pool-id STAKE_POOL_ID)
                                       )
+                                      [--output-json | --output-yaml]
                                       [--out-file FILEPATH]
 
   Dump the pool state
@@ -30,5 +31,7 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --output-json            Format pool-state query output to JSON (default).
+  --output-yaml            Format pool-state query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_protocol-parameters.cli
@@ -5,6 +5,7 @@ Usage: cardano-cli query protocol-parameters
                                                | --testnet-magic NATURAL
                                                )
                                                --socket-path SOCKET_PATH
+                                               [--output-json | --output-yaml]
                                                [--out-file FILEPATH]
 
   Get the node's current protocol parameters
@@ -23,5 +24,8 @@ Available options:
                            CARDANO_NODE_SOCKET_PATH environment variable. The
                            argument is optional if CARDANO_NODE_SOCKET_PATH is
                            defined and mandatory otherwise.
+  --output-json            Format protocol-parameters query output to JSON
+                           (default).
+  --output-yaml            Format protocol-parameters query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-address-info.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli query stake-address-info
                                               --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               --address ADDRESS
+                                              [--output-json | --output-yaml]
                                               [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
@@ -29,5 +30,8 @@ Available options:
                            default)
   --immutable-tip          Use the immutable tip as a target.
   --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
+  --output-json            Format stake-address-info query output to JSON
+                           (default).
+  --output-yaml            Format stake-address-info query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-snapshot.cli
@@ -5,6 +5,7 @@ Usage: cardano-cli query stake-snapshot [--cardano-mode [--epoch-slots SLOTS]]
                                           ( --all-stake-pools
                                           | (--stake-pool-id STAKE_POOL_ID)
                                           )
+                                          [--output-json | --output-yaml]
                                           [--out-file FILEPATH]
 
   Obtain the three stake snapshots for a pool, plus the total active stake
@@ -31,5 +32,7 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --output-json            Format stake-snapshot query output to JSON (default).
+  --output-yaml            Format stake-snapshot query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tip.cli
@@ -2,6 +2,7 @@ Usage: cardano-cli query tip [--cardano-mode [--epoch-slots SLOTS]]
                                (--mainnet | --testnet-magic NATURAL)
                                --socket-path SOCKET_PATH
                                [--volatile-tip | --immutable-tip]
+                               [--output-json | --output-yaml]
                                [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
@@ -23,5 +24,7 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format tip query output to JSON (default).
+  --output-yaml            Format tip query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool.cli
@@ -2,6 +2,7 @@ Usage: cardano-cli query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
                                       --socket-path SOCKET_PATH
                                       (info | next-tx | tx-exists)
+                                      [--output-json | --output-yaml]
                                       [--out-file FILEPATH]
 
   Local Mempool info
@@ -20,6 +21,8 @@ Available options:
                            CARDANO_NODE_SOCKET_PATH environment variable. The
                            argument is optional if CARDANO_NODE_SOCKET_PATH is
                            defined and mandatory otherwise.
+  --output-json            Format tx-mempool query output to JSON (default).
+  --output-yaml            Format tx-mempool query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_info.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
                                       --socket-path SOCKET_PATH
                                       (info | next-tx | tx-exists)
+                                      [--output-json | --output-yaml]
                                       [--out-file FILEPATH]
 
   Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_next-tx.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
                                       --socket-path SOCKET_PATH
                                       (info | next-tx | tx-exists)
+                                      [--output-json | --output-yaml]
                                       [--out-file FILEPATH]
 
   Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_tx-exists_TX_ID.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
                                       --socket-path SOCKET_PATH
                                       (info | next-tx | tx-exists)
+                                      [--output-json | --output-yaml]
                                       [--out-file FILEPATH]
 
   Local Mempool info


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    The following commands have been updated to take output format:
    * `conway query kes-period-info`
    * `conway query ledger-peer-snapshot`
    * `conway query pool-params`
    * `conway query pool-state`
    * `conway query protocol-parameters`
    * `conway query spo-stake-distribution`
    * `conway query stake-address-info`
    * `conway query stake-pool-default-vote`
    * `conway query stake-snapshot`
    * `conway query tip`
    * `conway query tx-mempool`
    * `conway query tx-mempool info`
    * `conway query tx-mempool next-tx`
    * `conway query tx-mempool tx-exists`
    * `latest query kes-period-info`
    * `latest query ledger-peer-snapshot`
    * `latest query pool-params`
    * `latest query pool-state`
    * `latest query protocol-parameters`
    * `latest query spo-stake-distribution`
    * `latest query stake-address-info`
    * `latest query stake-pool-default-vote`
    * `latest query stake-snapshot`
    * `latest query tip`
    * `latest query tx-mempool`
    * `latest query tx-mempool info`
    * `latest query tx-mempool next-tx`
    * `latest query tx-mempool tx-exists`
    * `query kes-period-info`
    * `query ledger-peer-snapshot`
    * `query pool-params`
    * `query pool-state`
    * `query protocol-parameters`
    * `query stake-address-info`
    * `query stake-snapshot`
    * `query tip`
    * `query tx-mempool`
    * `query tx-mempool info`
    * `query tx-mempool next-tx`
    * `query tx-mempool tx-exists`

# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Make it so that commands that output `json` can also output `yaml` as other similar commands have.

Additionally includes the following changes:

* Consistent use `outputFormat` as the name of the output format field
* Simplify with `writeLazyByteStringOutput`

# How to trust this PR

Golden tests

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
