### PR TITLE
Update to new `cardano-api`'s modules structure. Replace usage of parital `IsString` with parsers

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2025-06-06T12:15:17Z
-  , cardano-haskell-packages 2025-06-07T03:18:32Z
+  , cardano-haskell-packages 2025-06-11T08:32:56Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -371,7 +371,6 @@ test-suite cardano-cli-test
     microlens-aeson,
     mmorph,
     monad-control,
-    parsec,
     regex-tdfa,
     resourcet,
     tasty,

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -241,7 +241,7 @@ library
     binary,
     bytestring,
     canonical-json,
-    cardano-api ^>=10.16,
+    cardano-api ^>=10.17,
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class ^>=2.2,

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -287,7 +287,6 @@ library
     text,
     time,
     transformers,
-    transformers-except ^>=0.1.3,
     unliftio-core,
     utf8-string,
     validation,

--- a/cardano-cli/src/Cardano/CLI/Byron/Delegation.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Delegation.hs
@@ -16,6 +16,9 @@ where
 import Cardano.Api.Byron (ACertificate (delegateVK))
 import Cardano.Api.Byron hiding (delegateVK)
 import Cardano.Api.Ledger qualified as L
+import Cardano.Api.Monad.Error
+import Cardano.Api.Pretty
+import Cardano.Api.Serialise.Raw
 
 import Cardano.CLI.Byron.Key (ByronKeyFailure, renderByronKeyFailure)
 import Cardano.CLI.Type.Common (CertificateFile (..))

--- a/cardano-cli/src/Cardano/CLI/Byron/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Genesis.hs
@@ -13,14 +13,14 @@ module Cardano.CLI.Byron.Genesis
   )
 where
 
-import Cardano.Api (Doc, Error (..), Key (..), NetworkId, pretty, pshow, writeSecrets)
-import Cardano.Api.Byron
-  ( ByronKey
-  , SerialiseAsRawBytes (..)
-  , SigningKey (..)
-  , toByronRequiresNetworkMagic
-  )
+import Cardano.Api.Byron (ByronKey, NetworkId, SigningKey (..), toByronRequiresNetworkMagic)
 import Cardano.Api.Byron qualified as Byron
+import Cardano.Api.Error
+import Cardano.Api.IO
+import Cardano.Api.Key
+import Cardano.Api.Monad.Error
+import Cardano.Api.Pretty
+import Cardano.Api.Serialise.Raw
 
 import Cardano.CLI.Byron.Delegation
 import Cardano.CLI.Byron.Key
@@ -30,10 +30,6 @@ import Cardano.CLI.Type.Common (GenesisFile (..))
 import Cardano.Crypto qualified as Crypto
 import Cardano.Prelude (canonicalDecodePretty, canonicalEncodePretty)
 
-import Control.Monad.IO.Class
-import Control.Monad.Trans (MonadTrans (..))
-import Control.Monad.Trans.Except (ExceptT (..), withExceptT)
-import Control.Monad.Trans.Except.Extra (firstExceptT, left, right)
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as LB
 import Data.List qualified as List

--- a/cardano-cli/src/Cardano/CLI/Byron/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Key.hs
@@ -17,6 +17,10 @@ module Cardano.CLI.Byron.Key
 where
 
 import Cardano.Api.Byron
+import Cardano.Api.Key
+import Cardano.Api.Monad.Error
+import Cardano.Api.Pretty
+import Cardano.Api.Serialise.Raw
 
 import Cardano.CLI.Type.Common
 import Cardano.Crypto.Signing qualified as Crypto

