### PR TITLE
More accurate format flags

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -1843,11 +1843,11 @@ flagFormatBech32
 flagFormatBech32 =
   mkFlag "output-bech32" "BECH32" FormatBech32
 
-flagFormatCbor
-  :: FormatCbor :| fs
+flagFormatCborHex
+  :: FormatCborHex :| fs
   => Flag (Vary fs)
-flagFormatCbor =
-  mkFlag "output-cbor" "BASE16 CBOR" FormatCbor
+flagFormatCborHex =
+  mkFlag "output-cbor-hex" "BASE16 CBOR" FormatCborHex
 
 flagFormatHex
   :: FormatHex :| fs

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -1849,6 +1849,12 @@ flagFormatCborHex
 flagFormatCborHex =
   mkFlag "output-cbor-hex" "BASE16 CBOR" FormatCborHex
 
+flagFormatCborBin
+  :: FormatCborBin :| fs
+  => Flag (Vary fs)
+flagFormatCborBin =
+  mkFlag "output-cbor-bin" "CBOR" FormatCborBin
+
 flagFormatHex
   :: FormatHex :| fs
   => Flag (Vary fs)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -138,7 +138,7 @@ data QueryStakeAddressInfoCmdArgs = QueryStakeAddressInfoCmdArgs
 data QueryUTxOCmdArgs = QueryUTxOCmdArgs
   { commons :: !QueryCommons
   , queryFilter :: !QueryUTxOFilter
-  , outputFormat :: !(Vary [FormatCbor, FormatJson, FormatText])
+  , outputFormat :: !(Vary [FormatCborHex, FormatJson, FormatText])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -159,6 +159,7 @@ data QueryLedgerPeerSnapshotCmdArgs = QueryLedgerPeerSnapshotCmdArgs
 
 data QueryProtocolStateCmdArgs = QueryProtocolStateCmdArgs
   { commons :: !QueryCommons
+  , outputFormat :: !(Vary [FormatCborBin, FormatCborHex, FormatJson, FormatYaml])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -138,7 +138,7 @@ data QueryStakeAddressInfoCmdArgs = QueryStakeAddressInfoCmdArgs
 data QueryUTxOCmdArgs = QueryUTxOCmdArgs
   { commons :: !QueryCommons
   , queryFilter :: !QueryUTxOFilter
-  , outputFormat :: !(Vary [FormatCborHex, FormatJson, FormatText])
+  , outputFormat :: !(Vary [FormatCborBin, FormatCborHex, FormatJson, FormatText])
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -455,6 +455,13 @@ pQueryProtocolStateCmd era envCli =
   fmap QueryProtocolStateCmd $
     QueryProtocolStateCmdArgs
       <$> pQueryCommons era envCli
+      <*> pFormatFlags
+        "protocol-state query output"
+        [ flagFormatCborBin
+        , flagFormatCborHex
+        , flagFormatJson & setDefault
+        , flagFormatYaml
+        ]
       <*> pMaybeOutputFile
 
 pAllStakePoolsOrSome :: Parser (AllOrOnly (Hash StakePoolKey))

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -382,7 +382,8 @@ pQueryUTxOCmd era envCli =
       <*> pQueryUTxOFilter
       <*> pFormatFlags
         "utxo query output"
-        [ flagFormatCborHex
+        [ flagFormatCborBin
+        , flagFormatCborHex
         , flagFormatJson & setDefault
         , flagFormatText
         ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -382,7 +382,7 @@ pQueryUTxOCmd era envCli =
       <*> pQueryUTxOFilter
       <*> pFormatFlags
         "utxo query output"
-        [ flagFormatCbor
+        [ flagFormatCborHex
         , flagFormatJson & setDefault
         , flagFormatText
         ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -1253,7 +1253,7 @@ writePoolState outputFormat mOutFile serialisedCurrentEpochState = do
 
 writeFilteredUTxOs
   :: Api.ShelleyBasedEra era
-  -> Vary [FormatCbor, FormatJson, FormatText]
+  -> Vary [FormatCborHex, FormatJson, FormatText]
   -> Maybe (File () Out)
   -> UTxO era
   -> ExceptT QueryCmdError IO ()
@@ -1262,7 +1262,7 @@ writeFilteredUTxOs sbe format mOutFile utxo = do
         shelleyBasedEraConstraints sbe $
           format
             & ( id
-                  . Vary.on (\FormatCbor -> Base16.encode . CBOR.serialize $ toLedgerUTxO sbe utxo)
+                  . Vary.on (\FormatCborHex -> Base16.encode . CBOR.serialize $ toLedgerUTxO sbe utxo)
                   . Vary.on (\FormatJson -> Json.encodeJson utxo)
                   . Vary.on (\FormatText -> strictTextToLazyBytestring $ filteredUTxOsToText sbe utxo)
                   $ Vary.exhaustiveCase

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -1253,7 +1253,7 @@ writePoolState outputFormat mOutFile serialisedCurrentEpochState = do
 
 writeFilteredUTxOs
   :: Api.ShelleyBasedEra era
-  -> Vary [FormatCborHex, FormatJson, FormatText]
+  -> Vary [FormatCborBin, FormatCborHex, FormatJson, FormatText]
   -> Maybe (File () Out)
   -> UTxO era
   -> ExceptT QueryCmdError IO ()
@@ -1262,6 +1262,7 @@ writeFilteredUTxOs sbe format mOutFile utxo = do
         shelleyBasedEraConstraints sbe $
           format
             & ( id
+                  . Vary.on (\FormatCborBin -> CBOR.serialize $ toLedgerUTxO sbe utxo)
                   . Vary.on (\FormatCborHex -> Base16.encode . CBOR.serialize $ toLedgerUTxO sbe utxo)
                   . Vary.on (\FormatJson -> Json.encodeJson utxo)
                   . Vary.on (\FormatText -> strictTextToLazyBytestring $ filteredUTxOsToText sbe utxo)

--- a/cardano-cli/src/Cardano/CLI/EraBased/TextView/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/TextView/Command.hs
@@ -10,7 +10,7 @@ where
 
 import Cardano.Api.Shelley
 
-import Cardano.CLI.Type.Common (FormatCbor, FormatText)
+import Cardano.CLI.Type.Common (FormatCborHex, FormatText)
 
 import Data.Text (Text)
 import Vary
@@ -22,7 +22,7 @@ newtype TextViewCmds era
 data TextViewDecodeCborCmdArgs
   = TextViewDecodeCborCmdArgs
   { inputFile :: !FilePath
-  , outputFormat :: !(Vary [FormatCbor, FormatText])
+  , outputFormat :: !(Vary [FormatCborHex, FormatText])
   , mOutFile :: Maybe (File () Out)
   }
   deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/TextView/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/TextView/Option.hs
@@ -40,7 +40,7 @@ pTextViewCmds =
                 <$> pCBORInFile
                 <*> pFormatFlags
                   "text view info output format"
-                  [ flagFormatCbor
+                  [ flagFormatCborHex
                   , flagFormatText & setDefault
                   ]
                 <*> pMaybeOutputFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/TextView/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/TextView/Run.hs
@@ -42,7 +42,7 @@ runTextViewInfoCmd
     output <-
       outputFormat
         & ( id
-              . Vary.on (\FormatCbor -> pure lbCBOR)
+              . Vary.on (\FormatCborHex -> pure lbCBOR)
               . Vary.on (\FormatText -> LBS.fromStrict . Text.encodeUtf8 <$> cborToText lbCBOR)
               $ Vary.exhaustiveCase
           )

--- a/cardano-cli/src/Cardano/CLI/Type/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Common.hs
@@ -27,6 +27,7 @@ module Cardano.CLI.Type.Common
   , File (..)
   , FileDirection (..)
   , FormatBech32 (..)
+  , FormatCborBin (..)
   , FormatCborHex (..)
   , FormatHex (..)
   , FormatJson (..)
@@ -477,6 +478,9 @@ data FormatBech32 = FormatBech32
   deriving (Enum, Eq, Ord, Show)
 
 data FormatHex = FormatHex
+  deriving (Enum, Eq, Ord, Show)
+
+data FormatCborBin = FormatCborBin
   deriving (Enum, Eq, Ord, Show)
 
 data FormatCborHex = FormatCborHex

--- a/cardano-cli/src/Cardano/CLI/Type/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Common.hs
@@ -27,7 +27,7 @@ module Cardano.CLI.Type.Common
   , File (..)
   , FileDirection (..)
   , FormatBech32 (..)
-  , FormatCbor (..)
+  , FormatCborHex (..)
   , FormatHex (..)
   , FormatJson (..)
   , FormatText (..)
@@ -479,7 +479,7 @@ data FormatBech32 = FormatBech32
 data FormatHex = FormatHex
   deriving (Enum, Eq, Ord, Show)
 
-data FormatCbor = FormatCbor
+data FormatCborHex = FormatCborHex
   deriving (Enum, Eq, Ord, Show)
 
 data FormatJson = FormatJson

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -365,7 +365,10 @@ Usage: cardano-cli query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                 | (--address ADDRESS)
                                 | (--tx-in TX_IN)
                                 )
-                                [--output-cbor | --output-json | --output-text]
+                                [ --output-cbor-hex
+                                | --output-json
+                                | --output-text
+                                ]
                                 [--out-file FILEPATH]
 
   Get a portion of the current UTxO: by tx in, by address or the whole.
@@ -2374,7 +2377,7 @@ Usage: cardano-cli conway query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        | (--address ADDRESS)
                                        | (--tx-in TX_IN)
                                        )
-                                       [ --output-cbor
+                                       [ --output-cbor-hex
                                        | --output-json
                                        | --output-text
                                        ]
@@ -2660,7 +2663,7 @@ Usage: cardano-cli conway text-view decode-cbor
   are stored on disk as TextView files.
 
 Usage: cardano-cli conway text-view decode-cbor --in-file FILEPATH
-                                                  [ --output-cbor
+                                                  [ --output-cbor-hex
                                                   | --output-text
                                                   ]
                                                   [--out-file FILEPATH]
@@ -4635,7 +4638,7 @@ Usage: cardano-cli latest query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        | (--address ADDRESS)
                                        | (--tx-in TX_IN)
                                        )
-                                       [ --output-cbor
+                                       [ --output-cbor-hex
                                        | --output-json
                                        | --output-text
                                        ]
@@ -4921,7 +4924,7 @@ Usage: cardano-cli latest text-view decode-cbor
   are stored on disk as TextView files.
 
 Usage: cardano-cli latest text-view decode-cbor --in-file FILEPATH
-                                                  [ --output-cbor
+                                                  [ --output-cbor-hex
                                                   | --output-text
                                                   ]
                                                   [--out-file FILEPATH]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -388,6 +388,11 @@ Usage: cardano-cli query protocol-state [--cardano-mode [--epoch-slots SLOTS]]
                                           (--mainnet | --testnet-magic NATURAL)
                                           --socket-path SOCKET_PATH
                                           [--volatile-tip | --immutable-tip]
+                                          [ --output-cbor-bin
+                                          | --output-cbor-hex
+                                          | --output-json
+                                          | --output-yaml
+                                          ]
                                           [--out-file FILEPATH]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
@@ -2165,6 +2170,11 @@ Usage: cardano-cli conway query protocol-state
                                                  --socket-path SOCKET_PATH
                                                  [ --volatile-tip
                                                  | --immutable-tip
+                                                 ]
+                                                 [ --output-cbor-bin
+                                                 | --output-cbor-hex
+                                                 | --output-json
+                                                 | --output-yaml
                                                  ]
                                                  [--out-file FILEPATH]
 
@@ -4427,6 +4437,11 @@ Usage: cardano-cli latest query protocol-state
                                                  --socket-path SOCKET_PATH
                                                  [ --volatile-tip
                                                  | --immutable-tip
+                                                 ]
+                                                 [ --output-cbor-bin
+                                                 | --output-cbor-hex
+                                                 | --output-json
+                                                 | --output-yaml
                                                  ]
                                                  [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -365,7 +365,8 @@ Usage: cardano-cli query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                 | (--address ADDRESS)
                                 | (--tx-in TX_IN)
                                 )
-                                [ --output-cbor-hex
+                                [ --output-cbor-bin
+                                | --output-cbor-hex
                                 | --output-json
                                 | --output-text
                                 ]
@@ -2377,7 +2378,8 @@ Usage: cardano-cli conway query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        | (--address ADDRESS)
                                        | (--tx-in TX_IN)
                                        )
-                                       [ --output-cbor-hex
+                                       [ --output-cbor-bin
+                                       | --output-cbor-hex
                                        | --output-json
                                        | --output-text
                                        ]
@@ -4638,7 +4640,8 @@ Usage: cardano-cli latest query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        | (--address ADDRESS)
                                        | (--tx-in TX_IN)
                                        )
-                                       [ --output-cbor-hex
+                                       [ --output-cbor-bin
+                                       | --output-cbor-hex
                                        | --output-json
                                        | --output-text
                                        ]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_protocol-state.cli
@@ -8,6 +8,11 @@ Usage: cardano-cli conway query protocol-state
                                                  [ --volatile-tip
                                                  | --immutable-tip
                                                  ]
+                                                 [ --output-cbor-bin
+                                                 | --output-cbor-hex
+                                                 | --output-json
+                                                 | --output-yaml
+                                                 ]
                                                  [--out-file FILEPATH]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
@@ -30,5 +35,9 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
+  --output-cbor-bin        Format protocol-state query output to CBOR.
+  --output-cbor-hex        Format protocol-state query output to BASE16 CBOR.
+  --output-json            Format protocol-state query output to JSON (default).
+  --output-yaml            Format protocol-state query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
@@ -6,7 +6,8 @@ Usage: cardano-cli conway query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        | (--address ADDRESS)
                                        | (--tx-in TX_IN)
                                        )
-                                       [ --output-cbor-hex
+                                       [ --output-cbor-bin
+                                       | --output-cbor-hex
                                        | --output-json
                                        | --output-text
                                        ]
@@ -35,6 +36,7 @@ Available options:
                            testnets).
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
   --tx-in TX_IN            Filter by transaction input (TxId#TxIx).
+  --output-cbor-bin        Format utxo query output to CBOR.
   --output-cbor-hex        Format utxo query output to BASE16 CBOR.
   --output-json            Format utxo query output to JSON (default).
   --output-text            Format utxo query output to TEXT.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
@@ -6,7 +6,7 @@ Usage: cardano-cli conway query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        | (--address ADDRESS)
                                        | (--tx-in TX_IN)
                                        )
-                                       [ --output-cbor
+                                       [ --output-cbor-hex
                                        | --output-json
                                        | --output-text
                                        ]
@@ -35,7 +35,7 @@ Available options:
                            testnets).
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
   --tx-in TX_IN            Filter by transaction input (TxId#TxIx).
-  --output-cbor            Format utxo query output to BASE16 CBOR.
+  --output-cbor-hex        Format utxo query output to BASE16 CBOR.
   --output-json            Format utxo query output to JSON (default).
   --output-text            Format utxo query output to TEXT.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_text-view_decode-cbor.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_text-view_decode-cbor.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli conway text-view decode-cbor --in-file FILEPATH
-                                                  [ --output-cbor
+                                                  [ --output-cbor-hex
                                                   | --output-text
                                                   ]
                                                   [--out-file FILEPATH]
@@ -8,7 +8,7 @@ Usage: cardano-cli conway text-view decode-cbor --in-file FILEPATH
 
 Available options:
   --in-file FILEPATH       CBOR input file.
-  --output-cbor            Format text view info output format to BASE16 CBOR.
+  --output-cbor-hex        Format text view info output format to BASE16 CBOR.
   --output-text            Format text view info output format to TEXT
                            (default).
   --out-file FILEPATH      Optional output file. Default is to write to stdout.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_protocol-state.cli
@@ -8,6 +8,11 @@ Usage: cardano-cli latest query protocol-state
                                                  [ --volatile-tip
                                                  | --immutable-tip
                                                  ]
+                                                 [ --output-cbor-bin
+                                                 | --output-cbor-hex
+                                                 | --output-json
+                                                 | --output-yaml
+                                                 ]
                                                  [--out-file FILEPATH]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
@@ -30,5 +35,9 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
+  --output-cbor-bin        Format protocol-state query output to CBOR.
+  --output-cbor-hex        Format protocol-state query output to BASE16 CBOR.
+  --output-json            Format protocol-state query output to JSON (default).
+  --output-yaml            Format protocol-state query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_utxo.cli
@@ -6,7 +6,8 @@ Usage: cardano-cli latest query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        | (--address ADDRESS)
                                        | (--tx-in TX_IN)
                                        )
-                                       [ --output-cbor-hex
+                                       [ --output-cbor-bin
+                                       | --output-cbor-hex
                                        | --output-json
                                        | --output-text
                                        ]
@@ -35,6 +36,7 @@ Available options:
                            testnets).
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
   --tx-in TX_IN            Filter by transaction input (TxId#TxIx).
+  --output-cbor-bin        Format utxo query output to CBOR.
   --output-cbor-hex        Format utxo query output to BASE16 CBOR.
   --output-json            Format utxo query output to JSON (default).
   --output-text            Format utxo query output to TEXT.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_utxo.cli
@@ -6,7 +6,7 @@ Usage: cardano-cli latest query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        | (--address ADDRESS)
                                        | (--tx-in TX_IN)
                                        )
-                                       [ --output-cbor
+                                       [ --output-cbor-hex
                                        | --output-json
                                        | --output-text
                                        ]
@@ -35,7 +35,7 @@ Available options:
                            testnets).
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
   --tx-in TX_IN            Filter by transaction input (TxId#TxIx).
-  --output-cbor            Format utxo query output to BASE16 CBOR.
+  --output-cbor-hex        Format utxo query output to BASE16 CBOR.
   --output-json            Format utxo query output to JSON (default).
   --output-text            Format utxo query output to TEXT.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_text-view_decode-cbor.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_text-view_decode-cbor.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli latest text-view decode-cbor --in-file FILEPATH
-                                                  [ --output-cbor
+                                                  [ --output-cbor-hex
                                                   | --output-text
                                                   ]
                                                   [--out-file FILEPATH]
@@ -8,7 +8,7 @@ Usage: cardano-cli latest text-view decode-cbor --in-file FILEPATH
 
 Available options:
   --in-file FILEPATH       CBOR input file.
-  --output-cbor            Format text view info output format to BASE16 CBOR.
+  --output-cbor-hex        Format text view info output format to BASE16 CBOR.
   --output-text            Format text view info output format to TEXT
                            (default).
   --out-file FILEPATH      Optional output file. Default is to write to stdout.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_protocol-state.cli
@@ -2,6 +2,11 @@ Usage: cardano-cli query protocol-state [--cardano-mode [--epoch-slots SLOTS]]
                                           (--mainnet | --testnet-magic NATURAL)
                                           --socket-path SOCKET_PATH
                                           [--volatile-tip | --immutable-tip]
+                                          [ --output-cbor-bin
+                                          | --output-cbor-hex
+                                          | --output-json
+                                          | --output-yaml
+                                          ]
                                           [--out-file FILEPATH]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
@@ -24,5 +29,9 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
+  --output-cbor-bin        Format protocol-state query output to CBOR.
+  --output-cbor-hex        Format protocol-state query output to BASE16 CBOR.
+  --output-json            Format protocol-state query output to JSON (default).
+  --output-yaml            Format protocol-state query output to YAML.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_utxo.cli
@@ -6,7 +6,8 @@ Usage: cardano-cli query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                 | (--address ADDRESS)
                                 | (--tx-in TX_IN)
                                 )
-                                [ --output-cbor-hex
+                                [ --output-cbor-bin
+                                | --output-cbor-hex
                                 | --output-json
                                 | --output-text
                                 ]
@@ -35,6 +36,7 @@ Available options:
                            testnets).
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
   --tx-in TX_IN            Filter by transaction input (TxId#TxIx).
+  --output-cbor-bin        Format utxo query output to CBOR.
   --output-cbor-hex        Format utxo query output to BASE16 CBOR.
   --output-json            Format utxo query output to JSON (default).
   --output-text            Format utxo query output to TEXT.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_utxo.cli
@@ -6,7 +6,10 @@ Usage: cardano-cli query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                 | (--address ADDRESS)
                                 | (--tx-in TX_IN)
                                 )
-                                [--output-cbor | --output-json | --output-text]
+                                [ --output-cbor-hex
+                                | --output-json
+                                | --output-text
+                                ]
                                 [--out-file FILEPATH]
 
   Get a portion of the current UTxO: by tx in, by address or the whole.
@@ -32,7 +35,7 @@ Available options:
                            testnets).
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
   --tx-in TX_IN            Filter by transaction input (TxId#TxIx).
-  --output-cbor            Format utxo query output to BASE16 CBOR.
+  --output-cbor-hex        Format utxo query output to BASE16 CBOR.
   --output-json            Format utxo query output to JSON (default).
   --output-text            Format utxo query output to TEXT.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    The `--output-cbor` flag has been split to `--output-cbor-bin` and `--output-cbor-hex`.
    The `query protocol-state` command now takes output format flags:
    * `--output-cbor-bin`
    * `--output-cbor-hex`
    * `--output-json`
    * `--output-yaml`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Implements [ADR-012](https://github.com/input-output-hk/cardano-node-wiki/blob/main/docs/ADR-012-standardise-CLI-multiple-choice-flags-construction.md)

# How to trust this PR

Golden tests.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
