### PR TITLE
Change default era value from Babbage to Conway

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -407,7 +407,7 @@ pAnyShelleyBasedEra envCli =
             mconcat [Opt.long "conway-era", Opt.help "Specify the Conway era"]
         ]
       , maybeToList $ pure <$> envCliAnyEon envCli
-      , pure $ pure $ EraInEon ShelleyBasedEraBabbage
+      , pure $ pure $ EraInEon ShelleyBasedEraConway
       ]
 
 deprecationText :: String


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Change default era value from `babbage` to `conway`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Since most Babbage commands have been decommissioned, it makes no sense for `babbage` to be the default era, when none is provided to the CLI. This PR changes the default to `conway` instead. Additionally, it fixes an upstream bug in `cardano-testnet` where the default era was passed back as an input to `cardano-cli`.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