--- a/cardano-cli/src/Cardano/CLI/Byron/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parser.hs
@@ -88,27 +88,27 @@ parseByronCommands envCli =
   asum
     [ subParser'
         "key"
-        ( Opt.info (asum $ map Opt.subparser (parseKeyRelatedValues envCli)) $
+        ( Opt.info (asum (map Opt.subparser (parseKeyRelatedValues envCli)) <**> Opt.helper) $
             Opt.progDesc "Byron key utility commands"
         )
     , subParser'
         "transaction"
-        ( Opt.info (asum $ map Opt.subparser (parseTxRelatedValues envCli)) $
+        ( Opt.info (asum (map Opt.subparser (parseTxRelatedValues envCli)) <**> Opt.helper) $
             Opt.progDesc "Byron transaction commands"
         )
     , subParser'
         "genesis"
-        ( Opt.info (asum $ map Opt.subparser parseGenesisRelatedValues) $
+        ( Opt.info (asum (map Opt.subparser parseGenesisRelatedValues) <**> Opt.helper) $
             Opt.progDesc "Byron genesis block commands"
         )
     , subParser'
         "governance"
-        ( Opt.info (NodeCmds <$> Opt.subparser (pNodeCmds envCli)) $
+        ( Opt.info ((NodeCmds <$> Opt.subparser (pNodeCmds envCli)) <**> Opt.helper) $
             Opt.progDesc "Byron governance commands"
         )
     , subParser'
         "miscellaneous"
-        ( Opt.info (asum $ map Opt.subparser parseMiscellaneous) $
+        ( Opt.info (asum (map Opt.subparser parseMiscellaneous) <**> Opt.helper) $
             Opt.progDesc "Byron miscellaneous commands"
         )
     , NodeCmds <$> pNodeCmdBackwardCompatible envCli
@@ -362,16 +362,16 @@ pNodeCmds :: EnvCli -> Mod CommandFields NodeCmds
 pNodeCmds envCli =
   mconcat
     [ Opt.command "create-update-proposal" $
-        Opt.info (parseByronUpdateProposal envCli) $
+        Opt.info (parseByronUpdateProposal envCli <**> Opt.helper) $
           Opt.progDesc "Create an update proposal."
     , Opt.command "create-proposal-vote" $
-        Opt.info (parseByronVote envCli) $
+        Opt.info (parseByronVote envCli <**> Opt.helper) $
           Opt.progDesc "Create an update proposal vote."
     , Opt.command "submit-update-proposal" $
-        Opt.info (parseByronUpdateProposalSubmission envCli) $
+        Opt.info (parseByronUpdateProposalSubmission envCli <**> Opt.helper) $
           Opt.progDesc "Submit an update proposal."
     , Opt.command "submit-proposal-vote" $
-        Opt.info (parseByronVoteSubmission envCli) $
+        Opt.info (parseByronVoteSubmission envCli <**> Opt.helper) $
           Opt.progDesc "Submit a proposal vote."
     ]
 

--- a/cardano-cli/src/Cardano/CLI/Byron/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parser.hs
@@ -25,10 +25,9 @@ module Cardano.CLI.Byron.Parser
 where
 
 import Cardano.Api hiding (GenesisParameters, UpdateProposal, parseTxIn)
-import Cardano.Api.Byron (ByronProtocolParametersUpdate (..), toByronLovelace)
+import Cardano.Api.Byron (ByronProtocolParametersUpdate (..))
 import Cardano.Api.Byron qualified as Byron
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley (ReferenceScript (ReferenceScriptNone))
 
 import Cardano.CLI.Byron.Command
 import Cardano.CLI.Byron.Genesis

--- a/cardano-cli/src/Cardano/CLI/Byron/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parser.hs
@@ -24,7 +24,7 @@ module Cardano.CLI.Byron.Parser
   )
 where
 
-import Cardano.Api hiding (GenesisParameters, UpdateProposal)
+import Cardano.Api hiding (GenesisParameters, UpdateProposal, parseTxIn)
 import Cardano.Api.Byron (ByronProtocolParametersUpdate (..), toByronLovelace)
 import Cardano.Api.Byron qualified as Byron
 import Cardano.Api.Ledger qualified as L
@@ -35,7 +35,7 @@ import Cardano.CLI.Byron.Genesis
 import Cardano.CLI.Byron.Key
 import Cardano.CLI.Byron.Tx
 import Cardano.CLI.Environment (EnvCli (..))
-import Cardano.CLI.EraBased.Common.Option hiding (parseLovelace, parseTxIn)
+import Cardano.CLI.EraBased.Common.Option hiding (parseLovelace)
 import Cardano.CLI.Parser (commandWithMetavar)
 import Cardano.CLI.Run (ClientCommand (ByronCommand))
 import Cardano.CLI.Type.Common

--- a/cardano-cli/src/Cardano/CLI/Byron/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Run.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 
+{- HLINT ignore "Use newtype instead of data" -}
+
 module Cardano.CLI.Byron.Run
   ( ByronClientCmdError
   , renderByronClientCmdError
@@ -10,8 +12,12 @@ module Cardano.CLI.Byron.Run
   )
 where
 
-import Cardano.Api hiding (GenesisParameters, UpdateProposal)
-import Cardano.Api.Byron (SomeByronSigningKey (..), serializeByronTx)
+import Cardano.Api hiding (GenesisParameters, UpdateProposal, txId)
+import Cardano.Api.Byron
+  ( SigningKey (ByronSigningKey, ByronSigningKeyLegacy)
+  , SomeByronSigningKey (..)
+  , VerificationKey (ByronVerificationKey)
+  )
 import Cardano.Api.Byron qualified as Byron
 
 import Cardano.CLI.Byron.Command

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -25,7 +25,6 @@ where
 
 import Cardano.Api
 import Cardano.Api.Byron qualified as Byron
-import Cardano.Api.Consensus (ByronBlock, EraMismatch (..), GenTx (..))
 import Cardano.Api.Consensus qualified as Byron
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Network qualified as Net.Tx
@@ -158,7 +157,7 @@ txSpendGenesisUTxOByronPBFT gc nId sk (ByronAddress bAddr) outs =
           let bWit = fromByronWitness sk nId txBody
            in makeSignedByronTransaction [bWit] txBody
  where
-  ByronVerificationKey vKey = byronWitnessToVerKey sk
+  Byron.ByronVerificationKey vKey = byronWitnessToVerKey sk
 
   txIn :: Byron.TxIn
   txIn = genesisUTxOTxIn gc vKey bAddr

--- a/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 
+{- HLINT ignore "Use newtype instead of data" -}
+
 module Cardano.CLI.Byron.UpdateProposal
   ( ByronUpdateProposalError (..)
   , runProposalCreation
@@ -21,7 +23,6 @@ import Cardano.Api.Byron
   , toByronLedgerUpdateProposal
   )
 import Cardano.Api.Byron qualified as Byron
-import Cardano.Api.Consensus (condense, txId)
 
 import Cardano.CLI.Byron.Key (readByronSigningKey)
 import Cardano.CLI.Byron.Tx (nodeSubmitTx)

--- a/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
@@ -12,6 +12,16 @@ module Cardano.CLI.Byron.Vote
   )
 where
 
+import Cardano.Api
+  ( Doc
+  , ExceptT
+  , SocketPath
+  , deserialiseFromRawBytes
+  , hoistEither
+  , liftIO
+  , pretty
+  , serialiseToRawBytes
+  )
 import Cardano.Api.Byron
 import Cardano.Api.Consensus (condense, txId)
 

--- a/cardano-cli/src/Cardano/CLI/Compatible/Governance/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Governance/Command.hs
@@ -8,8 +8,6 @@ module Cardano.CLI.Compatible.Governance.Command
 where
 
 import Cardano.Api
-import Cardano.Api.Ledger (Coin)
-import Cardano.Api.Shelley (VrfKey)
 
 import Cardano.CLI.EraBased.Governance.Actions.Command
 import Cardano.CLI.EraBased.Governance.Option

--- a/cardano-cli/src/Cardano/CLI/Compatible/StakeAddress/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/StakeAddress/Command.hs
@@ -7,8 +7,9 @@ module Cardano.CLI.Compatible.StakeAddress.Command
   )
 where
 
+import Cardano.Api.Era
+import Cardano.Api.IO
 import Cardano.Api.Ledger (Coin)
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Type.Key
 

--- a/cardano-cli/src/Cardano/CLI/Compatible/StakeAddress/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/StakeAddress/Run.hs
@@ -12,7 +12,6 @@ where
 
 import Cardano.Api
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.Compatible.StakeAddress.Command

--- a/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Command.hs
@@ -9,8 +9,7 @@ module Cardano.CLI.Compatible.StakePool.Command
   )
 where
 
-import Cardano.Api.Ledger (Coin)
-import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api
 
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Key

--- a/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Run.hs
@@ -8,8 +8,8 @@ module Cardano.CLI.Compatible.StakePool.Run
   )
 where
 
+import Cardano.Api
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.Compatible.StakePool.Command

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Command.hs
@@ -12,7 +12,6 @@ module Cardano.CLI.Compatible.Transaction.Command
 where
 
 import Cardano.Api
-import Cardano.Api.Ledger hiding (TxIn, VotingProcedures)
 
 import Cardano.CLI.EraBased.Script.Certificate.Type
 import Cardano.CLI.EraBased.Script.Proposal.Type

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Option.hs
@@ -17,6 +17,7 @@ import Cardano.CLI.Environment
 import Cardano.CLI.EraBased.Common.Option hiding (pRefScriptFp, pTxOutDatum, pVoteFiles)
 import Cardano.CLI.EraBased.Script.Vote.Type
 import Cardano.CLI.Parser
+import Cardano.CLI.Read
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Governance
 
@@ -113,7 +114,7 @@ pTxOutDatum =
 
   pTxOutDatumByHashOnly =
     fmap TxOutDatumByHashOnly $
-      Opt.option (readerFromParsecParser parseHash) $
+      Opt.option (readerFromParsecParser parseScriptDataHash) $
         mconcat
           [ Opt.long "tx-out-datum-hash"
           , Opt.metavar "HASH"

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
@@ -12,11 +12,12 @@ module Cardano.CLI.Compatible.Transaction.Run
   )
 where
 
-import Cardano.Api
+import Cardano.Api hiding (VotingProcedures)
 import Cardano.Api.Compatible
 import Cardano.Api.Experimental qualified as Exp
-import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley hiding (VotingProcedures)
+import Cardano.Api.Ledger qualified as L hiding
+  ( VotingProcedures
+  )
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.Compatible.Transaction.Command

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/TxOut.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/TxOut.hs
@@ -8,7 +8,6 @@ module Cardano.CLI.Compatible.Transaction.TxOut
 where
 
 import Cardano.Api
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.EraBased.Script.Read.Common

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -16,11 +16,9 @@ module Cardano.CLI.EraBased.Common.Option where
 
 import Cardano.Api
 import Cardano.Api.Experimental
-import Cardano.Api.Internal.Error
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Network qualified as Consensus
 import Cardano.Api.Parser.Text qualified as P
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Environment (EnvCli (..), envCliAnyEon)
 import Cardano.CLI.EraBased.Script.Certificate.Type (CliCertificateScriptRequirements)
@@ -52,7 +50,7 @@ import Data.Bits (Bits, toIntegralSized)
 import Data.ByteString (ByteString)
 import Data.ByteString.Base16 qualified as B16
 import Data.ByteString.Char8 qualified as BSC
-import Data.Data (Proxy (..), Typeable, typeRep)
+import Data.Data (Typeable, typeRep)
 import Data.Foldable
 import Data.Functor (($>))
 import Data.IP qualified as IP

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -19,6 +19,7 @@ import Cardano.Api.Experimental
 import Cardano.Api.Internal.Error
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Network qualified as Consensus
+import Cardano.Api.Parser.Text qualified as P
 import Cardano.Api.Shelley
 
 import Cardano.CLI.Environment (EnvCli (..), envCliAnyEon)
@@ -68,12 +69,6 @@ import Lens.Micro
 import Network.Socket (PortNumber)
 import Options.Applicative hiding (help, str)
 import Options.Applicative qualified as Opt
-import Text.Parsec ((<?>))
-import Text.Parsec qualified as Parsec
-import Text.Parsec.Error qualified as Parsec
-import Text.Parsec.Language qualified as Parsec
-import Text.Parsec.String qualified as Parsec
-import Text.Parsec.Token qualified as Parsec
 import Text.Read (readEither, readMaybe)
 import Text.Read qualified as Read
 import Vary (Vary, (:|))
@@ -101,7 +96,7 @@ bounded t = Opt.eitherReader $ \s -> do
   when (i > fromIntegral (maxBound @a)) $ Left $ t <> " must not greater than " <> show (maxBound @a)
   pure (fromIntegral i)
 
-parseFilePath :: String -> String -> Opt.Parser FilePath
+parseFilePath :: String -> String -> Parser FilePath
 parseFilePath optname desc =
   Opt.strOption
     ( Opt.long optname
@@ -257,35 +252,6 @@ pSocketPath envCli =
         pure . File <$> maybeToList (envCliSocketPath envCli)
       ]
 
-readerFromParsecParser :: Parsec.Parser a -> Opt.ReadM a
-readerFromParsecParser p =
-  Opt.eitherReader (first formatError . Parsec.parse (p <* Parsec.eof) "")
- where
-  formatError err =
-    Parsec.showErrorMessages
-      "or"
-      "unknown parse error"
-      "expecting"
-      "unexpected"
-      "end of input"
-      (Parsec.errorMessages err)
-
-parseTxIn :: Parsec.Parser TxIn
-parseTxIn = TxIn <$> parseTxId <*> (Parsec.char '#' *> parseTxIx)
-
-parseTxId :: Parsec.Parser TxId
-parseTxId = do
-  str' <- some Parsec.hexDigit <?> "transaction id (hexadecimal)"
-  case deserialiseFromRawBytesHex (BSC.pack str') of
-    Right addr -> return addr
-    Left e -> fail $ docToString $ "Incorrect transaction id format: " <> prettyError e
-
-parseTxIx :: Parsec.Parser TxIx
-parseTxIx = TxIx . fromIntegral <$> decimal
-
-decimal :: Parsec.Parser Integer
-Parsec.TokenParser{Parsec.decimal = decimal} = Parsec.haskell
-
 pStakeIdentifier :: Maybe String -> Parser StakeIdentifier
 pStakeIdentifier prefix =
   asum
@@ -432,9 +398,9 @@ pFileOutDirection l h = File <$> parseFilePath l h
 pFileInDirection :: String -> String -> Parser (File a In)
 pFileInDirection l h = File <$> parseFilePath l h
 
-parseLovelace :: Parsec.Parser Lovelace
+parseLovelace :: P.Parser Lovelace
 parseLovelace = do
-  i <- decimal
+  i <- P.parseDecimal
   if i > toInteger (maxBound :: Word64)
     then fail $ show i <> " lovelace exceeds the Word64 upper bound"
     else return $ L.Coin i
@@ -1577,9 +1543,9 @@ pWithdrawal balance =
       , "a script witness."
       ]
 
-  parseWithdrawal :: Parsec.Parser (StakeAddress, Lovelace)
+  parseWithdrawal :: P.Parser (StakeAddress, Lovelace)
   parseWithdrawal =
-    (,) <$> parseAddressAny <* Parsec.char '+' <*> parseLovelace
+    (,) <$> parseAddressAny <* P.char '+' <*> parseLovelace
 
 pWithdrawalScriptWitness
   :: BalanceTxExecUnits -> String -> Maybe String -> String -> Parser CliWithdrawalScriptRequirements
@@ -1651,7 +1617,7 @@ pRequiredSigner =
         "Input filepath of the signing key (zero or more) whose signature is required."
   sPayKeyHash :: Parser (Hash PaymentKey)
   sPayKeyHash =
-    Opt.option (readerFromParsecParser parseHash) $
+    Opt.option (readerFromParsecParser parseHexHash) $
       mconcat
         [ Opt.long "required-signer-hash"
         , Opt.metavar "HASH"
@@ -2108,7 +2074,7 @@ pReturnCollateral =
 
 pTotalCollateral :: Parser Lovelace
 pTotalCollateral =
-  Opt.option (L.Coin <$> readerFromParsecParser decimal) $
+  Opt.option (L.Coin <$> readerFromParsecParser P.parseDecimal) $
     mconcat
       [ Opt.long "tx-total-collateral"
       , Opt.metavar "INTEGER"
@@ -2196,7 +2162,7 @@ pTxOutDatum =
  where
   pTxOutDatumByHashOnly =
     fmap TxOutDatumByHashOnly $
-      Opt.option (readerFromParsecParser parseHash) $
+      Opt.option (readerFromParsecParser parseScriptDataHash) $
         mconcat
           [ Opt.long "tx-out-datum-hash"
           , Opt.metavar "HASH"
@@ -2920,19 +2886,19 @@ pMaxTransactionSize =
 pairIntegralReader :: (Typeable a, Integral a, Bits a) => ReadM (a, a)
 pairIntegralReader = readerFromParsecParser pairIntegralParsecParser
 
-pairIntegralParsecParser :: (Typeable a, Integral a, Bits a) => Parsec.Parser (a, a)
+pairIntegralParsecParser :: (Typeable a, Integral a, Bits a) => P.Parser (a, a)
 pairIntegralParsecParser = do
-  Parsec.spaces -- Skip initial spaces
-  void $ Parsec.char '('
-  Parsec.spaces -- Skip spaces between opening paren and lhs
+  P.spaces -- Skip initial spaces
+  void $ P.char '('
+  P.spaces -- Skip spaces between opening paren and lhs
   lhs :: a <- integralParsecParser
-  Parsec.spaces -- Skip spaces between lhs and comma
-  void $ Parsec.char ','
-  Parsec.spaces -- Skip spaces between comma and rhs
+  P.spaces -- Skip spaces between lhs and comma
+  void $ P.char ','
+  P.spaces -- Skip spaces between comma and rhs
   rhs :: a <- integralParsecParser
-  Parsec.spaces -- Skip spaces between comma and closing paren
-  void $ Parsec.char ')'
-  Parsec.spaces -- Skip trailing spaces
+  P.spaces -- Skip spaces between comma and closing paren
+  void $ P.char ')'
+  P.spaces -- Skip trailing spaces
   return (lhs, rhs)
 
 -- | @integralReader@ is a reader for a word of type @a@. When it fails
@@ -2941,9 +2907,9 @@ pairIntegralParsecParser = do
 integralReader :: (Typeable a, Integral a, Bits a) => ReadM a
 integralReader = readerFromParsecParser integralParsecParser
 
-integralParsecParser :: forall a. (Typeable a, Integral a, Bits a) => Parsec.Parser a
+integralParsecParser :: forall a. (Typeable a, Integral a, Bits a) => P.Parser a
 integralParsecParser = do
-  i <- decimal
+  i <- P.parseDecimal
   case toIntegralSized i of
     Nothing -> fail $ "Cannot parse " <> show i <> " as a " <> typeName
     Just n -> return n
@@ -2953,9 +2919,9 @@ integralParsecParser = do
 nonZeroReader :: ReadM (NonZero Word64)
 nonZeroReader = readerFromParsecParser nonZeroParsecParser
 
-nonZeroParsecParser :: Parsec.Parser (NonZero Word64)
+nonZeroParsecParser :: P.Parser (NonZero Word64)
 nonZeroParsecParser = do
-  i <- decimal -- Parses a non-negative whole number, so we only need to check for zero.
+  i <- P.parseDecimal
   case nonZero $ fromIntegral i of
     Nothing -> fail $ "Cannot parse " <> show i <> " as a (NonZero Word64)"
     Just nz -> return nz
@@ -3074,15 +3040,15 @@ pExtraEntropy =
           ]
     ]
  where
-  parsePraosNonce :: Parsec.Parser PraosNonce
+  parsePraosNonce :: P.Parser PraosNonce
   parsePraosNonce = makePraosNonce <$> parseEntropyBytes
 
-  parseEntropyBytes :: Parsec.Parser ByteString
+  parseEntropyBytes :: P.Parser ByteString
   parseEntropyBytes =
     either fail return
       . B16.decode
       . BSC.pack
-      =<< some Parsec.hexDigit
+      =<< some P.hexDigit
 
 pUTxOCostPerByte :: Parser Lovelace
 pUTxOCostPerByte =
@@ -3406,24 +3372,24 @@ pDRepActivity =
         ]
 
 parseTxOutShelleyBasedEra
-  :: Parsec.Parser (TxOutDatumAnyEra -> ReferenceScriptAnyEra -> TxOutShelleyBasedEra)
+  :: P.Parser (TxOutDatumAnyEra -> ReferenceScriptAnyEra -> TxOutShelleyBasedEra)
 parseTxOutShelleyBasedEra = do
   addr <- parseAddressAny
-  Parsec.spaces
+  P.spaces
   -- Accept the old style of separating the address and value in a
   -- transaction output:
-  Parsec.option () (Parsec.char '+' >> Parsec.spaces)
+  P.option () (P.char '+' >> P.spaces)
   val <- parseTxOutMultiAssetValue -- UTxO role works for transaction output
   return (TxOutShelleyBasedEra addr val)
 
 parseTxOutAnyEra
-  :: Parsec.Parser (TxOutDatumAnyEra -> ReferenceScriptAnyEra -> TxOutAnyEra)
+  :: P.Parser (TxOutDatumAnyEra -> ReferenceScriptAnyEra -> TxOutAnyEra)
 parseTxOutAnyEra = do
   addr <- parseAddressAny
-  Parsec.spaces
+  P.spaces
   -- Accept the old style of separating the address and value in a
   -- transaction output:
-  Parsec.option () (Parsec.char '+' >> Parsec.spaces)
+  P.option () (P.char '+' >> P.spaces)
   val <- parseTxOutMultiAssetValue
   return (TxOutAnyEra addr val)
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Command.hs
@@ -19,9 +19,8 @@ module Cardano.CLI.EraBased.Genesis.Command
   )
 where
 
