### PR TITLE
Fix annotations in file note functions

### DIFF
--- a/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
+++ b/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
@@ -47,7 +47,7 @@ import GHC.Stack qualified as GHC
 import System.Directory qualified as IO
 import System.Environment qualified as IO
 import System.Exit qualified as IO
-import System.FilePath (takeDirectory)
+import System.FilePath (isAbsolute, takeDirectory, (</>))
 import System.IO.Unsafe qualified as IO
 import System.Process (CreateProcess)
 import System.Process qualified as IO
@@ -258,15 +258,23 @@ cardanoCliPath = "cardano-cli"
 -- | Return the input file path after annotating it relative to the project root directory
 noteInputFile :: (MonadTest m, HasCallStack) => FilePath -> m FilePath
 noteInputFile filePath = GHC.withFrozenCallStack $ do
-  H.annotate $ cardanoCliPath <> "/" <> filePath
+  if isAbsolute filePath
+    then H.annotate filePath
+    else H.annotate $ cardanoCliPath </> filePath
   return filePath
 
 -- | Return the test file path after annotating it relative to the project root directory
 noteTempFile :: (MonadTest m, HasCallStack) => FilePath -> FilePath -> m FilePath
 noteTempFile tempDir filePath = GHC.withFrozenCallStack $ do
-  let relPath = tempDir <> "/" <> filePath
-  H.annotate $ cardanoCliPath <> "/" <> relPath
-  return relPath
+  if isAbsolute filePath
+    then H.note filePath
+    else do
+      let tempWithFilePath = tempDir </> filePath
+      if isAbsolute tempWithFilePath
+        then H.note tempWithFilePath
+        else do
+          H.annotate $ cardanoCliPath </> tempWithFilePath
+          return tempWithFilePath
 
 -- | Return the supply value with the result of the supplied function as a tuple
 withSnd :: (a -> b) -> a -> (a, b)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix annotations in file note functions
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The annotations were incorrect in the case of absolute file paths.  Absolute file paths should not be prepended to.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
