### PR TITLE
Simplify by not using `QueryStakeAddressInfoCmdArgs` unnecessarily

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -979,11 +979,11 @@ runQueryStakeAddressInfoCmd
         & onLeft (left . QueryCmdUnsupportedNtcVersion)
     sbe <- requireShelleyBasedEra era & onNothing (left QueryCmdByronEra)
 
-    said <- callQueryStakeAddressInfoCmd commons addr
+    said <- getQueryStakeAddressInfo commons addr
 
     writeStakeAddressInfo sbe said outputFormat mOutFile
 
--- | Container for data returned by 'callQueryStakeAddressInfoCmd' where:
+-- | Container for data returned by 'getQueryStakeAddressInfo' where:
 data StakeAddressInfoData = StakeAddressInfoData
   { rewards :: DelegationsAndRewards
   -- ^ Rewards: map of stake addresses to pool ID and rewards balance.
@@ -996,11 +996,11 @@ data StakeAddressInfoData = StakeAddressInfoData
   -- ^ Delegatees: map of stake addresses and their vote delegation preference.
   }
 
-callQueryStakeAddressInfoCmd
+getQueryStakeAddressInfo
   :: Cmd.QueryCommons
   -> StakeAddress
   -> ExceptT QueryCmdError IO StakeAddressInfoData
-callQueryStakeAddressInfoCmd
+getQueryStakeAddressInfo
   Cmd.QueryCommons
     { Cmd.nodeConnInfo = nodeConnInfo@LocalNodeConnectInfo{localNodeNetworkId = networkId}
     , Cmd.target
@@ -1836,7 +1836,7 @@ runQuerySPOStakeDistribution
       Map.fromList . concat
         <$> traverse
           ( \stakeAddr -> do
-              info <- callQueryStakeAddressInfoCmd commons stakeAddr
+              info <- getQueryStakeAddressInfo commons stakeAddr
               return $
                 [ (spo, delegatee)
                 | (Just spo, delegatee) <-


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Simplify code by not using `QueryStakeAddressInfoCmdArgs` unnecessarily.
    Also fixes `query spo-stake-distribution` command so that the output format flags are respected.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Don't build a value of a data type if it doesn't make sense to use all the fields.  Just pass the values directly to the function instead.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