+import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
-import Cardano.Api.Ledger (Coin)
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Type.Common
 import Cardano.Ledger.BaseTypes (NonZero)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/CreateTestnetData/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/CreateTestnetData/Run.hs
@@ -26,33 +26,8 @@ module Cardano.CLI.EraBased.Genesis.CreateTestnetData.Run
 where
 
 import Cardano.Api hiding (ConwayEra)
-import Cardano.Api.Consensus (ShelleyGenesisStaking (..))
 import Cardano.Api.Ledger (StandardCrypto, StrictMaybe (SNothing))
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
-  ( Hash (..)
-  , KESPeriod (KESPeriod)
-  , OperationalCertificateIssueCounter (OperationalCertificateIssueCounter)
-  , ShelleyGenesis
-    ( ShelleyGenesis
-    , sgGenDelegs
-    , sgInitialFunds
-    , sgMaxLovelaceSupply
-    , sgNetworkMagic
-    , sgProtocolParams
-    , sgStaking
-    , sgSystemStart
-    )
-  , StakeCredential (StakeCredentialByKey)
-  , VerificationKey (VrfVerificationKey)
-  , VrfKey
-  , alonzoGenesisDefaults
-  , conwayGenesisDefaults
-  , shelleyGenesisDefaults
-  , toShelleyAddr
-  , toShelleyNetwork
-  , toShelleyStakeAddr
-  )
 
 import Cardano.CLI.Byron.Genesis (NewDirectory (NewDirectory))
 import Cardano.CLI.Byron.Genesis qualified as Byron

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Internal/Byron.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Internal/Byron.hs
@@ -4,10 +4,10 @@
 
 module Cardano.CLI.EraBased.Genesis.Internal.Byron where
 
+import Cardano.Api qualified as Shelley
 import Cardano.Api.Byron (rationalToLovelacePortion)
-import Cardano.Api.Byron qualified as Byron hiding (GenesisParameters)
+import Cardano.Api.Byron qualified as Byron
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley qualified as Shelley
 
 import Cardano.CLI.Byron.Genesis qualified as Byron
 import Cardano.Crypto.ProtocolMagic qualified as Crypto

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Internal/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Internal/Common.hs
@@ -21,12 +21,11 @@ module Cardano.CLI.EraBased.Genesis.Internal.Common
   )
 where
 
-import Cardano.Api hiding (ConwayEra)
+import Cardano.Api hiding (ConwayEra, HashAlgorithm)
 import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger (AlonzoGenesis, ConwayGenesis)
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley (ShelleyGenesis, ShelleyLedgerEra, decodeAlonzoGenesis)
 
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Error.GenesisCmdError
@@ -40,7 +39,6 @@ import Data.Binary.Get qualified as Bin
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy.Char8 qualified as LBS
 import Data.Coerce (coerce)
-import Data.Data (Proxy (..))
 import Data.Map.Strict (Map)
 import Data.Text qualified as Text
 import Data.Time (NominalDiffTime, UTCTime, addUTCTime, getCurrentTime)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Option.hs
@@ -12,7 +12,6 @@ where
 
 import Cardano.Api hiding (QueryInShelleyBasedEra (..))
 import Cardano.Api.Experimental qualified as Exp
-import Cardano.Api.Ledger (Coin (..))
 
 import Cardano.CLI.Environment (EnvCli (..))
 import Cardano.CLI.EraBased.Common.Option

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Run.hs
@@ -30,14 +30,11 @@ where
 
 import Cardano.Api
 import Cardano.Api.Byron
-  ( toByronLovelace
-  , toByronProtocolMagicId
-  , toByronRequiresNetworkMagic
+  ( ByronKey
+  , SigningKey (..)
   )
-import Cardano.Api.Byron qualified as Byron hiding (GenesisParameters, SigningKey)
-import Cardano.Api.Consensus (ShelleyGenesisStaking (..))
+import Cardano.Api.Byron qualified as Byron hiding (SigningKey)
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Byron.Delegation
 import Cardano.CLI.Byron.Genesis as Byron
@@ -67,7 +64,6 @@ import Cardano.Crypto.Hash qualified as Crypto
 import Cardano.Crypto.Signing qualified as Byron
 import Cardano.Ledger.BaseTypes (unNonZero)
 import Cardano.Protocol.Crypto qualified as C
-import Cardano.Slotting.Slot (EpochSize (EpochSize))
 
 import Control.DeepSeq (NFData, force)
 import Control.Exception (evaluate)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Command.hs
@@ -25,7 +25,6 @@ where
 import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Key

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Option.hs
@@ -14,7 +14,6 @@ where
 import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Common.Option
 import Cardano.CLI.EraBased.Governance.Actions.Command qualified as Cmd

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
@@ -21,7 +21,6 @@ import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger (StrictMaybe (..))
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.EraBased.Governance.Actions.Command

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Committee/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Committee/Run.hs
@@ -14,7 +14,6 @@ where
 
 import Cardano.Api
 import Cardano.Api.Experimental (obtainCommonConstraints)
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.EraBased.Governance.Committee.Command

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Option.hs
@@ -10,7 +10,6 @@ where
 import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley (Hash (DRepMetadataHash))
 
 import Cardano.CLI.EraBased.Common.Option
 import Cardano.CLI.EraBased.Governance.DRep.Command

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Run.hs
@@ -20,7 +20,6 @@ where
 import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.EraBased.Governance.DRep.Command qualified as Cmd

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/GenesisKeyDelegationCertificate/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/GenesisKeyDelegationCertificate/Run.hs
@@ -10,7 +10,6 @@ module Cardano.CLI.EraBased.Governance.GenesisKeyDelegationCertificate.Run
 where
 
 import Cardano.Api
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.Type.Key

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Run.hs
@@ -18,7 +18,6 @@ where
 
 import Cardano.Api
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.EraBased.Governance.Actions.Run

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Command.hs
@@ -12,8 +12,8 @@ module Cardano.CLI.EraBased.Governance.Vote.Command
 where
 
 import Cardano.Api.Experimental qualified as Exp
+import Cardano.Api.Governance
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Governance

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Run.hs
@@ -18,7 +18,6 @@ where
 import Cardano.Api
 import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.EraBased.Governance.Vote.Command qualified as Cmd

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -36,9 +36,9 @@ module Cardano.CLI.EraBased.Query.Command
   )
 where
 
+import Cardano.Api
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Network qualified as Consensus
-import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api.Network as Consensus
 
 import Cardano.CLI.Orphan ()
 import Cardano.CLI.Type.Common

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -15,7 +15,6 @@ where
 
 import Cardano.Api hiding (QueryInShelleyBasedEra (..))
 import Cardano.Api qualified as MemberStatus (MemberStatus (..))
-import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import Cardano.CLI.Environment (EnvCli (..))
 import Cardano.CLI.EraBased.Common.Option

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -22,6 +22,7 @@ import Cardano.CLI.EraBased.Common.Option
 import Cardano.CLI.EraBased.Query.Command
 import Cardano.CLI.Option.Flag
 import Cardano.CLI.Parser
+import Cardano.CLI.Read
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Key
 
@@ -538,7 +539,7 @@ pQueryTxMempoolCmd envCli =
           $ Opt.progDesc "Requests the next transaction from the mempool's current list"
       , Opt.hsubparser
           . commandWithMetavar "tx-exists"
-          . Opt.info (TxMempoolQueryTxExists <$> argument Opt.str (metavar "TX_ID"))
+          . Opt.info (TxMempoolQueryTxExists <$> argument (readerFromParsecParser parseTxId) (metavar "TX_ID"))
           $ Opt.progDesc "Query if a particular transaction exists in the mempool"
       ]
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -44,9 +44,7 @@ import Cardano.Api qualified as Api
 import Cardano.Api.Consensus qualified as Consensus
 import Cardano.Api.Ledger (strictMaybeToMaybe)
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Network (LedgerPeerSnapshot, Serialised (..))
 import Cardano.Api.Network qualified as Consensus
-import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import Cardano.Binary qualified as CBOR
 import Cardano.CLI.EraBased.Genesis.Internal.Common
@@ -79,7 +77,6 @@ import Data.Functor ((<&>))
 import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Proxy (Proxy (..))
 import Data.Sequence qualified as Seq
 import Data.Set (Set)
 import Data.Set qualified as Set

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Read.hs
@@ -10,7 +10,6 @@ module Cardano.CLI.EraBased.Script.Certificate.Read
 where
 
 import Cardano.Api
-import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Script.Certificate.Type
 import Cardano.CLI.EraBased.Script.Read.Common

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
@@ -9,7 +9,6 @@ where
 
 import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
-import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Script.Mint.Type
 import Cardano.CLI.EraBased.Script.Read.Common

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Proposal/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Proposal/Read.hs
@@ -13,7 +13,6 @@ where
 import Cardano.Api
 import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Experimental qualified as Exp
-import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Script.Proposal.Type
 import Cardano.CLI.EraBased.Script.Read.Common

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Read.hs
@@ -12,7 +12,6 @@ module Cardano.CLI.EraBased.Script.Spend.Read
 where
 
 import Cardano.Api
-import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Script.Read.Common
 import Cardano.CLI.EraBased.Script.Spend.Type

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Vote/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Vote/Read.hs
@@ -8,7 +8,6 @@ module Cardano.CLI.EraBased.Script.Vote.Read
 where
 
 import Cardano.Api
-import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Script.Read.Common
 import Cardano.CLI.EraBased.Script.Type

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Withdrawal/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Withdrawal/Read.hs
@@ -8,8 +8,6 @@ module Cardano.CLI.EraBased.Script.Withdrawal.Read
 where
 
 import Cardano.Api
-import Cardano.Api.Ledger
-import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Script.Read.Common
 import Cardano.CLI.EraBased.Script.Type

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Command.hs
@@ -7,9 +7,8 @@ module Cardano.CLI.EraBased.StakeAddress.Command
   )
 where
 
+import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
-import Cardano.Api.Ledger (Coin)
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Governance

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Run.hs
@@ -27,7 +27,6 @@ import Cardano.Api
 import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.EraBased.StakeAddress.Command

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Command.hs
@@ -13,10 +13,9 @@ module Cardano.CLI.EraBased.StakePool.Command
   )
 where
 
+import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
-import Cardano.Api.Ledger (Coin)
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import Cardano.CLI.EraIndependent.Hash.Command (HashGoal)
 import Cardano.CLI.Type.Common

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Internal/Metadata.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Internal/Metadata.hs
@@ -3,7 +3,7 @@ module Cardano.CLI.EraBased.StakePool.Internal.Metadata
   )
 where
 
-import Cardano.Api.Shelley
+import Cardano.Api
 
 import Cardano.CLI.EraIndependent.Hash.Internal.Common hiding (carryHashChecks)
 import Cardano.CLI.Type.Common

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Option.hs
@@ -13,7 +13,6 @@ where
 
 import Cardano.Api
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley (Hash (StakePoolMetadataHash))
 
 import Cardano.CLI.Environment (EnvCli (..))
 import Cardano.CLI.EraBased.Common.Option

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Run.hs
@@ -17,9 +17,9 @@ module Cardano.CLI.EraBased.StakePool.Run
   )
 where
 
+import Cardano.Api
 import Cardano.Api.Experimental
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.StakePool.Command
 import Cardano.CLI.EraBased.StakePool.Command qualified as Cmd

--- a/cardano-cli/src/Cardano/CLI/EraBased/TextView/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/TextView/Command.hs
@@ -8,7 +8,7 @@ module Cardano.CLI.EraBased.TextView.Command
   )
 where
 
-import Cardano.Api.Shelley
+import Cardano.Api
 
 import Cardano.CLI.Type.Common (FormatCborHex, FormatJson, FormatText, FormatYaml)
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
@@ -28,10 +28,9 @@ module Cardano.CLI.EraBased.Transaction.Command
   )
 where
 
+import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
-import Cardano.Api.Ledger (Coin)
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Script.Certificate.Type (CliCertificateScriptRequirements)
 import Cardano.CLI.EraBased.Script.Mint.Type

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Internal/HashCheck.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Internal/HashCheck.hs
@@ -8,16 +8,7 @@ module Cardano.CLI.EraBased.Transaction.Internal.HashCheck
 where
 
 import Cardano.Api
-  ( Certificate (..)
-  , ExceptT
-  , except
-  , firstExceptT
-  , getAnchorDataFromCertificate
-  , getAnchorDataFromGovernanceAction
-  , withExceptT
-  )
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley qualified as Shelley
 
 import Cardano.CLI.EraIndependent.Hash.Internal.Common (carryHashChecks)
 import Cardano.CLI.Type.Common (MustCheckHash (..), PotentiallyCheckedAnchor (..))
@@ -46,9 +37,9 @@ checkCertificateHashes cert = do
 -- | Find references to anchor data in voting procedures and check the hashes are valid
 -- and they match the linked data.
 checkVotingProcedureHashes
-  :: Shelley.ShelleyBasedEra era -> Shelley.VotingProcedures era -> ExceptT TxCmdError IO ()
-checkVotingProcedureHashes eon (Shelley.VotingProcedures (L.VotingProcedures voterMap)) =
-  Shelley.shelleyBasedEraConstraints eon $
+  :: ShelleyBasedEra era -> VotingProcedures era -> ExceptT TxCmdError IO ()
+checkVotingProcedureHashes eon (VotingProcedures (L.VotingProcedures voterMap)) =
+  shelleyBasedEraConstraints eon $
     forM_
       voterMap
       ( mapM $ \(L.VotingProcedure _ mAnchor) ->
@@ -58,17 +49,17 @@ checkVotingProcedureHashes eon (Shelley.VotingProcedures (L.VotingProcedures vot
 -- | Find references to anchor data in proposals and check the hashes are valid
 -- and they match the linked data.
 checkProposalHashes
-  :: forall era. Shelley.ShelleyBasedEra era -> Shelley.Proposal era -> ExceptT TxCmdError IO ()
+  :: forall era. ShelleyBasedEra era -> Proposal era -> ExceptT TxCmdError IO ()
 checkProposalHashes
   eon
-  ( Shelley.Proposal
+  ( Proposal
       ( L.ProposalProcedure
           { L.pProcGovAction = govAction
           , L.pProcAnchor = anchor
           }
         )
     ) =
-    Shelley.shelleyBasedEraConstraints eon $ do
+    shelleyBasedEraConstraints eon $ do
       checkAnchorMetadataHash anchor
       maybe (return ()) checkAnchorMetadataHash (getAnchorDataFromGovernanceAction govAction)
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
@@ -129,17 +129,18 @@ pTransactionCmds envCli =
 -- Backwards compatible parsers
 calcMinValueInfo :: Exp.IsEra era => ParserInfo (TransactionCmds era)
 calcMinValueInfo =
-  Opt.info pTransactionCalculateMinReqUTxO $
+  Opt.info (pTransactionCalculateMinReqUTxO <**> Opt.helper) $
     Opt.progDesc "DEPRECATED: Use 'calculate-min-required-utxo' instead."
 
-pCalculateMinRequiredUtxoBackwardCompatible :: Exp.IsEra era => Parser (TransactionCmds era)
+pCalculateMinRequiredUtxoBackwardCompatible
+  :: forall era. Exp.IsEra era => Parser (TransactionCmds era)
 pCalculateMinRequiredUtxoBackwardCompatible =
-  Opt.subparser $
+  Opt.subparser @(TransactionCmds era) $
     Opt.command "calculate-min-value" calcMinValueInfo <> Opt.internal
 
 assembleInfo :: ParserInfo (TransactionCmds era)
 assembleInfo =
-  Opt.info pTransactionAssembleTxBodyWit $
+  Opt.info (pTransactionAssembleTxBodyWit <**> Opt.helper) $
     Opt.progDesc "Assemble a tx body and witness(es) to form a transaction"
 
 pSignWitnessBackwardCompatible :: Parser (TransactionCmds era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
@@ -19,6 +19,7 @@ import Cardano.CLI.EraBased.Common.Option
 import Cardano.CLI.EraBased.Transaction.Command
 import Cardano.CLI.Option.Flag
 import Cardano.CLI.Parser
+import Cardano.CLI.Read
 import Cardano.CLI.Type.Common
 
 import Control.Monad

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
@@ -32,29 +32,14 @@ module Cardano.CLI.EraBased.Transaction.Run
   )
 where
 
-import Cardano.Api
+import Cardano.Api hiding (txId, validateTxIns, validateTxInsCollateral)
 import Cardano.Api qualified as Api
 import Cardano.Api.Byron qualified as Byron
-import Cardano.Api.Consensus (EraMismatch (..), unsafeExtendSafeZone)
 import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Network qualified as Consensus
 import Cardano.Api.Network qualified as Net.Tx
-import Cardano.Api.Shelley
-  ( GovernanceAction (TreasuryWithdrawal)
-  , Hash (StakePoolKeyHash)
-  , LedgerProtocolParameters (..)
-  , PoolId
-  , Proposal (..)
-  , ShelleyLedgerEra
-  , Tx (ShelleyTx)
-  , VotingProcedures
-  , fromProposalProcedure
-  , fromShelleyStakeCredential
-  , fromShelleyTxIn
-  , getTxBodyAndWitnesses
-  )
 
 import Cardano.Binary qualified as CBOR
 import Cardano.CLI.Compatible.Exception

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Command.hs
@@ -7,7 +7,7 @@ module Cardano.CLI.EraIndependent.Address.Command
   )
 where
 
-import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api
 
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Key

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Info/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Info/Run.hs
@@ -12,7 +12,7 @@ import Cardano.Api
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.Type.Error.AddressInfoError
 
-import Data.Aeson (ToJSON (..), object, (.=))
+import Data.Aeson (object, (.=))
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.ByteString.Lazy.Char8 qualified as LBS
 import Data.Text (Text)

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Run.hs
@@ -19,7 +19,6 @@ module Cardano.CLI.EraIndependent.Address.Run
 where
 
 import Cardano.Api
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.EraIndependent.Address.Command

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Cip/Cip129/Internal/Conversion.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Cip/Cip129/Internal/Conversion.hs
@@ -8,8 +8,8 @@ module Cardano.CLI.EraIndependent.Cip.Cip129.Internal.Conversion
   )
 where
 
+import Cardano.Api
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Read.Committee.ColdKey
 import Cardano.CLI.Read.Committee.HotKey

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/Option.hs
@@ -11,7 +11,7 @@ module Cardano.CLI.EraIndependent.Debug.Option
   )
 where
 
-import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api
 
 import Cardano.CLI.Environment
 import Cardano.CLI.EraBased.Common.Option

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Command.hs
@@ -20,7 +20,7 @@ module Cardano.CLI.EraIndependent.Key.Command
   )
 where
 
-import Cardano.Api.Shelley
+import Cardano.Api
 
 import Cardano.CLI.Type.Common
 import Cardano.Prelude (Word32)

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Run.hs
@@ -36,10 +36,14 @@ module Cardano.CLI.EraIndependent.Key.Run
 where
 
 import Cardano.Api
+import Cardano.Api.Byron
+  ( ByronKey
+  , SigningKey (ByronSigningKey, ByronSigningKeyLegacy)
+  , VerificationKey (ByronVerificationKey)
+  )
 import Cardano.Api.Byron qualified as ByronApi
 import Cardano.Api.Crypto.Ed25519Bip32 (xPrvFromBytes)
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Byron.Key qualified as Byron
 import Cardano.CLI.Compatible.Exception

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Command.hs
@@ -14,7 +14,7 @@ module Cardano.CLI.EraIndependent.Node.Command
   )
 where
 
-import Cardano.Api.Shelley
+import Cardano.Api
 
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Key

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Run.hs
@@ -18,7 +18,6 @@ module Cardano.CLI.EraIndependent.Node.Run
 where
 
 import Cardano.Api
-import Cardano.Api.Shelley
 
 import Cardano.CLI.EraIndependent.Node.Command qualified as Cmd
 import Cardano.CLI.Type.Common
@@ -302,7 +301,7 @@ runNodeIssueOpCertCmd
     signKey <-
       firstExceptT NodeCmdReadKeyFileError
         . newExceptT
-        $ readKeyFileAnyOf
+        $ readFormattedFileAnyOf
           bech32PossibleBlockIssuers
           textEnvPossibleBlockIssuers
           poolSkeyFile

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Ping/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Ping/Option.hs
@@ -12,14 +12,14 @@ import Cardano.CLI.EraBased.Common.Option (integralReader)
 import Cardano.CLI.EraIndependent.Ping.Command
 import Cardano.Network.Ping qualified as CNP
 
-import Control.Applicative ((<|>))
+import Control.Applicative
 import Options.Applicative qualified as Opt
 import Prettyprinter qualified as PP
 
 parsePingCmd :: Opt.Mod Opt.CommandFields ClientCommand
 parsePingCmd =
   Opt.command "ping" $
-    Opt.info (CliPingCommand <$> pPing) $
+    Opt.info (CliPingCommand <$> pPing <**> Opt.helper) $
       Opt.progDescDoc $
         Just $
           mconcat

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -34,25 +34,12 @@ module Cardano.CLI.Json.Friendly
 where
 
 import Cardano.Api as Api
-import Cardano.Api.Byron (KeyWitness (ByronKeyWitness))
 import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger (ExUnits (..), extractHash, strictMaybeToMaybe)
 import Cardano.Api.Ledger qualified as Alonzo
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Ledger qualified as Ledger
-import Cardano.Api.Shelley
-  ( Hash (..)
-  , KeyWitness (ShelleyBootstrapWitness, ShelleyKeyWitness)
-  , Proposal (..)
-  , ShelleyLedgerEra
-  , StakeAddress (..)
-  , Tx (ShelleyTx)
-  , fromShelleyPaymentCredential
-  , fromShelleyStakeReference
-  , getTxBodyAndWitnesses
-  , toShelleyStakeCredential
-  )
 
 import Cardano.CLI.Json.Encode qualified as Json
 import Cardano.CLI.Orphan ()
@@ -60,7 +47,7 @@ import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.MonadWarning (MonadWarning, runWarningIO)
 import Cardano.Crypto.Hash (hashToTextAsHex)
 
-import Data.Aeson (Value (..), object, toJSON, (.=))
+import Data.Aeson (Value (..), object, (.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Aeson
 import Data.Aeson.KeyMap qualified as KeyMap

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -872,8 +872,8 @@ friendlyValue _ v =
   friendlyAssets = Map.mapKeys friendlyAssetName
 
   friendlyAssetName = \case
-    "" -> "default asset"
-    name@(AssetName nameBS) ->
+    UnsafeAssetName "" -> "default asset"
+    name@(UnsafeAssetName nameBS) ->
       "asset " <> serialiseToRawBytesHexText name <> nameAsciiSuffix
      where
       nameAsciiSuffix

--- a/cardano-cli/src/Cardano/CLI/Legacy/Genesis/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Genesis/Command.hs
@@ -7,8 +7,7 @@ module Cardano.CLI.Legacy.Genesis.Command
   )
 where
 
-import Cardano.Api.Ledger (Coin)
-import Cardano.Api.Shelley
+import Cardano.Api
 
 import Cardano.CLI.Type.Common
 import Cardano.Ledger.BaseTypes (NonZero)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Genesis/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Genesis/Run.hs
@@ -11,7 +11,6 @@ module Cardano.CLI.Legacy.Genesis.Run
 where
 
 import Cardano.Api
-import Cardano.Api.Ledger (Coin (..))
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.EraBased.Genesis.Command

--- a/cardano-cli/src/Cardano/CLI/Legacy/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Option.hs
@@ -46,7 +46,7 @@ parseLegacyCmds :: EnvCli -> Parser LegacyCmds
 parseLegacyCmds envCli =
   Opt.hsubparser $
     mconcat
-      [ Opt.metavar "Legacy commands"
+      [ Opt.metavar "COMMAND"
       , Opt.command "genesis" $
           Opt.info (LegacyGenesisCmds <$> pGenesisCmds envCli) $
             Opt.progDesc "Genesis block commands"

--- a/cardano-cli/src/Cardano/CLI/Legacy/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Option.hs
@@ -20,7 +20,6 @@ module Cardano.CLI.Legacy.Option
 where
 
 import Cardano.Api hiding (QueryInShelleyBasedEra (..))
-import Cardano.Api.Ledger (Coin (..))
 
 import Cardano.CLI.Environment
 import Cardano.CLI.EraBased.Common.Option

--- a/cardano-cli/src/Cardano/CLI/Orphan.hs
+++ b/cardano-cli/src/Cardano/CLI/Orphan.hs
@@ -72,16 +72,6 @@ instance ToJSON HashableScriptData where
       , "json" .= scriptDataToJsonDetailedSchema hsd
       ]
 
--- TODO: Move to cardano-api
-instance Convert Era MaryEraOnwards where
-  convert = \case
-    Exp.ConwayEra -> MaryEraOnwardsConway
-
--- TODO: Move to cardano-api
-instance Convert Era ConwayEraOnwards where
-  convert = \case
-    Exp.ConwayEra -> ConwayEraOnwardsConway
-
 -- TODO: Convert readVerificationKeySource to use CIO. We can then
 -- remove this instance
 instance

--- a/cardano-cli/src/Cardano/CLI/Orphan.hs
+++ b/cardano-cli/src/Cardano/CLI/Orphan.hs
@@ -11,16 +11,8 @@ where
 
 import Cardano.Api
 import Cardano.Api.Byron qualified as Byron
-import Cardano.Api.Consensus (EraMismatch (..))
 import Cardano.Api.Experimental as Exp
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
-  ( AcquiringFailure
-  , GovernancePollError (..)
-  , VotesMergingConflict
-  , renderGovernancePollError
-  , scriptDataToJsonDetailedSchema
-  )
 
 import Cardano.CLI.Type.Error.ScriptDecodeError
 import Cardano.Ledger.CertState qualified as L

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -98,6 +98,9 @@ module Cardano.CLI.Read
     -- * Genesis hashes
   , readShelleyOnwardsGenesisAndHash
   , readFileCli
+
+    -- * utilities
+  , readerFromParsecParser
   )
 where
 
@@ -105,6 +108,7 @@ import Cardano.Api as Api
 import Cardano.Api.Byron qualified as Byron
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L
+import Cardano.Api.Parser.Text qualified as P
 import Cardano.Api.Shelley as Api
 
 import Cardano.Binary qualified as CBOR
@@ -146,7 +150,6 @@ import Data.Function ((&))
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.List qualified as List
 import Data.Proxy (Proxy (..))
-import Data.String
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text qualified as Text
@@ -1006,7 +1009,7 @@ readSafeHash =
       & first (Text.unpack . renderReadSafeHashError)
 
 scriptHashReader :: Opt.ReadM ScriptHash
-scriptHashReader = Opt.eitherReader $ Right . fromString
+scriptHashReader = readerFromParsecParser parseScriptHash
 
 readVoteDelegationTarget
   :: ()
@@ -1061,3 +1064,6 @@ getVerificationKeyFromStakePoolVerificationKeySource = \case
 
 readFileCli :: (HasCallStack, MonadIO m) => FilePath -> m ByteString
 readFileCli = withFrozenCallStack . readFileBinary
+
+readerFromParsecParser :: P.Parser a -> Opt.ReadM a
+readerFromParsecParser p = Opt.eitherReader (P.runParser p . T.pack)

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -105,11 +105,11 @@ module Cardano.CLI.Read
 where
 
 import Cardano.Api as Api
+import Cardano.Api.Byron (ByronKey)
 import Cardano.Api.Byron qualified as Byron
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Parser.Text qualified as P
-import Cardano.Api.Shelley as Api
 
 import Cardano.Binary qualified as CBOR
 import Cardano.CLI.Compatible.Exception
@@ -149,7 +149,6 @@ import Data.ByteString.Lazy.Char8 qualified as LBS
 import Data.Function ((&))
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.List qualified as List
-import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text qualified as Text
@@ -614,7 +613,7 @@ readWitnessSigningData
 readWitnessSigningData (KeyWitnessSigningData skFile mbByronAddr) = do
   eRes <-
     first ReadWitnessSigningDataSigningKeyDecodeError
-      <$> readKeyFileAnyOf bech32FileTypes textEnvFileTypes skFile
+      <$> readFormattedFileAnyOf bech32FileTypes textEnvFileTypes skFile
   return $ do
     res <- eRes
     case (res, mbByronAddr) of
@@ -675,7 +674,7 @@ readRequiredSigner :: RequiredSigner -> IO (Either RequiredSignerError (Hash Pay
 readRequiredSigner (RequiredSignerHash h) = return $ Right h
 readRequiredSigner (RequiredSignerSkeyFile skFile) = do
   eKeyWit <-
-    first RequiredSignerErrorFile <$> readKeyFileAnyOf bech32FileTypes textEnvFileTypes skFile
+    first RequiredSignerErrorFile <$> readFormattedFileAnyOf bech32FileTypes textEnvFileTypes skFile
   return $ do
     keyWit <- eKeyWit
     case categoriseSomeSigningWitness keyWit of

--- a/cardano-cli/src/Cardano/CLI/Read/Committee/ColdKey.hs
+++ b/cardano-cli/src/Cardano/CLI/Read/Committee/ColdKey.hs
@@ -14,7 +14,7 @@ module Cardano.CLI.Read.Committee.ColdKey
   )
 where
 
-import Cardano.Api.Shelley
+import Cardano.Api
 
 import Cardano.CLI.Read
 import Cardano.Prelude qualified as Text

--- a/cardano-cli/src/Cardano/CLI/Read/Committee/HotKey.hs
+++ b/cardano-cli/src/Cardano/CLI/Read/Committee/HotKey.hs
@@ -14,7 +14,7 @@ module Cardano.CLI.Read.Committee.HotKey
   )
 where
 
-import Cardano.Api.Shelley
+import Cardano.Api
 
 import Cardano.CLI.Read
 import Cardano.Prelude qualified as Text

--- a/cardano-cli/src/Cardano/CLI/Read/GovernanceActionId.hs
+++ b/cardano-cli/src/Cardano/CLI/Read/GovernanceActionId.hs
@@ -4,15 +4,12 @@ module Cardano.CLI.Read.GovernanceActionId
 where
 
 import Cardano.Api.Ledger qualified as L
+import Cardano.Api.Parser.Text as P
 import Cardano.Api.Shelley
 
-import Cardano.CLI.EraBased.Common.Option (parseTxIn)
-
 import Data.Text (Text)
-import Data.Text qualified as Text
-import Text.Parsec qualified as Text
 
-readGoveranceActionIdHexText :: Text -> Either Text.ParseError L.GovActionId
+readGoveranceActionIdHexText :: Text -> Either String L.GovActionId
 readGoveranceActionIdHexText hexText = do
-  TxIn txid (TxIx index) <- Text.parse parseTxIn "" $ Text.unpack hexText
+  TxIn txid (TxIx index) <- P.runParser parseTxIn hexText
   return $ createGovernanceActionId txid $ fromIntegral index

--- a/cardano-cli/src/Cardano/CLI/Read/GovernanceActionId.hs
+++ b/cardano-cli/src/Cardano/CLI/Read/GovernanceActionId.hs
@@ -3,9 +3,10 @@ module Cardano.CLI.Read.GovernanceActionId
   )
 where
 
+import Cardano.Api.Governance
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Parser.Text as P
-import Cardano.Api.Shelley
+import Cardano.Api.Tx
 
 import Data.Text (Text)
 

--- a/cardano-cli/src/Cardano/CLI/Type/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Common.hs
@@ -103,7 +103,7 @@ where
 import Cardano.Api hiding (Script)
 import Cardano.Api.Ledger qualified as L
 
-import Data.Aeson (FromJSON (..), ToJSON (..), object, pairs, (.=))
+import Data.Aeson (object, pairs, (.=))
 import Data.Aeson qualified as Aeson
 import Data.String (IsString)
 import Data.Text (Text)

--- a/cardano-cli/src/Cardano/CLI/Type/Error/GovernanceCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/GovernanceCmdError.hs
@@ -5,7 +5,6 @@
 module Cardano.CLI.Type.Error.GovernanceCmdError where
 
 import Cardano.Api
-import Cardano.Api.Shelley
 
 data GovernanceCmdError
   = -- Voting related

--- a/cardano-cli/src/Cardano/CLI/Type/Error/GovernanceQueryError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/GovernanceQueryError.hs
@@ -3,8 +3,6 @@
 module Cardano.CLI.Type.Error.GovernanceQueryError where
 
 import Cardano.Api
-import Cardano.Api.Consensus (EraMismatch)
-import Cardano.Api.Shelley
 
 data GovernanceQueryError
   = GovernanceQueryWriteFileError !(FileError ())

--- a/cardano-cli/src/Cardano/CLI/Type/Error/QueryCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/QueryCmdError.hs
@@ -17,8 +17,7 @@ module Cardano.CLI.Type.Error.QueryCmdError
 where
 
 import Cardano.Api hiding (QueryInShelleyBasedEra (..))
-import Cardano.Api.Consensus as Consensus (EraMismatch (..), PastHorizonException)
-import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api.Consensus as Consensus (PastHorizonException)
 
 import Cardano.Binary (DecoderError)
 import Cardano.CLI.Helper (HelpersError (..), renderHelpersError)

--- a/cardano-cli/src/Cardano/CLI/Type/Error/StakePoolCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/StakePoolCmdError.hs
@@ -9,7 +9,6 @@ module Cardano.CLI.Type.Error.StakePoolCmdError
 where
 
 import Cardano.Api
-import Cardano.Api.Shelley (Hash (StakePoolMetadataHash))
 
 import Cardano.CLI.Type.Error.HashCmdError (FetchURLError)
 

--- a/cardano-cli/src/Cardano/CLI/Type/Error/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/TxCmdError.hs
@@ -15,7 +15,6 @@ where
 
 import Cardano.Api
 import Cardano.Api.Byron (GenesisDataError)
-import Cardano.Api.Consensus (EraMismatch (..))
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Read

--- a/cardano-cli/src/Cardano/CLI/Type/Error/TxValidationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/TxValidationError.hs
@@ -27,7 +27,6 @@ where
 import Cardano.Api
 import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Experimental qualified as Exp
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Type.Common
 

--- a/cardano-cli/src/Cardano/CLI/Type/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Key.hs
@@ -47,8 +47,8 @@ module Cardano.CLI.Type.Key
 where
 
 import Cardano.Api
+import Cardano.Api.Byron (ByronKey)
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Type.Common
 
@@ -95,7 +95,7 @@ readVerificationKeyOrFile verKeyOrFile =
     VerificationKeyValue vk -> pure vk
     VerificationKeyFilePath (File fp) ->
       hoistIOEither $
-        readKeyFile
+        readFormattedFile
           (fromList [InputFormatBech32, InputFormatHex, InputFormatTextEnvelope])
           fp
 
@@ -112,7 +112,7 @@ readVerificationKeyOrTextEnvFile
 readVerificationKeyOrTextEnvFile verKeyOrFile =
   case verKeyOrFile of
     VerificationKeyValue vk -> pure vk
-    VerificationKeyFilePath fp -> hoistIOEither $ readKeyFileTextEnvelope fp
+    VerificationKeyFilePath fp -> hoistIOEither $ readFormattedFileTextEnvelope fp
 
 data PaymentVerifier
   = PaymentVerifierKey VerificationKeyTextOrFile
@@ -453,7 +453,7 @@ readSigningKeyFile
   -> ExceptT (FileError InputDecodeError) IO SomeSigningKey
 readSigningKeyFile skFile =
   newExceptT $
-    readKeyFileAnyOf bech32FileTypes textEnvFileTypes skFile
+    readFormattedFileAnyOf bech32FileTypes textEnvFileTypes skFile
  where
   -- If you update these variables, consider updating the ones with the same
   -- names in Cardano.CLI.Read

--- a/cardano-cli/src/Cardano/CLI/Type/Output.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Output.hs
@@ -19,7 +19,6 @@ where
 
 import Cardano.Api
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Type.Common
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/SigningKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/SigningKeys.hs
@@ -13,6 +13,9 @@ module Test.Golden.Byron.SigningKeys
 where
 
 import Cardano.Api.Byron
+import Cardano.Api.Key
+import Cardano.Api.Monad.Error
+import Cardano.Api.Serialise.Raw
 
 import Cardano.CLI.Byron.Key (readByronSigningKey)
 import Cardano.CLI.Byron.Legacy (decodeLegacyDelegateKey)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Tx.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Tx.hs
@@ -3,7 +3,6 @@
 module Test.Golden.Byron.Tx where
 
 import Cardano.Api
-import Cardano.Api.Byron (ATxAux)
 
 import Cardano.CLI.Byron.Tx
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateStaked.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateStaked.hs
@@ -2,11 +2,9 @@
 
 module Test.Golden.CreateStaked where
 
-import Cardano.Api.Ledger (ShelleyGenesisStaking (sgsPools, sgsStake))
-import Cardano.Api.Shelley (ShelleyGenesis (sgNetworkMagic, sgStaking))
+import Cardano.Api
 
 import Control.Monad (filterM, void)
-import Control.Monad.IO.Class
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as LBS
 import Data.List (intercalate, sort)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateTestnetData.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateTestnetData.hs
@@ -7,7 +7,6 @@ module Test.Golden.CreateTestnetData where
 import Cardano.Api
 import Cardano.Api.Ledger (ConwayGenesis (..))
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley (ShelleyGenesis (..))
 
 import Control.Monad
 import Data.List (intercalate, sort)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 {- HLINT ignore "Redundant id" -}
@@ -10,13 +11,15 @@ where
 
 import Prelude hiding (lines)
 
-import Control.Monad (unless, (<=<))
+import Control.Monad
 import Data.Char qualified as Char
 import Data.List (nub)
 import Data.List qualified as List
 import Data.Maybe (maybeToList)
 import Data.Text (Text)
 import Data.Text qualified as Text
+import GHC.Exts (IsList (..))
+import System.Exit (ExitCode (..))
 import System.FilePath ((</>))
 import System.Process.Extra (readProcess)
 import Text.Regex (Regex, mkRegex, subRegex)
@@ -25,6 +28,7 @@ import Test.Cardano.CLI.Util (execCardanoCLI, propertyOnce, watchdogProp)
 import Test.Cardano.CLI.Util qualified as H
 
 import Hedgehog (Property)
+import Hedgehog qualified as H
 import Hedgehog.Extras.Stock.OS (isWin32)
 import Hedgehog.Extras.Test qualified as H
 import Test.Tasty (TestTree, testGroup)
@@ -72,9 +76,6 @@ hprop_golden_HelpAll =
 
       H.diffVsGoldenFile help helpFp
 
-third :: (a, b, c) -> c
-third (_, _, c) = c
-
 -- | Return the string with the prefix dropped if the prefix is present, otherwise return Nothing.
 selectAndDropPrefix :: Text -> Text -> Maybe Text
 selectAndDropPrefix prefix text =
@@ -82,14 +83,26 @@ selectAndDropPrefix prefix text =
     then Just $ Text.drop (Text.length prefix) text
     else Nothing
 
-deselectSuffix :: Text -> Text -> Maybe Text
-deselectSuffix suffix text =
-  if Text.isSuffixOf suffix text
-    then Nothing
-    else Just text
+-- | If the command invocation has a metavar with screaming snake case in the last position, remove it
+stripMetavar :: Text -> Text
+stripMetavar =
+  Text.unwords
+    . removeMetavar
+    . Text.words
+ where
+  removeMetavar =
+    \case
+      [] -> []
+      [w] -- remove metavar from the last position
+        | isScreamingSnakeCase w -> []
+        | otherwise -> [w]
+      w : ws -> w : removeMetavar ws
+
+  isScreamingSnakeCase :: Text -> Bool
+  isScreamingSnakeCase = all (\c -> Char.isUpperCase c || c == '_') . toList
 
 selectCmd :: Text -> Maybe Text
-selectCmd = selectAndDropPrefix "Usage: cardano-cli " <=< deselectSuffix " COMMAND"
+selectCmd = fmap stripMetavar . selectAndDropPrefix "Usage: cardano-cli "
 
 test_golden_HelpCmds :: IO TestTree
 test_golden_HelpCmds =
@@ -99,7 +112,7 @@ test_golden_HelpCmds =
   if isWin32
     then return $ testGroup "help-commands" []
     else do
-      help <-
+      helpText <-
         filterAnsi
           <$> readProcess
             "cardano-cli"
@@ -107,7 +120,7 @@ test_golden_HelpCmds =
             ]
             ""
 
-      let lines = Text.lines (Text.pack help)
+      let lines = Text.lines (Text.pack helpText)
           usages = [] : nub (List.filter (not . null) (fmap extractCmd $ maybeToList . selectCmd =<< lines))
 
       return $
@@ -120,9 +133,18 @@ test_golden_HelpCmds =
                   let expectedCmdHelpFp =
                         "test/cardano-cli-golden/files/golden" </> subPath usage
 
-                  cmdHelp <- filterAnsi . third <$> H.execDetailCardanoCLI (fmap Text.unpack usage)
+                  (exitCode, stdout, stderr) <- H.execDetailCardanoCLI (Text.unpack <$> usage <> ["--help"])
+                  let cmdHelp = filterAnsi stdout
 
-                  H.diffVsGoldenFile cmdHelp expectedCmdHelpFp
+                  case exitCode of
+                    ExitSuccess ->
+                      H.diffVsGoldenFile cmdHelp expectedCmdHelpFp
+                    ExitFailure _ -> do
+                      H.note_ "Failed to generate correct help text"
+                      H.noteShow_ exitCode
+                      H.note_ $ filterAnsi stderr
+                      H.note_ cmdHelp -- stdout
+                      H.failure
               )
           | usage <- usages
           ]

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
@@ -4,13 +4,6 @@
 module Test.Golden.Shelley.StakePool.RegistrationCertificate where
 
 import Cardano.Api
-  ( File (File)
-  , VerificationKey
-  , liftIO
-  , readFileTextEnvelope
-  , serialiseToBech32
-  )
-import Cardano.Api.Shelley (StakePoolExtendedKey)
 
 import Control.Monad (void)
 import Data.Text qualified as Text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -530,7 +530,7 @@ Usage: cardano-cli query ledger-peer-snapshot
   Dump the current snapshot of big ledger peers. These are the largest pools
   that cumulatively hold 90% of total stake.
 
-Usage: cardano-cli legacy Legacy commands
+Usage: cardano-cli legacy COMMAND
 
   Legacy commands
 
@@ -688,12 +688,13 @@ Usage: cardano-cli byron
 
   Byron specific commands
 
-Usage: cardano-cli byron key ( keygen
-                             | to-verification
-                             | signing-key-public
-                             | signing-key-address
-                             | migrate-delegate-key-from
-                             )
+Usage: cardano-cli byron key 
+                               ( keygen
+                               | to-verification
+                               | signing-key-public
+                               | signing-key-address
+                               | migrate-delegate-key-from
+                               )
 
   Byron key utility commands
 
@@ -734,11 +735,12 @@ Usage: cardano-cli byron key migrate-delegate-key-from --from FILEPATH
 
   Migrate a delegate key from an older version.
 
-Usage: cardano-cli byron transaction ( submit-tx
-                                     | issue-genesis-utxo-expenditure
-                                     | issue-utxo-expenditure
-                                     | txid
-                                     )
+Usage: cardano-cli byron transaction 
+                                       ( submit-tx
+                                       | issue-genesis-utxo-expenditure
+                                       | issue-utxo-expenditure
+                                       | txid
+                                       )
 
   Byron transaction commands
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_create-proposal-vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_create-proposal-vote.cli
@@ -21,3 +21,4 @@ Available options:
   --vote-no                Vote no with respect to an update proposal.
   --output-filepath FILEPATH
                            Byron vote output filepath.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_create-update-proposal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_create-update-proposal.cli
@@ -82,3 +82,4 @@ Available options:
                            the size.
   --unlock-stake-epoch WORD64
                            Proposed epoch to unlock all stake.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_genesis.cli
@@ -2,6 +2,9 @@ Usage: cardano-cli byron genesis (genesis | print-genesis-hash)
 
   Byron genesis block commands
 
+Available options:
+  -h,--help                Show this help text
+
 Available commands:
   genesis                  Create genesis.
   print-genesis-hash       Compute hash of a genesis file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli byron governance COMMAND
+
+  Byron governance commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-update-proposal   Create an update proposal.
+  create-proposal-vote     Create an update proposal vote.
+  submit-update-proposal   Submit an update proposal.
+  submit-proposal-vote     Submit a proposal vote.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_create-proposal-vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_create-proposal-vote.cli
@@ -23,3 +23,4 @@ Available options:
   --vote-no                Vote no with respect to an update proposal.
   --output-filepath FILEPATH
                            Byron vote output filepath.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_create-update-proposal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_create-update-proposal.cli
@@ -82,3 +82,4 @@ Available options:
                            the size.
   --unlock-stake-epoch WORD64
                            Proposed epoch to unlock all stake.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_submit-proposal-vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_submit-proposal-vote.cli
@@ -18,3 +18,4 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --filepath FILEPATH      Filepath of Byron update proposal vote.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_submit-update-proposal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_submit-update-proposal.cli
@@ -18,3 +18,4 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --filepath FILEPATH      Filepath of Byron update proposal.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_key.cli
@@ -1,11 +1,15 @@
-Usage: cardano-cli byron key ( keygen
-                             | to-verification
-                             | signing-key-public
-                             | signing-key-address
-                             | migrate-delegate-key-from
-                             )
+Usage: cardano-cli byron key 
+                               ( keygen
+                               | to-verification
+                               | signing-key-public
+                               | signing-key-address
+                               | migrate-delegate-key-from
+                               )
 
   Byron key utility commands
+
+Available options:
+  -h,--help                Show this help text
 
 Available commands:
   keygen                   Generate a signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_miscellaneous.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_miscellaneous.cli
@@ -2,6 +2,9 @@ Usage: cardano-cli byron miscellaneous (validate-cbor | pretty-print-cbor)
 
   Byron miscellaneous commands
 
+Available options:
+  -h,--help                Show this help text
+
 Available commands:
   validate-cbor            Validate a CBOR blockchain object.
   pretty-print-cbor        Pretty print a CBOR file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_submit-proposal-vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_submit-proposal-vote.cli
@@ -17,3 +17,4 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --filepath FILEPATH      Filepath of Byron update proposal vote.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_submit-update-proposal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_submit-update-proposal.cli
@@ -17,3 +17,4 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --filepath FILEPATH      Filepath of Byron update proposal.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_transaction.cli
@@ -1,10 +1,14 @@
-Usage: cardano-cli byron transaction ( submit-tx
-                                     | issue-genesis-utxo-expenditure
-                                     | issue-utxo-expenditure
-                                     | txid
-                                     )
+Usage: cardano-cli byron transaction 
+                                       ( submit-tx
+                                       | issue-genesis-utxo-expenditure
+                                       | issue-utxo-expenditure
+                                       | txid
+                                       )
 
   Byron transaction commands
+
+Available options:
+  -h,--help                Show this help text
 
 Available commands:
   submit-tx                Submit a raw, signed transaction, in its on-wire

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_info.cli
@@ -1,14 +1,6 @@
-Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
+Usage: cardano-cli conway query tx-mempool info 
 
-Usage: cardano-cli conway query tx-mempool 
-                                             [--cardano-mode
-                                               [--epoch-slots SLOTS]]
-                                             ( --mainnet
-                                             | --testnet-magic NATURAL
-                                             )
-                                             --socket-path SOCKET_PATH
-                                             (info | next-tx | tx-exists)
-                                             [--output-json | --output-yaml]
-                                             [--out-file FILEPATH]
+  Ask the node about the current mempool's capacity and sizes
 
-  Local Mempool info
+Available options:
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_next-tx.cli
@@ -1,14 +1,6 @@
-Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
+Usage: cardano-cli conway query tx-mempool next-tx 
 
-Usage: cardano-cli conway query tx-mempool 
-                                             [--cardano-mode
-                                               [--epoch-slots SLOTS]]
-                                             ( --mainnet
-                                             | --testnet-magic NATURAL
-                                             )
-                                             --socket-path SOCKET_PATH
-                                             (info | next-tx | tx-exists)
-                                             [--output-json | --output-yaml]
-                                             [--out-file FILEPATH]
+  Requests the next transaction from the mempool's current list
 
-  Local Mempool info
+Available options:
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_tx-exists.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_tx-exists.cli
@@ -1,8 +1,6 @@
-
-unexpected "T"
-expecting hexadecimal digit
-Failed to deserialise  as TxId: Unable to deserialise TxId
-
 Usage: cardano-cli conway query tx-mempool tx-exists TX_ID
 
   Query if a particular transaction exists in the mempool
+
+Available options:
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,14 +1,8 @@
-Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli conway query tx-mempool 
-                                             [--cardano-mode
-                                               [--epoch-slots SLOTS]]
-                                             ( --mainnet
-                                             | --testnet-magic NATURAL
-                                             )
-                                             --socket-path SOCKET_PATH
-                                             (info | next-tx | tx-exists)
-                                             [--output-json | --output-yaml]
-                                             [--out-file FILEPATH]
+unexpected "T"
+expecting hexadecimal digit
+Failed to deserialise  as TxId: Unable to deserialise TxId
 
-  Local Mempool info
+Usage: cardano-cli conway query tx-mempool tx-exists TX_ID
+
+  Query if a particular transaction exists in the mempool

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-value.cli
@@ -64,3 +64,4 @@ Available options:
                            top-level strings and numbers.
   --tx-out-reference-script-file FILEPATH
                            Reference script input file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_sign-witness.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_sign-witness.cli
@@ -11,3 +11,4 @@ Available options:
   --out-canonical-cbor     Produce transaction in canonical CBOR according to
                            RFC7049. Only this part of CIP-21 is implemented.
   --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/help.cli
@@ -1,0 +1,6 @@
+Usage: cardano-cli help 
+
+  Show all help
+
+Available options:
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_info.cli
@@ -1,14 +1,6 @@
-Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
+Usage: cardano-cli latest query tx-mempool info 
 
-Usage: cardano-cli latest query tx-mempool 
-                                             [--cardano-mode
-                                               [--epoch-slots SLOTS]]
-                                             ( --mainnet
-                                             | --testnet-magic NATURAL
-                                             )
-                                             --socket-path SOCKET_PATH
-                                             (info | next-tx | tx-exists)
-                                             [--output-json | --output-yaml]
-                                             [--out-file FILEPATH]
+  Ask the node about the current mempool's capacity and sizes
 
-  Local Mempool info
+Available options:
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_next-tx.cli
@@ -1,14 +1,6 @@
-Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
+Usage: cardano-cli latest query tx-mempool next-tx 
 
-Usage: cardano-cli latest query tx-mempool 
-                                             [--cardano-mode
-                                               [--epoch-slots SLOTS]]
-                                             ( --mainnet
-                                             | --testnet-magic NATURAL
-                                             )
-                                             --socket-path SOCKET_PATH
-                                             (info | next-tx | tx-exists)
-                                             [--output-json | --output-yaml]
-                                             [--out-file FILEPATH]
+  Requests the next transaction from the mempool's current list
 
-  Local Mempool info
+Available options:
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_tx-exists.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_tx-exists.cli
@@ -1,8 +1,6 @@
-
-unexpected "T"
-expecting hexadecimal digit
-Failed to deserialise  as TxId: Unable to deserialise TxId
-
 Usage: cardano-cli latest query tx-mempool tx-exists TX_ID
 
   Query if a particular transaction exists in the mempool
+
+Available options:
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,14 +1,8 @@
-Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli latest query tx-mempool 
-                                             [--cardano-mode
-                                               [--epoch-slots SLOTS]]
-                                             ( --mainnet
-                                             | --testnet-magic NATURAL
-                                             )
-                                             --socket-path SOCKET_PATH
-                                             (info | next-tx | tx-exists)
-                                             [--output-json | --output-yaml]
-                                             [--out-file FILEPATH]
+unexpected "T"
+expecting hexadecimal digit
+Failed to deserialise  as TxId: Unable to deserialise TxId
 
-  Local Mempool info
+Usage: cardano-cli latest query tx-mempool tx-exists TX_ID
+
+  Query if a particular transaction exists in the mempool

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-value.cli
@@ -64,3 +64,4 @@ Available options:
                            top-level strings and numbers.
   --tx-out-reference-script-file FILEPATH
                            Reference script input file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_sign-witness.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_sign-witness.cli
@@ -11,3 +11,4 @@ Available options:
   --out-canonical-cbor     Produce transaction in canonical CBOR according to
                            RFC7049. Only this part of CIP-21 is implemented.
   --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy.cli
@@ -1,0 +1,9 @@
+Usage: cardano-cli legacy COMMAND
+
+  Legacy commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  genesis                  Genesis block commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_Legacy_commands.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_Legacy_commands.cli
@@ -1,5 +1,0 @@
-Invalid argument `Legacy'
-
-Usage: cardano-cli legacy Legacy commands
-
-  Legacy commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/ping.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/ping.cli
@@ -22,3 +22,4 @@ Available options:
   -Q,--query-versions      Query the supported protocol versions using the
                            handshake protocol and terminate the connection.
   -t,--tip                 Request tip then exit.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_info.cli
@@ -1,10 +1,6 @@
-Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
+Usage: cardano-cli query tx-mempool info 
 
-Usage: cardano-cli query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
-                                      (--mainnet | --testnet-magic NATURAL)
-                                      --socket-path SOCKET_PATH
-                                      (info | next-tx | tx-exists)
-                                      [--output-json | --output-yaml]
-                                      [--out-file FILEPATH]
+  Ask the node about the current mempool's capacity and sizes
 
-  Local Mempool info
+Available options:
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_next-tx.cli
@@ -1,10 +1,6 @@
-Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
+Usage: cardano-cli query tx-mempool next-tx 
 
-Usage: cardano-cli query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
-                                      (--mainnet | --testnet-magic NATURAL)
-                                      --socket-path SOCKET_PATH
-                                      (info | next-tx | tx-exists)
-                                      [--output-json | --output-yaml]
-                                      [--out-file FILEPATH]
+  Requests the next transaction from the mempool's current list
 
-  Local Mempool info
+Available options:
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_tx-exists.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_tx-exists.cli
@@ -1,8 +1,6 @@
-
-unexpected "T"
-expecting hexadecimal digit
-Failed to deserialise  as TxId: Unable to deserialise TxId
-
 Usage: cardano-cli query tx-mempool tx-exists TX_ID
 
   Query if a particular transaction exists in the mempool
+
+Available options:
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,10 +1,8 @@
-Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
-                                      (--mainnet | --testnet-magic NATURAL)
-                                      --socket-path SOCKET_PATH
-                                      (info | next-tx | tx-exists)
-                                      [--output-json | --output-yaml]
-                                      [--out-file FILEPATH]
+unexpected "T"
+expecting hexadecimal digit
+Failed to deserialise  as TxId: Unable to deserialise TxId
 
-  Local Mempool info
+Usage: cardano-cli query tx-mempool tx-exists TX_ID
+
+  Query if a particular transaction exists in the mempool

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/version.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/version.cli
@@ -1,0 +1,6 @@
+Usage: cardano-cli version 
+
+  Show the cardano-cli version
+
+Available options:
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
+++ b/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
@@ -105,7 +105,7 @@ execDetailCardanoCLI
   => [String]
   -- ^ Arguments to the CLI command
   -> m (IO.ExitCode, String, String)
-  -- ^ Captured stdout
+  -- ^ exit code, stdout, stderr
 execDetailCardanoCLI params = GHC.withFrozenCallStack $ execDetailConfigCardanoCLI H.defaultExecConfig params
 
 -- | Execute cardano-cli via the command line, expecting it to fail, and accepting custom config.
@@ -118,7 +118,7 @@ execDetailConfigCardanoCLI
   -> [String]
   -- ^ Arguments to the CLI command
   -> m (IO.ExitCode, String, String)
-  -- ^ Captured stdout
+  -- ^ Exit code, stdout, stderr
 execDetailConfigCardanoCLI cfg = GHC.withFrozenCallStack $ execDetailFlex cfg "cardano-cli" "CARDANO_CLI"
 
 procFlex'
@@ -147,6 +147,7 @@ execDetailFlex
   -> String
   -> [String]
   -> m (IO.ExitCode, String, String)
+-- ^ exit code, stdout, stderr
 execDetailFlex execConfig pkgBin envBin arguments = GHC.withFrozenCallStack $ do
   cp <- procFlex' execConfig pkgBin envBin arguments
   H.annotate . ("Command: " <>) $ case IO.cmdspec cp of

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/AddCostModels.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/AddCostModels.hs
@@ -3,7 +3,6 @@
 module Test.Cli.AddCostModels where
 
 import Cardano.Api
-import Cardano.Api.Internal.ProtocolParameters
 import Cardano.Api.Ledger (StrictMaybe (..))
 import Cardano.Api.Ledger qualified as L
 

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/StakeAddress/DelegationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/StakeAddress/DelegationCertificate.hs
@@ -3,8 +3,8 @@
 
 module Test.Cli.Compatible.StakeAddress.DelegationCertificate where
 
-import Cardano.Api.Internal.Eras
-import Cardano.Api.Internal.Pretty
+import Cardano.Api.Era
+import Cardano.Api.Pretty
 
 import Control.Monad
 import Data.Aeson (Value)

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/StakeAddress/RegistrationCertificate.hs
@@ -3,8 +3,8 @@
 
 module Test.Cli.Compatible.StakeAddress.RegistrationCertificate where
 
-import Cardano.Api.Internal.Eras
-import Cardano.Api.Internal.Pretty
+import Cardano.Api.Era
+import Cardano.Api.Pretty
 
 import Control.Monad
 import Data.Aeson (Value)

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/StakePool/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/StakePool/RegistrationCertificate.hs
@@ -3,8 +3,8 @@
 
 module Test.Cli.Compatible.StakePool.RegistrationCertificate where
 
-import Cardano.Api.Internal.Eras
-import Cardano.Api.Internal.Pretty
+import Cardano.Api.Era
+import Cardano.Api.Pretty
 
 import Data.Aeson (Value)
 import Data.Char (toLower)

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/Transaction/Build.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/Transaction/Build.hs
@@ -2,8 +2,8 @@
 
 module Test.Cli.Compatible.Transaction.Build where
 
-import Cardano.Api.Internal.Eras
-import Cardano.Api.Internal.Pretty
+import Cardano.Api.Era
+import Cardano.Api.Pretty
 
 import Control.Monad.Catch (MonadCatch)
 import Control.Monad.IO.Class

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/CreateTestnetData.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/CreateTestnetData.hs
@@ -6,8 +6,9 @@
 
 module Test.Cli.CreateTestnetData where
 
+import Cardano.Api
+
 import Control.Monad (forM_, void)
-import Data.Aeson (FromJSON, ToJSON)
 import Data.List (isInfixOf)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as M

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/FilePermissions.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/FilePermissions.hs
@@ -6,7 +6,6 @@ module Test.Cli.FilePermissions
 where
 
 import Cardano.Api
-import Cardano.Api.Internal.IO (checkVrfFilePermissions)
 
 import Control.Monad (void)
 

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Json.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Json.hs
@@ -6,7 +6,7 @@ module Test.Cli.Json
   )
 where
 
-import Cardano.Api.Shelley
+import Cardano.Api
 
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Output (QueryKesPeriodInfoOutput (..), createOpCertIntervalInfo)

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Transaction/Build.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Transaction/Build.hs
@@ -2,25 +2,8 @@
 
 module Test.Cli.Transaction.Build where
 
+import Cardano.Api
 import Cardano.Api.Ledger (hashToBytes)
-import Cardano.Api.Shelley
-  ( AddressAny (AddressShelley)
-  , AddressInEra (AddressInEra)
-  , AddressTypeInEra (ShelleyAddressInEra)
-  , AsType (AsAddressAny)
-  , ReferenceScript (ReferenceScriptNone)
-  , ShelleyBasedEra (ShelleyBasedEraConway)
-  , TxId (TxId)
-  , TxIn (TxIn)
-  , TxIx (TxIx)
-  , TxOut (TxOut)
-  , TxOutDatum (TxOutDatumNone)
-  , UTxO (UTxO)
-  , deserialiseAddress
-  , liftIO
-  , lovelaceToTxOutValue
-  , writeFileJSON
-  )
 
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Base16 qualified as Base16

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1749268259,
-        "narHash": "sha256-z3JjhfO/1rLTYfyimwvn9nmySuK8/t8E9100UB7XztM=",
+        "lastModified": 1749631879,
+        "narHash": "sha256-H7dxW3fRA8/U4u4GaR+YVnu6aKkev4GPTPgY524V5uM=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "00cdddf38a472acd1aa517812e0028f70447cc13",
+        "rev": "2d1517e42e1ed5b19deb29c1c4fc9e30d360b961",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add `--help` argument where it was missing.
    Upgrade [cardano-api-10.17.0.0](https://github.com/IntersectMBO/cardano-api/blob/master/cardano-api/CHANGELOG.md#101700). 
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Integrates changes from:
- https://github.com/IntersectMBO/cardano-api/pull/842
- https://github.com/IntersectMBO/cardano-api/pull/840

Changes how we test help texts: instead of inducing a failure by invalid command usage, we now use `--help` toggle for the help text. Help text test will fail if the parsing results in an error.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
