### PR TITLE
Delete `watchdogProp` function

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,7 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2025-06-22T20:18:27Z
+  , hackage.haskell.org 2025-06-27T07:48:39Z
   , cardano-haskell-packages 2025-06-22T22:27:17Z
 
 packages:

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -332,7 +332,7 @@ library cardano-cli-test-lib
     exceptions,
     filepath,
     hedgehog,
-    hedgehog-extras >=0.7.1,
+    hedgehog-extras >=0.9,
     http-types,
     lifted-base,
     mmorph,

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/SigningKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/SigningKeys.hs
@@ -35,7 +35,7 @@ import Hedgehog.Internal.Property (failWith)
 
 hprop_deserialise_legacy_signing_Key :: Property
 hprop_deserialise_legacy_signing_Key =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     legSkeyBs <- H.evalIO $ LB.readFile "test/cardano-cli-golden/files/input/byron/keys/legacy.skey"
     case deserialiseFromBytes decodeLegacyDelegateKey legSkeyBs of
       Left deSerFail -> failWith Nothing $ show deSerFail
@@ -43,7 +43,7 @@ hprop_deserialise_legacy_signing_Key =
 
 hprop_deserialise_nonLegacy_signing_Key :: Property
 hprop_deserialise_nonLegacy_signing_Key =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     skeyBs <- H.evalIO $ LB.readFile "test/cardano-cli-golden/files/input/byron/keys/byron.skey"
     case deserialiseFromBytes Crypto.fromCBORXPrv skeyBs of
       Left deSerFail -> failWith Nothing $ show deSerFail
@@ -51,7 +51,7 @@ hprop_deserialise_nonLegacy_signing_Key =
 
 hprop_print_legacy_signing_key_address :: Property
 hprop_print_legacy_signing_key_address =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     let legKeyFp = "test/cardano-cli-golden/files/input/byron/keys/legacy.skey"
 
     void $
@@ -75,7 +75,7 @@ hprop_print_legacy_signing_key_address =
 
 hprop_print_nonLegacy_signing_key_address :: Property
 hprop_print_nonLegacy_signing_key_address =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     let nonLegKeyFp = "test/cardano-cli-golden/files/input/byron/keys/byron.skey"
 
     void $
@@ -99,7 +99,7 @@ hprop_print_nonLegacy_signing_key_address =
 
 hprop_generate_and_read_nonlegacy_signingkeys :: Property
 hprop_generate_and_read_nonlegacy_signingkeys =
-  watchdogProp . property $ do
+  property $ do
     byronSkey <- H.evalIO $ generateSigningKey AsByronKey
     case deserialiseFromRawBytes (AsSigningKey AsByronKey) (serialiseToRawBytes byronSkey) of
       Left _ -> failWith Nothing "Failed to deserialise non-legacy Byron signing key. "
@@ -107,7 +107,7 @@ hprop_generate_and_read_nonlegacy_signingkeys =
 
 hprop_migrate_legacy_to_nonlegacy_signingkeys :: Property
 hprop_migrate_legacy_to_nonlegacy_signingkeys =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     let legKeyFp = "test/cardano-cli-golden/files/input/byron/keys/legacy.skey"
     nonLegacyKeyFp <- noteTempFile tempDir "nonlegacy.skey"
 
@@ -130,7 +130,7 @@ hprop_migrate_legacy_to_nonlegacy_signingkeys =
 
 hprop_deserialise_NonLegacy_Signing_Key_API :: Property
 hprop_deserialise_NonLegacy_Signing_Key_API =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     eFailOrWit <-
       H.evalIO . runExceptT $
         readByronSigningKey
@@ -142,7 +142,7 @@ hprop_deserialise_NonLegacy_Signing_Key_API =
 
 hprop_deserialiseLegacy_Signing_Key_API :: Property
 hprop_deserialiseLegacy_Signing_Key_API =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     eFailOrWit <-
       H.evalIO . runExceptT $
         readByronSigningKey

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Tx.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Tx.hs
@@ -20,7 +20,7 @@ import Hedgehog.Internal.Property (failWith)
 
 hprop_byronTx_legacy :: Property
 hprop_byronTx_legacy =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     signingKey <- noteInputFile "test/cardano-cli-golden/files/input/byron/keys/legacy.skey"
     expectedTx <- noteInputFile "test/cardano-cli-golden/files/input/byron/tx/legacy.tx"
     createdTx <- noteTempFile tempDir "tx"
@@ -45,7 +45,7 @@ hprop_byronTx_legacy =
 
 hprop_byronTx :: Property
 hprop_byronTx =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     signingKey <- noteInputFile "test/cardano-cli-golden/files/input/byron/keys/byron.skey"
     expectedTx <- noteInputFile "test/cardano-cli-golden/files/input/byron/tx/normal.tx"
     createdTx <- noteTempFile tempDir "tx"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/TxBody.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/TxBody.hs
@@ -1,6 +1,6 @@
 module Test.Golden.Byron.TxBody where
 
-import Test.Cardano.CLI.Util (propertyOnce, watchdogProp)
+import Test.Cardano.CLI.Util (propertyOnce)
 
 import Hedgehog (Property, success)
 
@@ -8,4 +8,4 @@ import Hedgehog (Property, success)
 
 hprop_golden_byronTxBody :: Property
 hprop_golden_byronTxBody =
-  watchdogProp . propertyOnce $ success -- TODO
+  propertyOnce success -- TODO

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/UpdateProposal.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/UpdateProposal.hs
@@ -15,7 +15,7 @@ import Hedgehog.Extras.Test.Base qualified as H
 
 hprop_byron_update_proposal :: Property
 hprop_byron_update_proposal =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     expectedUpdateProposal <- noteInputFile "test/cardano-cli-golden/files/input/byron/update-proposal"
     signingKey <- noteInputFile "test/cardano-cli-golden/files/input/byron/keys/byron.skey"
     createdUpdateProposal <- noteTempFile tempDir "byron-update-proposal"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Vote.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Vote.hs
@@ -18,7 +18,7 @@ import Hedgehog.Internal.Property (failWith)
 
 hprop_byron_yes_vote :: Property
 hprop_byron_yes_vote =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     expectedYesVote <- noteInputFile "test/cardano-cli-golden/files/input/byron/votes/vote-yes"
     proposal <- noteInputFile "test/cardano-cli-golden/files/input/byron/update-proposal"
     signingKey <- noteInputFile "test/cardano-cli-golden/files/input/byron/keys/byron.skey"
@@ -52,7 +52,7 @@ hprop_byron_yes_vote =
 
 hprop_byron_no_vote :: Property
 hprop_byron_no_vote =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     expectedNoVote <- noteInputFile "test/cardano-cli-golden/files/input/byron/votes/vote-no"
     proposal <- noteInputFile "test/cardano-cli-golden/files/input/byron/update-proposal"
     signingKey <- noteInputFile "test/cardano-cli-golden/files/input/byron/keys/byron.skey"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Witness.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Witness.hs
@@ -1,6 +1,6 @@
 module Test.Golden.Byron.Witness where
 
-import Test.Cardano.CLI.Util (propertyOnce, watchdogProp)
+import Test.Cardano.CLI.Util (propertyOnce)
 
 import Hedgehog (Property, success)
 
@@ -8,4 +8,4 @@ import Hedgehog (Property, success)
 
 golden_byronWitness :: Property
 golden_byronWitness =
-  watchdogProp . propertyOnce $ success -- TODO
+  propertyOnce success -- TODO

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Conway/Transaction/Assemble.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Conway/Transaction/Assemble.hs
@@ -15,7 +15,7 @@ import Hedgehog.Extras.Test qualified as H
 
 hprop_golden_conway_transaction_assemble_witness_signing_key :: Property
 hprop_golden_conway_transaction_assemble_witness_signing_key =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     witnessTx <- noteTempFile tempDir "single-signing-key-witness-tx"
     txBodyFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/txbody"
     signingKeyWitnessFile <-

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Conway/Transaction/BuildRaw.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Conway/Transaction/BuildRaw.hs
@@ -18,7 +18,7 @@ import Hedgehog.Extras.Test qualified as H
 -- @cabal test cardano-cli-golden --test-options '-p "/golden conway build raw treasury donation/"'@
 hprop_golden_conway_build_raw_treasury_donation :: Property
 hprop_golden_conway_build_raw_treasury_donation =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     let goldenFile = "test/cardano-cli-golden/files/golden/conway/build-raw-out.tx"
 
     -- Key filepaths
@@ -53,7 +53,7 @@ hprop_golden_conway_build_raw_treasury_donation =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden conway build raw donation no current treasury value/"'@
 hprop_golden_conway_build_raw_donation_no_current_treasury_value :: Property
 hprop_golden_conway_build_raw_donation_no_current_treasury_value =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Key filepaths
     outFile <- noteTempFile tempDir "out.json"
 
@@ -86,7 +86,7 @@ hprop_golden_conway_build_raw_donation_no_current_treasury_value =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden conway build raw donation no treasury donation/"'@
 hprop_golden_conway_build_raw_donation_no_treasury_donation :: Property
 hprop_golden_conway_build_raw_donation_no_treasury_donation =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Key filepaths
     outFile <- noteTempFile tempDir "out.json"
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Conway/Transaction/CreateWitness.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Conway/Transaction/CreateWitness.hs
@@ -20,7 +20,7 @@ txOut =
 
 hprop_golden_shelley_transaction_signing_key_witness :: Property
 hprop_golden_shelley_transaction_signing_key_witness =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     txBodyOutFile <- noteTempFile tempDir "tx-body-out"
 
     -- Create tx body file

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateStaked.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateStaked.hs
@@ -11,7 +11,7 @@ import Data.List (intercalate, sort)
 import System.Directory
 import System.FilePath
 
-import Test.Cardano.CLI.Util (execCardanoCLI, watchdogProp)
+import Test.Cardano.CLI.Util (execCardanoCLI)
 
 import Hedgehog (Property)
 import Hedgehog qualified as H
@@ -33,7 +33,7 @@ tree root = do
 
 hprop_golden_create_staked :: Property
 hprop_golden_create_staked =
-  watchdogProp . propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
     let alonzo = "genesis.alonzo.spec.json"
         conway = "genesis.conway.spec.json"
         networkMagic = 42

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateTestnetData.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateTestnetData.hs
@@ -18,7 +18,7 @@ import System.Directory.Extra (listDirectories)
 import System.FilePath
 
 import Test.Cardano.CLI.Aeson
-import Test.Cardano.CLI.Util (execCardanoCLI, watchdogProp)
+import Test.Cardano.CLI.Util (execCardanoCLI)
 
 import Hedgehog (Property)
 import Hedgehog qualified as H
@@ -105,7 +105,7 @@ golden_create_testnet_data
   -- ^ The path to the shelley template use, if any
   -> Property
 golden_create_testnet_data mShelleyTemplate =
-  watchdogProp . propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
     let outputDir = tempDir </> "out"
         templateArg :: [String] =
           case mShelleyTemplate of
@@ -159,7 +159,7 @@ golden_create_testnet_data mShelleyTemplate =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden create testnet data deleg non deleg/"'@
 hprop_golden_create_testnet_data_deleg_non_deleg :: Property
 hprop_golden_create_testnet_data_deleg_non_deleg =
-  watchdogProp . propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
     let outputDir = tempDir </> "out"
         totalSupply :: Int = 2_000_000_000_000 -- 2*10^12
         delegatedSupply :: Int = 500_000_000_000 -- 5*10^11, i.e. totalSupply / 4
@@ -205,7 +205,7 @@ hprop_golden_create_testnet_data_deleg_non_deleg =
 -- is not specified. It was broken in the past (see https://github.com/IntersectMBO/cardano-node/issues/5953).
 hprop_golden_create_testnet_data_shelley_genesis_output :: Property
 hprop_golden_create_testnet_data_shelley_genesis_output =
-  watchdogProp . propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
     vanillaShelleyGenesis :: ShelleyGenesis <-
       H.readJsonFileOk "test/cardano-cli-golden/files/input/shelley/genesis/genesis.spec.json"
     let tweakedValue = 3_123_456_000_000

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
@@ -26,7 +26,6 @@ import Test.Cardano.CLI.Util
   , noteInputFile
   , noteTempFile
   , propertyOnce
-  , watchdogProp
   )
 import Test.Cardano.CLI.Util qualified as H
 
@@ -36,7 +35,7 @@ import Hedgehog.Extras qualified as H
 
 hprop_golden_governance_action_create_constitution_wrong_hash1_fails :: Property
 hprop_golden_governance_action_create_constitution_wrong_hash1_fails =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleAnchorDataHash
     -- We run the test with the modified hash
@@ -47,7 +46,7 @@ hprop_golden_governance_action_create_constitution_wrong_hash1_fails =
 
 hprop_golden_governance_action_create_constitution_wrong_hash2_fails :: Property
 hprop_golden_governance_action_create_constitution_wrong_hash2_fails =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleAnchorDataHash2
     -- We run the test with the modified hash
@@ -58,7 +57,7 @@ hprop_golden_governance_action_create_constitution_wrong_hash2_fails =
 
 hprop_golden_governance_action_create_constitution :: Property
 hprop_golden_governance_action_create_constitution =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
     base_golden_governance_action_create_constitution
       exampleAnchorDataHash
       exampleAnchorDataHash2
@@ -136,7 +135,7 @@ base_golden_governance_action_create_constitution hash1 hash2 tempDir = do
 
 hprop_golden_conway_governance_action_view_constitution_json :: Property
 hprop_golden_conway_governance_action_view_constitution_json =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     stakeAddressVKeyFile <- H.note "test/cardano-cli-golden/files/input/governance/stake-address.vkey"
     hashFile <- noteTempFile tempDir "hash.txt"
 
@@ -201,7 +200,7 @@ hprop_golden_conway_governance_action_view_constitution_json =
 
 hprop_golden_conway_governance_action_view_update_committee_yaml_wrong_hash_fails :: Property
 hprop_golden_conway_governance_action_view_update_committee_yaml_wrong_hash_fails =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleAnchorDataHash
     -- We run the test with the modified hash
@@ -211,7 +210,7 @@ hprop_golden_conway_governance_action_view_update_committee_yaml_wrong_hash_fail
 
 hprop_golden_conway_governance_action_view_update_committee_yaml :: Property
 hprop_golden_conway_governance_action_view_update_committee_yaml =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
     base_golden_conway_governance_action_view_update_committee_yaml exampleAnchorDataHash tempDir
 
 base_golden_conway_governance_action_view_update_committee_yaml
@@ -268,7 +267,7 @@ base_golden_conway_governance_action_view_update_committee_yaml hash tempDir = d
 
 hprop_golden_conway_governance_action_view_create_info_json_outfile_wrong_hash_fails :: Property
 hprop_golden_conway_governance_action_view_create_info_json_outfile_wrong_hash_fails =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleAnchorDataHash
     -- We run the test with the modified hash
@@ -278,7 +277,7 @@ hprop_golden_conway_governance_action_view_create_info_json_outfile_wrong_hash_f
 
 hprop_golden_conway_governance_action_view_create_info_json_outfile :: Property
 hprop_golden_conway_governance_action_view_create_info_json_outfile =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
     base_golden_conway_governance_action_view_create_info_json_outfile exampleAnchorDataHash tempDir
 
 base_golden_conway_governance_action_view_create_info_json_outfile
@@ -335,7 +334,7 @@ base_golden_conway_governance_action_view_create_info_json_outfile hash tempDir 
 
 hprop_golden_governanceActionCreateNoConfidence_wrong_hash_fails :: Property
 hprop_golden_governanceActionCreateNoConfidence_wrong_hash_fails =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleAnchorDataHash
     -- We run the test with the modified hash
@@ -345,7 +344,7 @@ hprop_golden_governanceActionCreateNoConfidence_wrong_hash_fails =
 
 hprop_golden_governanceActionCreateNoConfidence :: Property
 hprop_golden_governanceActionCreateNoConfidence =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
     base_golden_governanceActionCreateNoConfidence exampleAnchorDataHash tempDir
 
 base_golden_governanceActionCreateNoConfidence
@@ -408,7 +407,7 @@ base_golden_governanceActionCreateNoConfidence hash tempDir = do
 
 hprop_golden_conway_governance_action_create_protocol_parameters_update_wrong_hash_fails :: Property
 hprop_golden_conway_governance_action_create_protocol_parameters_update_wrong_hash_fails =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleAnchorDataHash
     -- We run the test with the modified hash
@@ -418,7 +417,7 @@ hprop_golden_conway_governance_action_create_protocol_parameters_update_wrong_ha
 
 hprop_golden_conway_governance_action_create_protocol_parameters_update :: Property
 hprop_golden_conway_governance_action_create_protocol_parameters_update =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
     base_golden_conway_governance_action_create_protocol_parameters_update exampleAnchorDataHash tempDir
 
 base_golden_conway_governance_action_create_protocol_parameters_update
@@ -474,7 +473,7 @@ base_golden_conway_governance_action_create_protocol_parameters_update hash temp
 hprop_golden_conway_governance_action_create_protocol_parameters_update_partial_costmodel
   :: Property
 hprop_golden_conway_governance_action_create_protocol_parameters_update_partial_costmodel =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     stakeAddressVKeyFile <- H.note "test/cardano-cli-golden/files/input/governance/stake-address.vkey"
     costModelsFile <- H.note "test/cardano-cli-golden/files/input/governance/costmodels-partial.json"
 
@@ -508,7 +507,7 @@ hprop_golden_conway_governance_action_create_protocol_parameters_update_partial_
 
 hprop_golden_conway_governance_action_create_hardfork_wrong_hash_fails :: Property
 hprop_golden_conway_governance_action_create_hardfork_wrong_hash_fails =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleAnchorDataHash
     -- We run the test with the modified hash
@@ -518,7 +517,7 @@ hprop_golden_conway_governance_action_create_hardfork_wrong_hash_fails =
 
 hprop_golden_conway_governance_action_create_hardfork :: Property
 hprop_golden_conway_governance_action_create_hardfork =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
     base_golden_conway_governance_action_create_hardfork exampleAnchorDataHash tempDir
 
 base_golden_conway_governance_action_create_hardfork

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Committee.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Committee.hs
@@ -38,7 +38,7 @@ hprop_golden_governance_committee_key_gen =
         [ ("key-gen-cold", "Cold")
         , ("key-gen-hot", "Hot")
         ]
-   in watchdogProp . propertyOnce $ forM_ supplyValues $ \(flag, inJson) ->
+   in propertyOnce $ forM_ supplyValues $ \(flag, inJson) ->
         H.moduleWorkspace "tmp" $ \tempDir -> do
           verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
           signingKeyFile <- noteTempFile tempDir "key-gen.skey"
@@ -71,7 +71,7 @@ hprop_golden_governance_committee_key_gen =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden governance CommitteeCreateHotKeyAuthorizationCertificate/"'@
 hprop_golden_governance_CommitteeCreateHotKeyAuthorizationCertificate :: Property
 hprop_golden_governance_CommitteeCreateHotKeyAuthorizationCertificate =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     ccColdVKey <- noteTempFile tempDir "cc-cold.vkey"
     ccColdSKey <- noteTempFile tempDir "cc-cold.skey"
     ccHotVKey <- noteTempFile tempDir "cc-hot.vkey"
@@ -127,7 +127,7 @@ hprop_golden_governance_CommitteeCreateHotKeyAuthorizationCertificate =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden governance CommitteeCreateColdKeyResignationCertificate/"'@
 hprop_golden_governance_CommitteeCreateColdKeyResignationCertificate :: Property
 hprop_golden_governance_CommitteeCreateColdKeyResignationCertificate =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     ccColdVKey <- noteTempFile tempDir "cold.vkey"
     ccColdSKey <- noteTempFile tempDir "cold.skey"
 
@@ -167,7 +167,7 @@ hprop_golden_governance_CommitteeCreateColdKeyResignationCertificate =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden governance UpdateCommittee/"'@
 hprop_golden_governance_UpdateCommittee :: Property
 hprop_golden_governance_UpdateCommittee =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     stakeVkey <- noteInputFile $ inputDir </> "governance/stake-address.vkey"
     ccProposal <- noteInputFile $ inputDir </> "governance/committee/cc-proposal.txt"
     coldCCVkey1 <- noteInputFile $ inputDir </> "governance/committee/cc-cold1.vkey"
@@ -223,7 +223,7 @@ hprop_golden_governance_UpdateCommittee =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden governance committee cold extended key signing/"'@
 hprop_golden_governance_committee_cold_extended_key_signing :: Property
 hprop_golden_governance_committee_cold_extended_key_signing =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     skeyFile <- noteInputFile $ inputDir </> "governance/committee/cc.extended.cold.skey"
     txBody <- noteInputFile $ inputDir </> "governance/drep/extended-key-signing/tx.body"
 
@@ -249,7 +249,7 @@ hprop_golden_governance_committee_cold_extended_key_signing =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden governance committee hot extended key signing/"'@
 hprop_golden_governance_committee_hot_extended_key_signing :: Property
 hprop_golden_governance_committee_hot_extended_key_signing =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     skeyFile <- noteInputFile $ inputDir </> "governance/committee/cc.extended.hot.skey"
     txBody <- noteInputFile $ inputDir </> "governance/drep/extended-key-signing/tx.body"
 
@@ -286,7 +286,7 @@ hprop_golden_verification_key_committee = do
           )
         ]
 
-  watchdogProp . propertyOnce $ forM_ values $ \(skeyFile, vkeyGolden) ->
+  propertyOnce $ forM_ values $ \(skeyFile, vkeyGolden) ->
     H.moduleWorkspace "tmp" $ \tempDir -> do
       vkeyFileOut <- noteTempFile tempDir "cc.extended.vkey"
 
@@ -317,7 +317,7 @@ hprop_golden_governance_extended_committee_key_hash =
           , "4eb7202ffcc6d5513dba5edc618bd7b582a257c76d6b0cd83975f4e6\n"
           )
         ]
-   in watchdogProp . propertyOnce $ forM_ supplyValues $ \(extendedKeyFile, expected) ->
+   in propertyOnce $ forM_ supplyValues $ \(extendedKeyFile, expected) ->
         H.moduleWorkspace "tmp" $ \_tempDir -> do
           verificationKeyFile <- H.noteInputFile extendedKeyFile
 
@@ -337,7 +337,7 @@ hprop_golden_governance_extended_committee_key_hash =
 -- @cabal test cardano-cli-test --test-options '-p "/golden governance committee checks wrong hash fails/"'@
 hprop_golden_governance_committee_checks_wrong_hash_fails :: Property
 hprop_golden_governance_committee_checks_wrong_hash_fails =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleAnchorDataHash
     let relativeUrl = ["ipfs", exampleAnchorDataIpfsHash]

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
@@ -21,7 +21,7 @@ import           GHC.IO.Exception (ExitCode (ExitFailure))
 import           Test.Cardano.CLI.Hash (exampleAnchorDataHash, exampleAnchorDataIpfsHash,
                    exampleAnchorDataPathGolden, serveFilesWhile, tamperBase16Hash)
 import           Test.Cardano.CLI.Util (execCardanoCLI, execDetailCardanoCLI,
-                   noteInputFile, noteTempFile, propertyOnce, watchdogProp)
+                   noteInputFile, noteTempFile, propertyOnce)
 
 import           Hedgehog
 import qualified Hedgehog as H
@@ -35,7 +35,7 @@ drepRegistrationCertFile = "test/cardano-cli-golden/files/golden/governance/drep
 
 hprop_golden_governanceDRepKeyGen :: Property
 hprop_golden_governanceDRepKeyGen =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKeyFile <- H.noteTempFile tempDir "key-gen.vkey"
     signingKeyFile <- H.noteTempFile tempDir "key-gen.skey"
 
@@ -73,7 +73,7 @@ hprop_golden_governanceDRepKeyGen =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden governance drep id bech32/"'@
 hprop_golden_governance_drep_id_bech32 :: Property
 hprop_golden_governance_drep_id_bech32 =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/drep.vkey"
     idFile <- H.noteTempFile tempDir "drep.id.bech32"
     idGold <- H.note "test/cardano-cli-golden/files/golden/governance/drep/drep.id.bech32"
@@ -97,7 +97,7 @@ hprop_golden_governance_drep_id_bech32 =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden governance drep id hex/"'@
 hprop_golden_governance_drep_id_hex :: Property
 hprop_golden_governance_drep_id_hex =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/drep.vkey"
     idFile <- H.noteTempFile tempDir "drep.id.hex"
     idGold <- H.note "test/cardano-cli-golden/files/golden/governance/drep/drep.id.hex"
@@ -121,7 +121,7 @@ hprop_golden_governance_drep_id_hex =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden governance drep id hash/"'@
 hprop_golden_governance_drep_id_hash :: Property
 hprop_golden_governance_drep_id_hash =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     idGold <- H.note "test/cardano-cli-golden/files/golden/governance/drep/drep.id.hash"
 
     output <-
@@ -138,7 +138,7 @@ hprop_golden_governance_drep_id_hash =
 
 hprop_golden_governance_drep_extended_key_signing :: Property
 hprop_golden_governance_drep_extended_key_signing =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     skeyFile <-
       noteInputFile "test/cardano-cli-golden/files/input/governance/drep/extended-key-signing/drep.skey"
     txBody <-
@@ -165,7 +165,7 @@ hprop_golden_governance_drep_extended_key_signing =
 
 hprop_golden_governance_drep_retirement_certificate_vkey_file :: Property
 hprop_golden_governance_drep_retirement_certificate_vkey_file =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     drepVKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/drep.vkey"
     certFile <- H.noteTempFile tempDir "drep.retirement.cert"
     H.noteShow_ drepRetirementCertFile
@@ -188,7 +188,7 @@ hprop_golden_governance_drep_retirement_certificate_vkey_file =
 
 hprop_golden_governance_drep_retirement_certificate_id_hex :: Property
 hprop_golden_governance_drep_retirement_certificate_id_hex =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     certFile <- H.noteTempFile tempDir "drep.retirement.cert"
     H.noteShow_ drepRetirementCertFile
 
@@ -212,7 +212,7 @@ hprop_golden_governance_drep_retirement_certificate_id_hex =
 
 hprop_golden_governance_drep_retirement_certificate_id_bech32 :: Property
 hprop_golden_governance_drep_retirement_certificate_id_bech32 =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     certFile <- H.noteTempFile tempDir "drep.retirement.cert"
     H.noteShow_ drepRetirementCertFile
 
@@ -236,7 +236,7 @@ hprop_golden_governance_drep_retirement_certificate_id_bech32 =
 
 hprop_golden_governance_drep_metadata_hash :: Property
 hprop_golden_governance_drep_metadata_hash =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     goldenDRepMetadataHash <-
       H.note "test/cardano-cli-golden/files/golden/governance/drep/drep_metadata_hash"
 
@@ -264,7 +264,7 @@ hprop_golden_governance_drep_metadata_hash =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden governance drep metadata hash cip119/"'@
 hprop_golden_governance_drep_metadata_hash_cip119 :: Property
 hprop_golden_governance_drep_metadata_hash_cip119 =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     goldenDRepMetadataHashCip119 <-
       H.note "test/cardano-cli-golden/files/golden/governance/drep/drep_metadata_hash_cip119"
 
@@ -289,7 +289,7 @@ hprop_golden_governance_drep_metadata_hash_cip119 =
 
 hprop_golden_governance_drep_registration_certificate_vkey_file :: Property
 hprop_golden_governance_drep_registration_certificate_vkey_file =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     drepVKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/drep.vkey"
     H.noteShow_ drepRegistrationCertFile
 
@@ -317,7 +317,7 @@ hprop_golden_governance_drep_registration_certificate_vkey_file =
 
 hprop_golden_governance_drep_registration_certificate_id_hex :: Property
 hprop_golden_governance_drep_registration_certificate_id_hex =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     idFile <- H.readFile "test/cardano-cli-golden/files/input/drep.id.hex"
     H.noteShow_ drepRegistrationCertFile
 
@@ -345,7 +345,7 @@ hprop_golden_governance_drep_registration_certificate_id_hex =
 
 hprop_golden_governance_drep_registration_certificate_id_bech32 :: Property
 hprop_golden_governance_drep_registration_certificate_id_bech32 =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     idFile <- H.readFile "test/cardano-cli-golden/files/input/drep.id.bech32"
     H.noteShow_ drepRegistrationCertFile
 
@@ -373,7 +373,7 @@ hprop_golden_governance_drep_registration_certificate_id_bech32 =
 
 hprop_golden_governance_drep_registration_certificate_script_hash :: Property
 hprop_golden_governance_drep_registration_certificate_script_hash =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     goldenFile <-
       H.note
         "test/cardano-cli-golden/files/golden/governance/drep/drep_registration_certificate_script.json"
@@ -404,7 +404,7 @@ hprop_golden_governance_drep_registration_certificate_script_hash =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden governance drep update certificate vkey file/"'@
 hprop_golden_governance_drep_update_certificate_vkey_file :: Property
 hprop_golden_governance_drep_update_certificate_vkey_file =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     drepVKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/drep.vkey"
     goldenFile <-
       H.note "test/cardano-cli-golden/files/golden/governance/drep/drep_update_certificate.json"
@@ -433,7 +433,7 @@ hprop_golden_governance_drep_update_certificate_vkey_file =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden governance drep update certificate script hash/"'@
 hprop_golden_governance_drep_update_certificate_script_hash :: Property
 hprop_golden_governance_drep_update_certificate_script_hash =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     goldenFile <-
       H.note
         "test/cardano-cli-golden/files/golden/governance/drep/drep_update_certificate_script_hash.json"
@@ -461,7 +461,7 @@ hprop_golden_governance_drep_update_certificate_script_hash =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden verification key drep/"'@
 hprop_golden_verification_key_drep :: Property
 hprop_golden_verification_key_drep =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     skeyFile <-
       noteInputFile "test/cardano-cli-golden/files/input/governance/drep/extended-key-signing/drep.skey"
     vkeyFileOut <- noteTempFile tempDir "drep.extended.vkey"
@@ -484,7 +484,7 @@ hprop_golden_verification_key_drep =
 -- @cabal test cardano-cli-test --test-options '-p "/drep metadata hash url wrong hash fails/"'@
 hprop_golden_drep_metadata_hash_url_wrong_hash_fails :: Property
 hprop_golden_drep_metadata_hash_url_wrong_hash_fails =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleAnchorDataHash
     let relativeUrl = [exampleAnchorDataIpfsHash]

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/StakeAddress.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/StakeAddress.hs
@@ -12,7 +12,6 @@ import Test.Cardano.CLI.Util
   , execDetailCardanoCLI
   , noteInputFile
   , propertyOnce
-  , watchdogProp
   )
 
 import Hedgehog
@@ -30,7 +29,7 @@ exampleStakePoolMetadataIpfsHash = "QmR1HAT4Hb4HjjqcgoXwupYXMF6t8h7MoSP24HMfV8t3
 
 hprop_golden_conway_stakeaddress_delegate_no_confidence :: Property
 hprop_golden_conway_stakeaddress_delegate_no_confidence =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/stake.vkey"
     delegFile <- H.noteTempFile tempDir "deleg"
     delegGold <-
@@ -52,7 +51,7 @@ hprop_golden_conway_stakeaddress_delegate_no_confidence =
 
 hprop_golden_conway_stakeaddress_delegate_always_abstain :: Property
 hprop_golden_conway_stakeaddress_delegate_always_abstain =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/stake.vkey"
     delegFile <- H.noteTempFile tempDir "deleg"
     delegGold <-
@@ -74,7 +73,7 @@ hprop_golden_conway_stakeaddress_delegate_always_abstain =
 
 hprop_golden_conway_stakeaddress_delegate_pool_and_no_confidence :: Property
 hprop_golden_conway_stakeaddress_delegate_pool_and_no_confidence =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/stake.vkey"
     vkeyPool <- noteInputFile "test/cardano-cli-golden/files/input/conway/poolCold.vkey"
     delegFile <- H.noteTempFile tempDir "deleg"
@@ -99,7 +98,7 @@ hprop_golden_conway_stakeaddress_delegate_pool_and_no_confidence =
 
 hprop_golden_conway_stakeaddress_delegate_pool_and_always_abstain :: Property
 hprop_golden_conway_stakeaddress_delegate_pool_and_always_abstain =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/stake.vkey"
     vkeyPool <- noteInputFile "test/cardano-cli-golden/files/input/conway/poolCold.vkey"
     delegFile <- H.noteTempFile tempDir "deleg"
@@ -124,7 +123,7 @@ hprop_golden_conway_stakeaddress_delegate_pool_and_always_abstain =
 
 hprop_golden_conway_stakeaddress_delegate_pool_and_drep :: Property
 hprop_golden_conway_stakeaddress_delegate_pool_and_drep =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/stake.vkey"
     vkeyPool <- noteInputFile "test/cardano-cli-golden/files/input/conway/poolCold.vkey"
     vkeyDrep <- noteInputFile "test/cardano-cli-golden/files/input/governance/drep/drep.vkey"
@@ -153,7 +152,7 @@ hprop_golden_conway_stakeaddress_delegate_pool_and_drep =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden conway stakeaddress register and delegate pool/"'@
 hprop_golden_conway_stakeaddress_register_and_delegate_pool :: Property
 hprop_golden_conway_stakeaddress_register_and_delegate_pool =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/stake.vkey"
     vkeyPool <- noteInputFile "test/cardano-cli-golden/files/input/conway/poolCold.vkey"
     certFile <- H.noteTempFile tempDir "cert"
@@ -182,7 +181,7 @@ hprop_golden_conway_stakeaddress_register_and_delegate_pool =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden conway stakeaddress register and delegate vote/"'@
 hprop_golden_conway_stakeaddress_register_and_delegate_vote :: Property
 hprop_golden_conway_stakeaddress_register_and_delegate_vote =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/stake.vkey"
     vkeyDrepFile <- noteInputFile "test/cardano-cli-golden/files/input/governance/drep/drep.vkey"
     certFile <- H.noteTempFile tempDir "cert"
@@ -211,7 +210,7 @@ hprop_golden_conway_stakeaddress_register_and_delegate_vote =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden conway stakeaddress register and delegate stake and vote/"'@
 hprop_golden_conway_stakeaddress_register_and_delegate_stake_and_vote :: Property
 hprop_golden_conway_stakeaddress_register_and_delegate_stake_and_vote =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/stake.vkey"
     vkeyPool <- noteInputFile "test/cardano-cli-golden/files/input/conway/poolCold.vkey"
     vkeyDrepFile <- noteInputFile "test/cardano-cli-golden/files/input/governance/drep/drep.vkey"
@@ -243,7 +242,7 @@ hprop_golden_conway_stakeaddress_register_and_delegate_stake_and_vote =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden stake pool metadata hash url wrong hash/"'@
 hprop_golden_stake_pool_metadata_hash_url_wrong_hash :: Property
 hprop_golden_stake_pool_metadata_hash_url_wrong_hash = do
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleStakePoolMetadataHash
     let relativeUrl = [exampleStakePoolMetadataIpfsHash]

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Vote.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Vote.hs
@@ -19,7 +19,6 @@ import Test.Cardano.CLI.Util
   , execDetailConfigCardanoCLI
   , noteInputFile
   , propertyOnce
-  , watchdogProp
   )
 
 import Hedgehog (Property, (===))
@@ -28,7 +27,7 @@ import Hedgehog.Extras qualified as H
 
 hprop_golden_governance_governance_vote_create :: Property
 hprop_golden_governance_governance_vote_create =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/drep.vkey"
     voteFile <- H.noteTempFile tempDir "vote"
     voteGold <- H.note "test/cardano-cli-golden/files/golden/governance/vote/vote"
@@ -61,7 +60,7 @@ voteViewJsonFile = "test/cardano-cli-golden/files/golden/governance/vote/voteVie
 
 hprop_golden_governance_governance_vote_view_json_stdout :: Property
 hprop_golden_governance_governance_vote_view_json_stdout =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     voteFile <- noteInputFile "test/cardano-cli-golden/files/input/governance/vote/vote"
     H.noteShow_ voteViewJsonFile
     voteView <-
@@ -78,7 +77,7 @@ hprop_golden_governance_governance_vote_view_json_stdout =
 
 hprop_golden_governance_governance_vote_view_json_outfile :: Property
 hprop_golden_governance_governance_vote_view_json_outfile =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     voteFile <- noteInputFile "test/cardano-cli-golden/files/input/governance/vote/vote"
     voteViewFile <- H.noteTempFile tempDir "voteView"
     H.noteShow_ voteViewJsonFile
@@ -98,7 +97,7 @@ hprop_golden_governance_governance_vote_view_json_outfile =
 
 hprop_golden_governance_governance_vote_view_yaml :: Property
 hprop_golden_governance_governance_vote_view_yaml =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     voteFile <- noteInputFile "test/cardano-cli-golden/files/input/governance/vote/vote"
     voteViewGold <- H.note "test/cardano-cli-golden/files/golden/governance/vote/voteViewYAML"
     voteView <-
@@ -116,7 +115,7 @@ hprop_golden_governance_governance_vote_view_yaml =
 
 hprop_golden_governance_governance_vote_create_yes_cc_hot_key :: Property
 hprop_golden_governance_governance_vote_create_yes_cc_hot_key =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     ccVkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/cc.vkey"
     voteFile <- H.noteTempFile tempDir "vote"
     voteGold <- H.note "test/cardano-cli-golden/files/golden/governance/vote/vote_cc_yes.json"
@@ -142,7 +141,7 @@ hprop_golden_governance_governance_vote_create_yes_cc_hot_key =
 
 hprop_golden_governance_governance_vote_create_no_cc_hot_key :: Property
 hprop_golden_governance_governance_vote_create_no_cc_hot_key =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     ccVkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/cc.vkey"
     voteFile <- H.noteTempFile tempDir "vote"
     voteGold <- H.note "test/cardano-cli-golden/files/golden/governance/vote/vote_cc_no.json"
@@ -168,7 +167,7 @@ hprop_golden_governance_governance_vote_create_no_cc_hot_key =
 
 hprop_golden_governance_governance_vote_create_abstain_cc_hot_key :: Property
 hprop_golden_governance_governance_vote_create_abstain_cc_hot_key =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     ccVkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/cc.vkey"
     voteFile <- H.noteTempFile tempDir "vote"
     voteGold <- H.note "test/cardano-cli-golden/files/golden/governance/vote/vote_cc_abstain.json"
@@ -196,7 +195,7 @@ hprop_golden_governance_governance_vote_create_abstain_cc_hot_key =
 -- @cabal test cardano-cli-test --test-options '-p "/golden governance vote create wrong hash fails/"'@
 hprop_golden_governance_vote_create_hash_fails :: Property
 hprop_golden_governance_vote_create_hash_fails =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleAnchorDataHash
     let relativeUrl = ["ipfs", exampleAnchorDataIpfsHash]

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Hash/Hash.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Hash/Hash.hs
@@ -12,7 +12,7 @@ import Hedgehog.Extras qualified as H
 
 hprop_golden_governance_hash_script :: Property
 hprop_golden_governance_hash_script =
-  watchdogProp . H.propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  H.propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     scriptFile <- noteInputFile "test/cardano-cli-golden/files/input/hash/foo.script"
     hashFile <- H.noteTempFile tempDir "foo.script.hash"
     hashGold <- H.note "test/cardano-cli-golden/files/golden/hash/foo.script.hash"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
@@ -24,7 +24,7 @@ import System.FilePath ((</>))
 import System.Process.Extra (readProcess)
 import Text.Regex (Regex, mkRegex, subRegex)
 
-import Test.Cardano.CLI.Util (execCardanoCLI, propertyOnce, watchdogProp)
+import Test.Cardano.CLI.Util (execCardanoCLI, propertyOnce)
 import Test.Cardano.CLI.Util qualified as H
 
 import Hedgehog (Property)
@@ -61,7 +61,7 @@ extractCmd =
 -- expected result.
 hprop_golden_HelpAll :: Property
 hprop_golden_HelpAll =
-  watchdogProp . propertyOnce . H.moduleWorkspace "help" $ \_ -> do
+  propertyOnce . H.moduleWorkspace "help" $ \_ -> do
     -- These tests are not run on Windows because the cardano-cli usage
     -- output is slightly different on Windows.  For example it uses
     -- "cardano-cli.exe" instead of "cardano-cli".
@@ -128,7 +128,7 @@ test_golden_HelpCmds =
           "help-commands"
           [ testProperty
               (subPath usage)
-              ( watchdogProp . propertyOnce . H.moduleWorkspace "help-commands" $ \_ -> do
+              ( propertyOnce . H.moduleWorkspace "help-commands" $ \_ -> do
                   H.noteShow_ usage
                   let expectedCmdHelpFp =
                         "test/cardano-cli-golden/files/golden" </> subPath usage

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Key/NonExtendedKey.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Key/NonExtendedKey.hs
@@ -6,7 +6,7 @@ import Control.Monad (void)
 import Control.Monad.Extra (forM_)
 import System.FilePath ((</>))
 
-import Test.Cardano.CLI.Util (execCardanoCLI, propertyOnce, watchdogProp)
+import Test.Cardano.CLI.Util (execCardanoCLI, propertyOnce)
 import Test.Cardano.CLI.Util qualified as H
 
 import Hedgehog (Property)
@@ -18,7 +18,7 @@ import Hedgehog.Extras.Test qualified as H
 -- expected result.
 hprop_golden_KeyNonExtendedKey_GenesisExtendedVerificationKey :: Property
 hprop_golden_KeyNonExtendedKey_GenesisExtendedVerificationKey =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     genesisVKeyFp <-
       H.noteInputFile "test/cardano-cli-golden/files/input/key/non-extended-keys/shelley.000.vkey"
     nonExtendedFp <-
@@ -43,7 +43,7 @@ hprop_golden_KeyNonExtendedKey_GenesisExtendedVerificationKey =
 -- expected result.
 hprop_golden_KeyNonExtendedKey_StakeExtendedVerificationKeyShelley :: Property
 hprop_golden_KeyNonExtendedKey_StakeExtendedVerificationKeyShelley =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     genesisVKeyFp <-
       H.noteInputFile "test/cardano-cli-golden/files/input/key/non-extended-keys/stake.000.vkey"
     nonExtendedFp <-
@@ -68,7 +68,7 @@ hprop_golden_KeyNonExtendedKey_StakeExtendedVerificationKeyShelley =
 -- expected result.
 hprop_golden_KeyNonExtendedKey_DRepExtendedVerificationKey :: Property
 hprop_golden_KeyNonExtendedKey_DRepExtendedVerificationKey =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     extendedKeyFile <-
       H.noteInputFile "test/cardano-cli-golden/files/input/key/non-extended-keys/extended-drep.vkey"
     goldenFile <-
@@ -92,7 +92,7 @@ hprop_golden_KeyNonExtendedKey_DRepExtendedVerificationKey =
 -- expected result.
 hprop_golden_extended_payment_vkey_to_non_extended_vkey :: Property
 hprop_golden_extended_payment_vkey_to_non_extended_vkey =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     extendedKeyFile <-
       H.noteInputFile "test/cardano-cli-golden/files/input/key/non-extended-keys/extended-payment.vkey"
     goldenFile <-
@@ -118,7 +118,7 @@ hprop_golden_extended_payment_vkey_to_non_extended_vkey =
 hprop_golden_extended_cc_vkey_to_non_extended_vkey :: Property
 hprop_golden_extended_cc_vkey_to_non_extended_vkey =
   let supplyValues = ["cc-cold.vkey", "cc-hot.vkey"]
-   in watchdogProp . propertyOnce $ forM_ supplyValues $ \suffix ->
+   in propertyOnce $ forM_ supplyValues $ \suffix ->
         H.moduleWorkspace "tmp" $ \tempDir -> do
           extendedKeyFile <-
             H.noteInputFile $ "test/cardano-cli-golden/files/input/key/non-extended-keys/extended-" <> suffix

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Latest/Transaction/CalculateMinFee.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Latest/Transaction/CalculateMinFee.hs
@@ -24,7 +24,7 @@ import Hedgehog.Extras qualified as H
 
 hprop_golden_latest_transaction_calculate_min_fee :: Property
 hprop_golden_latest_transaction_calculate_min_fee =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     protocolParamsJsonFile <-
       noteInputFile
         "test/cardano-cli-golden/files/input/transaction/calculate-min-fee/protocol-params-preview.json"
@@ -60,7 +60,7 @@ hprop_golden_latest_transaction_calculate_min_fee_flags = do
         , ["--output-json", "--out-file"]
         , ["--output-text", "--out-file"]
         ]
-  watchdogProp . propertyOnce $ forM_ supplyValues $ \flags ->
+  propertyOnce $ forM_ supplyValues $ \flags ->
     H.moduleWorkspace "tmp" $ \tempDir -> do
       protocolParamsJsonFile <-
         noteInputFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Build.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Build.hs
@@ -14,7 +14,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_shelleyAddressBuild :: Property
 hprop_golden_shelleyAddressBuild =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     addressVKeyFile <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/payment_keys/verification_key"
     addressSKeyFile <-

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Info.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Info.hs
@@ -14,7 +14,7 @@ import Hedgehog qualified as H
 
 hprop_golden_shelleyAddressInfo :: Property
 hprop_golden_shelleyAddressInfo =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     -- Disable as per commit: e69984d797fc3bdd5d71bdd99a0328110d71f6ad
     when False $ do
       let byronBase58 =

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/KeyGen.hs
@@ -15,7 +15,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_shelley_address_key_gen :: Property
 hprop_golden_shelley_address_key_gen =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     addressVKeyFile <- noteTempFile tempDir "address.vkey"
     addressSKeyFile <- noteTempFile tempDir "address.skey"
 
@@ -48,7 +48,7 @@ hprop_golden_shelley_address_key_gen =
 
 hprop_golden_shelley_address_extended_key_gen :: Property
 hprop_golden_shelley_address_extended_key_gen =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     addressVKeyFile <- noteTempFile tempDir "address.vkey"
     addressSKeyFile <- noteTempFile tempDir "address.skey"
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/InitialTxIn.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/InitialTxIn.hs
@@ -11,7 +11,7 @@ import Hedgehog.Extras qualified as H
 
 hprop_golden_shelleyGenesisInitialTxIn :: Property
 hprop_golden_shelleyGenesisInitialTxIn =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     verificationKeyFile <-
       noteInputFile
         "test/cardano-cli-golden/files/input/shelley/keys/genesis_verification_keys/genesis-utxo.vkey"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenDelegate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenDelegate.hs
@@ -15,7 +15,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_shelley_genesis_key_gen_delegate :: Property
 hprop_golden_shelley_genesis_key_gen_delegate =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
     signingKeyFile <- noteTempFile tempDir "key-gen.skey"
     operationalCertificateIssueCounterFile <- noteTempFile tempDir "op-cert.counter"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
@@ -15,7 +15,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_shelleyGenesisKeyGenGenesis :: Property
 hprop_golden_shelleyGenesisKeyGenGenesis =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
     signingKeyFile <- noteTempFile tempDir "key-gen.skey"
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
@@ -15,7 +15,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_shelleyGenesisKeyGenUtxo :: Property
 hprop_golden_shelleyGenesisKeyGenUtxo =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     utxoVerificationKeyFile <- noteTempFile tempDir "utxo.vkey"
     utxoSigningKeyFile <- noteTempFile tempDir "utxo.skey"
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyHash.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyHash.hs
@@ -12,7 +12,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_shelleyGenesisKeyHash :: Property
 hprop_golden_shelleyGenesisKeyHash =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     referenceVerificationKey <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/genesis_keys/verification_key"
     goldenGenesisVerificationKeyHashFile <-

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Key/ConvertCardanoAddressKey.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Key/ConvertCardanoAddressKey.hs
@@ -44,7 +44,7 @@ exampleShelleySigningKey =
 -- expected result.
 hprop_golden_convertCardanoAddressByronSigningKey :: Property
 hprop_golden_convertCardanoAddressByronSigningKey =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- `cardano-address` signing key filepath
     signingKeyFp <- noteTempFile tempDir "cardano-address-byron.skey"
 
@@ -82,7 +82,7 @@ hprop_golden_convertCardanoAddressByronSigningKey =
 -- expected result.
 hprop_golden_convertCardanoAddressIcarusSigningKey :: Property
 hprop_golden_convertCardanoAddressIcarusSigningKey =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- `cardano-address` signing key filepath
     signingKeyFp <- H.noteTempFile tempDir "cardano-address-icarus.skey"
 
@@ -120,7 +120,7 @@ hprop_golden_convertCardanoAddressIcarusSigningKey =
 -- yields the expected result.
 hprop_golden_convertCardanoAddressShelleyPaymentSigningKey :: Property
 hprop_golden_convertCardanoAddressShelleyPaymentSigningKey =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- `cardano-address` signing key filepath
     signingKeyFp <-
       noteTempFile tempDir "cardano-address-shelley-payment.skey"
@@ -159,7 +159,7 @@ hprop_golden_convertCardanoAddressShelleyPaymentSigningKey =
 -- the expected result.
 hprop_golden_convertCardanoAddressShelleyStakeSigningKey :: Property
 hprop_golden_convertCardanoAddressShelleyStakeSigningKey =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- `cardano-address` signing key filepath
     signingKeyFp <-
       noteTempFile tempDir "cardano-address-shelley-stake.skey"
@@ -206,7 +206,7 @@ hprop_golden_convert_cardano_address_cc_drep = do
         , ("drep.key", "--drep-key", "Delegated Representative")
         ]
 
-  watchdogProp . propertyOnce $ forM_ supplyValues $ \(filename, flag, descPrefix) -> H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ forM_ supplyValues $ \(filename, flag, descPrefix) -> H.moduleWorkspace "tmp" $ \tempDir -> do
     let outFile = tempDir </> "out.json"
 
     -- `cardano-address` signing key filepath

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
@@ -17,7 +17,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_stakePoolMetadataHash :: Property
 hprop_golden_stakePoolMetadataHash =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     referenceStakePoolMetadata <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/metadata/stake_pool_metadata_hash"
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/MultiSig/Address.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/MultiSig/Address.hs
@@ -11,7 +11,7 @@ import Hedgehog.Extras.Test qualified as H
 
 hprop_golden_shelleyAllMultiSigAddressBuild :: Property
 hprop_golden_shelleyAllMultiSigAddressBuild =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
     allMultiSigFp <- noteInputFile "test/cardano-cli-golden/files/input/shelley/multisig/scripts/all"
 
     allMultiSigAddress <-
@@ -33,7 +33,7 @@ hprop_golden_shelleyAllMultiSigAddressBuild =
 
 hprop_golden_shelleyAnyMultiSigAddressBuild :: Property
 hprop_golden_shelleyAnyMultiSigAddressBuild =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
     anyMultiSigFp <- noteInputFile "test/cardano-cli-golden/files/input/shelley/multisig/scripts/any"
 
     anyMultiSigAddress <-
@@ -55,7 +55,7 @@ hprop_golden_shelleyAnyMultiSigAddressBuild =
 
 hprop_golden_shelleyAtLeastMultiSigAddressBuild :: Property
 hprop_golden_shelleyAtLeastMultiSigAddressBuild =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
     atLeastMultiSigFp <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/multisig/scripts/atleast"
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/IssueOpCert.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/IssueOpCert.hs
@@ -15,7 +15,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_shelleyNodeIssueOpCert :: Property
 hprop_golden_shelleyNodeIssueOpCert =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     hotKesVerificationKeyFile <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/kes_keys/verification_key"
     coldSigningKeyFile <-

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGen.hs
@@ -15,7 +15,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_shelleyNodeKeyGen :: Property
 hprop_golden_shelleyNodeKeyGen =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
     signingKeyFile <- noteTempFile tempDir "key-gen.skey"
     opCertCounterFile <- noteTempFile tempDir "op-cert.counter"
@@ -53,7 +53,7 @@ hprop_golden_shelleyNodeKeyGen =
 
 hprop_golden_shelleyNodeKeyGen_te :: Property
 hprop_golden_shelleyNodeKeyGen_te =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
     signingKeyFile <- noteTempFile tempDir "key-gen.skey"
     opCertCounterFile <- noteTempFile tempDir "op-cert.counter"
@@ -91,7 +91,7 @@ hprop_golden_shelleyNodeKeyGen_te =
 
 hprop_golden_shelleyNodeKeyGen_bech32 :: Property
 hprop_golden_shelleyNodeKeyGen_bech32 =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
     signingKeyFile <- noteTempFile tempDir "key-gen.skey"
     opCertCounterFile <- noteTempFile tempDir "op-cert.counter"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenKes.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenKes.hs
@@ -15,7 +15,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_shelleyNodeKeyGenKes :: Property
 hprop_golden_shelleyNodeKeyGenKes =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKey <- noteTempFile tempDir "kes.vkey"
     signingKey <- noteTempFile tempDir "kes.skey"
 
@@ -42,7 +42,7 @@ hprop_golden_shelleyNodeKeyGenKes =
 
 hprop_golden_shelleyNodeKeyGenKes_te :: Property
 hprop_golden_shelleyNodeKeyGenKes_te =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKey <- noteTempFile tempDir "kes.vkey"
     signingKey <- noteTempFile tempDir "kes.skey"
 
@@ -71,7 +71,7 @@ hprop_golden_shelleyNodeKeyGenKes_te =
 
 hprop_golden_shelleyNodeKeyGenKes_bech32 :: Property
 hprop_golden_shelleyNodeKeyGenKes_bech32 =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKey <- noteTempFile tempDir "kes.vkey"
     signingKey <- noteTempFile tempDir "kes.skey"
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenVrf.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenVrf.hs
@@ -15,7 +15,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_shelleyNodeKeyGenVrf :: Property
 hprop_golden_shelleyNodeKeyGenVrf =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKey <- noteTempFile tempDir "kes.vkey"
     signingKey <- noteTempFile tempDir "kes.skey"
 
@@ -42,7 +42,7 @@ hprop_golden_shelleyNodeKeyGenVrf =
 
 hprop_golden_shelleyNodeKeyGenVrf_te :: Property
 hprop_golden_shelleyNodeKeyGenVrf_te =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKey <- noteTempFile tempDir "kes.vkey"
     signingKey <- noteTempFile tempDir "kes.skey"
 
@@ -71,7 +71,7 @@ hprop_golden_shelleyNodeKeyGenVrf_te =
 
 hprop_golden_shelleyNodeKeyGenVrf_bech32 :: Property
 hprop_golden_shelleyNodeKeyGenVrf_bech32 =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKey <- noteTempFile tempDir "kes.vkey"
     signingKey <- noteTempFile tempDir "kes.skey"
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/Build.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/Build.hs
@@ -12,7 +12,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_shelleyStakeAddressBuild :: Property
 hprop_golden_shelleyStakeAddressBuild =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
     verificationKeyFile <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/stake_keys/verification_key"
     goldenRewardAddressFile <-

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
@@ -14,7 +14,7 @@ import Hedgehog.Extras.Test qualified as H
 
 hprop_golden_shelley_stake_address_deregistration_certificate :: Property
 hprop_golden_shelley_stake_address_deregistration_certificate =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     base <- H.getProjectBase
 
     verificationKeyFile <-

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/KeyGen.hs
@@ -14,7 +14,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_shelleyStakeAddressKeyGen :: Property
 hprop_golden_shelleyStakeAddressKeyGen =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKeyFile <- noteTempFile tempDir "kes.vkey"
     signingKeyFile <- noteTempFile tempDir "kes.skey"
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/KeyHash.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/KeyHash.hs
@@ -11,7 +11,7 @@ import Hedgehog.Extras.Test qualified as H
 
 hprop_golden_shelleyStakeAddressKeyHash :: Property
 hprop_golden_shelleyStakeAddressKeyHash =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
     verificationKeyFile <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/stake_keys/verification_key"
     goldenVerificationKeyHashFile <-

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
@@ -14,7 +14,7 @@ import Hedgehog.Extras.Test qualified as H
 
 hprop_golden_shelley_stake_address_registration_certificate :: Property
 hprop_golden_shelley_stake_address_registration_certificate =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     base <- H.getProjectBase
 
     keyGenStakingVerificationKeyFile <-
@@ -60,7 +60,7 @@ hprop_golden_shelley_stake_address_registration_certificate =
 
 hprop_golden_shelley_stake_address_registration_certificate_with_build_raw :: Property
 hprop_golden_shelley_stake_address_registration_certificate_with_build_raw =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     keyGenStakingVerificationKeyFile <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/stake_keys/verification_key"
     registrationCertFile <- noteTempFile tempDir "registration.cert"
@@ -104,7 +104,7 @@ hprop_golden_shelley_stake_address_registration_certificate_with_build_raw =
 
 hprop_golden_shelley_stake_address_registration_certificate_missing_reg_deposit :: Property
 hprop_golden_shelley_stake_address_registration_certificate_missing_reg_deposit =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     keyGenStakingVerificationKeyFile <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/stake_keys/verification_key"
     registrationCertFile <- noteTempFile tempDir "registration.cert"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
@@ -18,7 +18,7 @@ import Hedgehog.Extras.Test qualified as H
 
 hprop_golden_shelley_stake_pool_registration_certificate :: Property
 hprop_golden_shelley_stake_pool_registration_certificate =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     operatorVerificationKeyFile <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/node-pool/operator.vkey"
     vrfVerificationKeyFile <-
@@ -58,7 +58,7 @@ hprop_golden_shelley_stake_pool_registration_certificate =
 
 hprop_golden_conway_stake_pool_registration_certificate_extended_cold_key :: Property
 hprop_golden_conway_stake_pool_registration_certificate_extended_cold_key =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     operatorVerificationKeyFile <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/node-pool/extended-operator.vkey"
     vrfVerificationKeyFile <-
@@ -98,7 +98,7 @@ hprop_golden_conway_stake_pool_registration_certificate_extended_cold_key =
 
 hprop_golden_conway_stake_pool_registration_certificate_extended_literal_cold_key :: Property
 hprop_golden_conway_stake_pool_registration_certificate_extended_literal_cold_key =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     operatorVerificationKeyFile <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/node-pool/extended-operator.vkey"
     vrfVerificationKeyFile <-

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegation.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegation.hs
@@ -21,7 +21,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_shelleyGenesisKeyDelegationCertificate :: Property
 hprop_golden_shelleyGenesisKeyDelegationCertificate =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     let era = BabbageEra
 
     -- Reference certificate

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/Operational.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/Operational.hs
@@ -20,7 +20,7 @@ import Hedgehog.Extras.Test.File qualified as H
 --   4. Check the TextEnvelope serialization format has not changed.
 hprop_golden_shelleyOperationalCertificate :: Property
 hprop_golden_shelleyOperationalCertificate =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Reference keys
     referenceOperationalCertificate <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/certificates/operational_certificate"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
@@ -22,7 +22,7 @@ import Hedgehog.Extras.Test.File qualified as H
 --   3. Check the TextEnvelope serialization format has not changed.
 hprop_golden_shelleyExtendedPaymentKeys :: Property
 hprop_golden_shelleyExtendedPaymentKeys =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Reference keys
     referenceVerKey <-
       noteInputFile
@@ -60,7 +60,7 @@ hprop_golden_shelleyExtendedPaymentKeys =
 --   3. Check the TextEnvelope serialization format has not changed.
 hprop_golden_shelleyExtendedPaymentKeys_te :: Property
 hprop_golden_shelleyExtendedPaymentKeys_te =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Reference keys
     referenceVerKey <-
       noteInputFile
@@ -100,7 +100,7 @@ hprop_golden_shelleyExtendedPaymentKeys_te =
 --   3. Check the bech32 serialization format has not changed.
 hprop_golden_shelleyExtendedPaymentKeys_bech32 :: Property
 hprop_golden_shelleyExtendedPaymentKeys_bech32 =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     H.note_ tempDir
 
     -- Key filepaths

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
@@ -18,7 +18,7 @@ import Hedgehog.Extras.Test.Base qualified as H
 --   3. Check the TextEnvelope serialization format has not changed.
 hprop_golden_shelleyGenesisDelegateKeys :: Property
 hprop_golden_shelleyGenesisDelegateKeys =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Reference keys
     referenceVerKey <-
       noteInputFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
@@ -18,7 +18,7 @@ import Hedgehog.Extras.Test.Base qualified as H
 --   3. Check the TextEnvelope serialization format has not changed
 hprop_golden_shelleyGenesisKeys :: Property
 hprop_golden_shelleyGenesisKeys =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Reference keys
     referenceVerKey <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/genesis_keys/verification_key"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
@@ -18,7 +18,7 @@ import Hedgehog.Extras.Test.Base qualified as H
 --   3. Check the TextEnvelope serialization format has not changed.
 hprop_golden_shelleyGenesisUTxOKeys :: Property
 hprop_golden_shelleyGenesisUTxOKeys =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Reference keys
     referenceVerKey <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/genesis_utxo_keys/verification_key"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
@@ -22,7 +22,7 @@ import Hedgehog.Extras.Test.File qualified as H
 --   3. Check the TextEnvelope serialization format has not changed.
 hprop_golden_shelleyKESKeys :: Property
 hprop_golden_shelleyKESKeys =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Reference keys
     referenceVerKey <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/kes_keys/verification_key"
@@ -58,7 +58,7 @@ hprop_golden_shelleyKESKeys =
 --   3. Check the TextEnvelope serialization format has not changed.
 hprop_golden_shelleyKESKeys_te :: Property
 hprop_golden_shelleyKESKeys_te =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Reference keys
     referenceVerKey <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/kes_keys/verification_key"
@@ -96,7 +96,7 @@ hprop_golden_shelleyKESKeys_te =
 --   3. Check the TextEnvelope serialization format has not changed.
 hprop_golden_shelleyKESKeys_bech32 :: Property
 hprop_golden_shelleyKESKeys_bech32 =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Key filepaths
     verKeyFile <- noteTempFile tempDir "kes-verification-key-file"
     signKeyFile <- noteTempFile tempDir "kes-signing-key-file"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
@@ -22,7 +22,7 @@ import Hedgehog.Extras.Test.File qualified as H
 --   3. Check the TextEnvelope serialization format has not changed.
 hprop_golden_shelleyPaymentKeys :: Property
 hprop_golden_shelleyPaymentKeys =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Reference keys
     referenceVerKey <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/payment_keys/verification_key"
@@ -58,7 +58,7 @@ hprop_golden_shelleyPaymentKeys =
 --   3. Check the TextEnvelope serialization format has not changed.
 hprop_golden_shelleyPaymentKeys_te :: Property
 hprop_golden_shelleyPaymentKeys_te =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Reference keys
     referenceVerKey <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/payment_keys/verification_key"
@@ -96,7 +96,7 @@ hprop_golden_shelleyPaymentKeys_te =
 --   3. Check the bech32 serialization format has not changed.
 hprop_golden_shelleyPaymentKeys_bech32 :: Property
 hprop_golden_shelleyPaymentKeys_bech32 =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     H.note_ tempDir
 
     -- Key filepaths

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
@@ -22,7 +22,7 @@ import Hedgehog.Extras.Test.File qualified as H
 --   3. Check the TextEnvelope serialization format has not changed.
 hprop_golden_shelleyStakeKeys :: Property
 hprop_golden_shelleyStakeKeys =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Reference keys
     referenceVerKey <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/stake_keys/verification_key"
@@ -58,7 +58,7 @@ hprop_golden_shelleyStakeKeys =
 --   3. Check the TextEnvelope serialization format has not changed.
 hprop_golden_shelleyStakeKeys_te :: Property
 hprop_golden_shelleyStakeKeys_te =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Reference keys
     referenceVerKey <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/stake_keys/verification_key"
@@ -96,7 +96,7 @@ hprop_golden_shelleyStakeKeys_te =
 --   3. Check the bech32 serialization format has not changed.
 hprop_golden_shelleyStakeKeys_bech32 :: Property
 hprop_golden_shelleyStakeKeys_bech32 =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     H.note_ tempDir
 
     -- Key filepaths

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
@@ -22,7 +22,7 @@ import Hedgehog.Extras.Test.File qualified as H
 --   3. Check the TextEnvelope serialization format has not changed.
 hprop_golden_shelleyVRFKeys :: Property
 hprop_golden_shelleyVRFKeys =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     H.note_ tempDir
 
     -- Reference keys
@@ -60,7 +60,7 @@ hprop_golden_shelleyVRFKeys =
 --   3. Check the TextEnvelope serialization format has not changed.
 hprop_golden_shelleyVRFKeys_te :: Property
 hprop_golden_shelleyVRFKeys_te =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     H.note_ tempDir
 
     -- Reference keys
@@ -100,7 +100,7 @@ hprop_golden_shelleyVRFKeys_te =
 --   3. Check the bech32 serialization format has not changed.
 hprop_golden_shelleyVRFKeys_bech32 :: Property
 hprop_golden_shelleyVRFKeys_bech32 =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     H.note_ tempDir
 
     -- Key filepaths

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
@@ -17,7 +17,7 @@ import Hedgehog.Extras.Test.Base qualified as H
 --   4. Check the TextEnvelope serialization format has not changed.
 hprop_golden_shelleyTx :: Property
 hprop_golden_shelleyTx =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Reference keys
     let goldenReferenceTx = "test/cardano-cli-golden/files/golden/conway/tx"
 
@@ -68,7 +68,7 @@ hprop_golden_shelleyTx =
 -- TODO Re-enable this test
 disable_hprop_golden_checkIfConstitutionalCommitteeKeyCanSign :: Property
 disable_hprop_golden_checkIfConstitutionalCommitteeKeyCanSign =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Reference keys
     let referenceTx = "test/cardano-cli-golden/files/input/conway/witnessed.tx"
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextView/DecodeCbor.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextView/DecodeCbor.hs
@@ -12,7 +12,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_shelleyTextViewDecodeCbor :: Property
 hprop_golden_shelleyTextViewDecodeCbor =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     unsignedTxFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/tx/unsigned.tx"
     decodedTxtFile <- noteTempFile tempDir "decoded.txt"
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Assemble.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Assemble.hs
@@ -16,7 +16,7 @@ import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_shelleyTransactionAssembleWitness_SigningKey :: Property
 hprop_golden_shelleyTransactionAssembleWitness_SigningKey =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     witnessTx <- noteTempFile tempDir "single-signing-key-witness-tx"
     txBodyFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/tx/txbody"
     signingKeyWitnessFile <-

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Build.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Build.hs
@@ -22,7 +22,7 @@ txIn = "2392d2b1200b5139fe555c81261697b29a8ccf561c5c783d46e78a479d977053#0"
 
 hprop_golden_shelley_transaction_build :: Property
 hprop_golden_shelley_transaction_build =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     txBodyOutFile <- noteTempFile tempDir "tx-body-out"
 
     void $
@@ -45,7 +45,7 @@ hprop_golden_shelley_transaction_build =
 
 hprop_golden_shelley_transaction_build_minting :: Property
 hprop_golden_shelley_transaction_build_minting =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     let scriptWit = "test/cardano-cli-golden/files/input/shelley/multisig/scripts/any"
 
     polid <-
@@ -87,7 +87,7 @@ hprop_golden_shelley_transaction_build_minting =
 
 hprop_golden_shelley_transaction_build_withdrawal_script_witnessed :: Property
 hprop_golden_shelley_transaction_build_withdrawal_script_witnessed =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     txBodyOutFile <- noteTempFile tempDir "tx-body-out"
 
     stakeAddress <-
@@ -120,7 +120,7 @@ hprop_golden_shelley_transaction_build_withdrawal_script_witnessed =
 
 hprop_golden_shelley_transaction_build_txin_script_witnessed :: Property
 hprop_golden_shelley_transaction_build_txin_script_witnessed =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     let scriptWit = "test/cardano-cli-golden/files/input/shelley/multisig/scripts/any"
 
     txBodyOutFile <- noteTempFile tempDir "tx-body-out"
@@ -147,7 +147,7 @@ hprop_golden_shelley_transaction_build_txin_script_witnessed =
 
 hprop_golden_shelley_transaction_build_txout_inline_datum :: Property
 hprop_golden_shelley_transaction_build_txout_inline_datum =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     let datum = "test/cardano-cli-golden/files/input/conway/42.datum"
 
     txBodyOutFile <- noteTempFile tempDir "tx-body-out"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Id.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Id.hs
@@ -13,7 +13,7 @@ import Hedgehog.Extras.Test qualified as H
 -- @cabal test cardano-cli-golden --test-options '-p "/golden shelley transaction id/"'@
 hprop_golden_shelley_transaction_id :: Property
 hprop_golden_shelley_transaction_id =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     txFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/tx-for-txid.json"
 
     let baseCmd = ["latest", "transaction", "txid", "--tx-file", txFile]

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Sign.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Sign.hs
@@ -13,7 +13,7 @@ import Hedgehog.Extras.Test qualified as H
 
 hprop_golden_shelley_transaction_sign :: Property
 hprop_golden_shelley_transaction_sign =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     txBodyFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/tx/txbody"
     initialUtxo1SigningKeyFile <-
       noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/payment_keys/signing_key"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
@@ -7,7 +7,7 @@ import Cardano.Api (TxMetadataJsonSchema (..))
 import Control.Monad (void)
 import System.FilePath ((</>))
 
-import Test.Cardano.CLI.Util (execCardanoCLI, noteTempFile, watchdogProp)
+import Test.Cardano.CLI.Util (execCardanoCLI, noteTempFile)
 
 import Hedgehog (Property)
 import Hedgehog.Extras.Test (Integration, moduleWorkspace, propertyOnce)
@@ -21,7 +21,7 @@ inputDir = "test/cardano-cli-golden/files/input"
 -- @cabal test cardano-cli-golden --test-options '-p "/golden view babbage yaml/"'@
 hprop_golden_view_babbage_yaml :: Property
 hprop_golden_view_babbage_yaml =
-  watchdogProp . propertyOnce $
+  propertyOnce $
     moduleWorkspace "tmp" $ \tempDir -> do
       transactionBodyFile <- noteTempFile tempDir "transaction-body-file"
 
@@ -172,7 +172,7 @@ hprop_golden_view_babbage_yaml =
 -- | Test metadata format
 hprop_golden_view_metadata :: Property
 hprop_golden_view_metadata =
-  watchdogProp . propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
     transactionBodyMetaNoSchema <- noteTempFile tempDir "transaction-body-noschema"
     makeTxBody TxMetadataJsonNoSchema transactionBodyMetaNoSchema
     resultNoSchema <-
@@ -224,7 +224,7 @@ hprop_golden_view_metadata =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden view conway proposal/"'@
 hprop_golden_view_conway_proposal :: Property
 hprop_golden_view_conway_proposal =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     let golden = goldenDir </> "conway"
         input = inputDir </> "conway"
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Version.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Version.hs
@@ -15,7 +15,7 @@ import Hedgehog (Property)
 
 hprop_golden_version :: Property
 hprop_golden_version =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     void $
       execCardanoCLI
         [ "version"

--- a/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
+++ b/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
@@ -56,7 +56,7 @@ import Hedgehog qualified as H
 import Hedgehog.Extras (ExecConfig)
 import Hedgehog.Extras qualified as H
 import Hedgehog.Extras.Test (ExecConfig (..))
-import Hedgehog.Internal.Property (Diff, MonadTest, Property (..), liftTest, mkTest)
+import Hedgehog.Internal.Property (Diff, MonadTest, liftTest, mkTest)
 import Hedgehog.Internal.Property qualified as H
 import Hedgehog.Internal.Show (ValueDiff (ValueSame), mkValue, showPretty, valueDiff)
 import Hedgehog.Internal.Source (getCaller)
@@ -349,7 +349,5 @@ redactJsonField fieldName replacement sourceFilePath targetFilePath = GHC.withFr
         v -> pure v
       H.evalIO $ LBS.writeFile targetFilePath (Aeson.encodePretty redactedJson)
 
-watchdogProp :: HasCallStack => H.Property -> H.Property
-watchdogProp prop@Property{propertyTest} = prop{propertyTest = H.runWithWatchdog_ cfg propertyTest}
- where
-  cfg = H.WatchdogConfig{H.watchdogTimeout = 20}
+watchdogProp :: H.Property -> H.Property
+watchdogProp = id

--- a/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
+++ b/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -20,7 +19,6 @@ module Test.Cardano.CLI.Util
   , noteInputFile
   , noteTempFile
   , redactJsonField
-  , watchdogProp
   )
 where
 
@@ -348,6 +346,3 @@ redactJsonField fieldName replacement sourceFilePath targetFilePath = GHC.withFr
               else v
         v -> pure v
       H.evalIO $ LBS.writeFile targetFilePath (Aeson.encodePretty redactedJson)
-
-watchdogProp :: H.Property -> H.Property
-watchdogProp = id

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/AddCostModels.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/AddCostModels.hs
@@ -11,13 +11,11 @@ import Cardano.CLI.EraBased.Governance.Actions.Run
 import Test.Gen.Cardano.Api.ProtocolParameters
 import Test.Gen.Cardano.Api.Typed
 
-import Test.Cardano.CLI.Util (watchdogProp)
-
 import Hedgehog
 
 hprop_roundtrip_Alonzo_addCostModelsToEraBasedProtocolParametersUpdate :: Property
 hprop_roundtrip_Alonzo_addCostModelsToEraBasedProtocolParametersUpdate =
-  watchdogProp . property $ do
+  property $ do
     ppu <- forAll genAlonzoEraBasedProtocolParametersUpdate
     cmdl <- forAll genCostModels
     tripping
@@ -31,7 +29,7 @@ hprop_roundtrip_Alonzo_addCostModelsToEraBasedProtocolParametersUpdate =
 
 hprop_roundtrip_Babbage_addCostModelsToEraBasedProtocolParametersUpdate :: Property
 hprop_roundtrip_Babbage_addCostModelsToEraBasedProtocolParametersUpdate =
-  watchdogProp . property $ do
+  property $ do
     ppu <- forAll genBabbageEraBasedProtocolParametersUpdate
     cmdl <- forAll genCostModels
     tripping
@@ -45,7 +43,7 @@ hprop_roundtrip_Babbage_addCostModelsToEraBasedProtocolParametersUpdate =
 
 hprop_roundtrip_Conway_addCostModelsToEraBasedProtocolParametersUpdate :: Property
 hprop_roundtrip_Conway_addCostModelsToEraBasedProtocolParametersUpdate =
-  watchdogProp . property $ do
+  property $ do
     ppu <- forAll genConwayEraBasedProtocolParametersUpdate
     cmdl <- forAll genCostModels
     tripping

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Certificates/StakePool.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Certificates/StakePool.hs
@@ -20,7 +20,6 @@ import Test.Cardano.CLI.Util
   , execCardanoCLIWithEnvVars
   , noteTempFile
   , propertyOnce
-  , watchdogProp
   )
 
 import Hedgehog (MonadTest)
@@ -41,7 +40,7 @@ exampleStakePoolMetadataIpfsHash = "QmR1HAT4Hb4HjjqcgoXwupYXMF6t8h7MoSP24HMfV8t3
 -- @cabal test cardano-cli-test --test-options '-p "/stake pool certificate hash check wrong metadata fails/"'@
 hprop_stake_pool_certificate_hash_check_wrong_metadata_fails :: Property
 hprop_stake_pool_certificate_hash_check_wrong_metadata_fails =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
     -- We run the test with the wrong metadata file
     baseStakePoolCertificateHashCheck
       exampleAnchorDataIpfsHash
@@ -53,7 +52,7 @@ hprop_stake_pool_certificate_hash_check_wrong_metadata_fails =
 -- @cabal test cardano-cli-test --test-options '-p "/stake pool certificate hash check wrong hash fails/"'@
 hprop_stake_pool_certificate_hash_check_wrong_hash_fails :: Property
 hprop_stake_pool_certificate_hash_check_wrong_hash_fails =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleStakePoolMetadataHash
     -- We run the test with the modified hash
@@ -67,7 +66,7 @@ hprop_stake_pool_certificate_hash_check_wrong_hash_fails =
 -- @cabal test cardano-cli-test --test-options '-p "/stake pool certificate hash check right hash works/"'@
 hprop_stake_pool_certificate_hash_check_right_hash_works :: Property
 hprop_stake_pool_certificate_hash_check_right_hash_works =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
     baseStakePoolCertificateHashCheck
       exampleStakePoolMetadataIpfsHash
       exampleStakePoolMetadataPathTest
@@ -186,7 +185,7 @@ baseStakePoolCertificateHashCheck ipfsHash metadataFile hash tempDir = do
 -- @cabal test cardano-cli-test --test-options '-p "/stake pool metadata hash url wrong metadata fails/"'@
 hprop_stake_pool_metadata_hash_url_wrong_metadata_fails :: Property
 hprop_stake_pool_metadata_hash_url_wrong_metadata_fails =
-  watchdogProp . propertyOnce $ H.assertFailure_ $ do
+  propertyOnce $ H.assertFailure_ $ do
     -- We run the test with the wrong metadata file
     baseStakePoolMetadataHashUrl
       exampleAnchorDataIpfsHash
@@ -197,7 +196,7 @@ hprop_stake_pool_metadata_hash_url_wrong_metadata_fails =
 -- @cabal test cardano-cli-test --test-options '-p "/stake pool metadata hash url wrong hash fails/"'@
 hprop_stake_pool_metadata_hash_url_wrong_hash_fails :: Property
 hprop_stake_pool_metadata_hash_url_wrong_hash_fails =
-  watchdogProp . propertyOnce $ H.assertFailure_ $ do
+  propertyOnce $ H.assertFailure_ $ do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleStakePoolMetadataHash
     -- We run the test with the modified hash
@@ -210,7 +209,7 @@ hprop_stake_pool_metadata_hash_url_wrong_hash_fails =
 -- @cabal test cardano-cli-test --test-options '-p "/stake pool metadata hash url correct hash/"'@
 hprop_stake_pool_metadata_hash_url_correct_hash :: Property
 hprop_stake_pool_metadata_hash_url_correct_hash =
-  watchdogProp . propertyOnce $
+  propertyOnce $
     baseStakePoolMetadataHashUrl
       exampleStakePoolMetadataIpfsHash
       exampleStakePoolMetadataPathTest

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/CheckNodeConfiguration.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/CheckNodeConfiguration.hs
@@ -17,7 +17,7 @@ import Data.Yaml qualified as Yaml
 import GHC.IO.Exception (ExitCode (..))
 import System.FilePath ((</>))
 
-import Test.Cardano.CLI.Util (execCardanoCLI, execDetailCardanoCLI, watchdogProp)
+import Test.Cardano.CLI.Util (execCardanoCLI, execDetailCardanoCLI)
 
 import Hedgehog (Property)
 import Hedgehog qualified as H
@@ -31,7 +31,7 @@ nodeConfigFile = "test/cardano-cli-test/files/input/check-node-configuration/nod
 -- @cabal test cardano-cli-test --test-options '-p "/check node configuration success/"'@
 hprop_check_node_configuration_success :: Property
 hprop_check_node_configuration_success =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     H.noteM_ $
       execCardanoCLI
         [ "debug"

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/StakeAddress/DelegationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/StakeAddress/DelegationCertificate.hs
@@ -17,7 +17,7 @@ import Hedgehog.Extras qualified as H
 
 hprop_compatible_stake_address_delegation_certificate :: Property
 hprop_compatible_stake_address_delegation_certificate =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     refOutFile <- H.noteTempFile tempDir "stake-registration-certificate.reference.json"
     outFile <- H.noteTempFile tempDir "stake-registration-certificate.json"
     let eraName = map toLower . docToString $ pretty ConwayEra

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/StakeAddress/RegistrationCertificate.hs
@@ -17,7 +17,7 @@ import Hedgehog.Extras qualified as H
 
 hprop_compatible_stake_address_registration_certificate :: Property
 hprop_compatible_stake_address_registration_certificate =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     refOutFile <- H.noteTempFile tempDir "stake-registration-certificate.reference.json"
     outFile <- H.noteTempFile tempDir "stake-registration-certificate.json"
     let eraName = map toLower . docToString $ pretty ConwayEra

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/StakePool/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/StakePool/RegistrationCertificate.hs
@@ -16,7 +16,7 @@ import Hedgehog.Extras qualified as H
 
 hprop_compatible_stake_pool_registration_certificate :: Property
 hprop_compatible_stake_pool_registration_certificate =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     refOutFile <- H.noteTempFile tempDir "reference_tx.traw"
     outFile <- H.noteTempFile tempDir "tx.traw"
     let eraName = map toLower . docToString $ pretty ConwayEra

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/Transaction/Build.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Compatible/Transaction/Build.hs
@@ -25,7 +25,7 @@ inputDir = "test/cardano-cli-test/files/input/"
 -- @cabal test cardano-cli-test --test-options '-p "/conway transaction build one voter many votes/"'@
 hprop_compatible_conway_transaction_build_one_voter_many_votes :: Property
 hprop_compatible_conway_transaction_build_one_voter_many_votes =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     refOutFile <- H.noteTempFile tempDir "reference.tx.json"
     outFile <- H.noteTempFile tempDir "txbody.tx.json"
     let eraName = map toLower . docToString $ pretty ConwayEra
@@ -77,7 +77,7 @@ hprop_compatible_conway_transaction_build_one_voter_many_votes =
 
 hprop_compatible_shelley_create_update_proposal :: Property
 hprop_compatible_shelley_create_update_proposal =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     refOutFile <- H.noteTempFile tempDir "ref_update-proposal_allegra.proposal"
     outFile <- H.noteTempFile tempDir "update_proposal_allegra.proposal"
     let eraName = map toLower . docToString $ pretty ShelleyEra

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/CreateCardano.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/CreateCardano.hs
@@ -5,7 +5,7 @@ module Test.Cli.CreateCardano where
 import Control.Monad (void)
 import System.FilePath ((</>))
 
-import Test.Cardano.CLI.Util (execCardanoCLI, watchdogProp)
+import Test.Cardano.CLI.Util (execCardanoCLI)
 
 import Hedgehog (Property)
 import Hedgehog.Extras (moduleWorkspace, propertyOnce)
@@ -15,7 +15,7 @@ import Hedgehog.Extras qualified as H
 -- @cabal test cardano-cli-test --test-options '-p "/create cardano/'@
 hprop_create_cardano :: Property
 hprop_create_cardano =
-  watchdogProp . propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
     let outputDir = tempDir </> "out"
         eras = ["byron", "shelley", "alonzo", "conway"]
         templates =

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/CreateTestnetData.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/CreateTestnetData.hs
@@ -21,7 +21,6 @@ import Test.Cardano.CLI.Util
   ( assertDirectoryMissing
   , execCardanoCLI
   , execDetailCardanoCLI
-  , watchdogProp
   )
 
 import Hedgehog (Property, success, (===))
@@ -33,7 +32,7 @@ import Hedgehog.Extras qualified as H
 -- @cabal test cardano-cli-test --test-options '-p "/create testnet data minimal/"'@
 hprop_create_testnet_data_minimal :: Property
 hprop_create_testnet_data_minimal =
-  watchdogProp . propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
     let outputDir = tempDir </> "out"
 
     -- We test that the command doesn't crash, because otherwise
@@ -67,7 +66,7 @@ hprop_create_testnet_data_create_nonegative_supply = do
         ]
           :: [(Int, Int, ExitCode)]
 
-  watchdogProp . propertyOnce $ forM_ supplyValues $ \(totalSupply, delegatedSupply, expectedExitCode) ->
+  propertyOnce $ forM_ supplyValues $ \(totalSupply, delegatedSupply, expectedExitCode) ->
     moduleWorkspace "tmp" $ \tempDir -> do
       let outputDir = tempDir </> "out"
 
@@ -130,7 +129,7 @@ data TestGenesis = TestGenesis
 -- @cabal test cardano-cli-test --test-options '-p "/create testnet data transient stake delegators/'@
 hprop_create_testnet_data_transient_stake_delegators :: Property
 hprop_create_testnet_data_transient_stake_delegators =
-  watchdogProp . propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
     let outputDir = tempDir </> "out"
 
     void $

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/DRepMetadata.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/DRepMetadata.hs
@@ -15,7 +15,7 @@ import Test.Cardano.CLI.Hash
   , serveFilesWhile
   , tamperBase16Hash
   )
-import Test.Cardano.CLI.Util (execCardanoCLIWithEnvVars, propertyOnce, watchdogProp)
+import Test.Cardano.CLI.Util (execCardanoCLIWithEnvVars, propertyOnce)
 
 import Hedgehog (Property)
 import Hedgehog qualified as H
@@ -26,7 +26,7 @@ import Hedgehog.Internal.Property (MonadTest)
 -- @cabal test cardano-cli-test --test-options '-p "/drep metadata hash url wrong hash fails/"'@
 hprop_drep_metadata_hash_url_wrong_hash_fails :: Property
 hprop_drep_metadata_hash_url_wrong_hash_fails =
-  watchdogProp . propertyOnce $ H.assertFailure_ $ do
+  propertyOnce $ H.assertFailure_ $ do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleAnchorDataHash
     -- We run the test with the modified hash
@@ -36,7 +36,7 @@ hprop_drep_metadata_hash_url_wrong_hash_fails =
 -- @cabal test cardano-cli-test --test-options '-p "/drep metadata hash url correct hash/"'@
 hprop_drep_metadata_hash_url_correct_hash :: Property
 hprop_drep_metadata_hash_url_correct_hash =
-  watchdogProp . propertyOnce $ baseDrepMetadataHashUrl exampleAnchorDataHash
+  propertyOnce $ baseDrepMetadataHashUrl exampleAnchorDataHash
 
 baseDrepMetadataHashUrl
   :: (MonadBaseControl IO m, MonadTest m, MonadIO m, MonadCatch m)

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/FilePermissions.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/FilePermissions.hs
@@ -9,7 +9,7 @@ import Cardano.Api
 
 import Control.Monad (void)
 
-import Test.Cardano.CLI.Util (execCardanoCLI, watchdogProp)
+import Test.Cardano.CLI.Util (execCardanoCLI)
 
 import Hedgehog (Property, success)
 import Hedgehog.Extras.Test.Base qualified as H
@@ -18,7 +18,7 @@ import Hedgehog.Internal.Property (failWith)
 -- | This property ensures that the VRF signing key file is created only with owner permissions
 hprop_createVRFSigningKeyFilePermissions :: Property
 hprop_createVRFSigningKeyFilePermissions =
-  watchdogProp . H.propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  H.propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Key filepaths
     vrfVerKey <- H.noteTempFile tempDir "VRF-verification-key-file"
 

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Governance/Committee.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Governance/Committee.hs
@@ -20,7 +20,6 @@ import Test.Cardano.CLI.Util
   , execCardanoCLIWithEnvVars
   , noteTempFile
   , propertyOnce
-  , watchdogProp
   )
 
 import Hedgehog (MonadTest, Property)
@@ -31,7 +30,7 @@ import Hedgehog.Extras qualified as H
 -- @cabal test cardano-cli-test --test-options '-p "/governance committee checks wrong hash fails/"'@
 hprop_governance_committee_checks_wrong_hash_fails :: Property
 hprop_governance_committee_checks_wrong_hash_fails =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleAnchorDataHash
     -- We run the test with the altered
@@ -43,7 +42,7 @@ hprop_governance_committee_checks_wrong_hash_fails =
 -- @cabal test cardano-cli-test --test-options '-p "/governance committee checks right hash works/"'@
 hprop_governance_committee_checks_right_hash_works :: Property
 hprop_governance_committee_checks_right_hash_works =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
     baseGovernanceGovernanceCommitteeChecksHash exampleAnchorDataHash tempDir
 
 baseGovernanceGovernanceCommitteeChecksHash

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Governance/Vote.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Governance/Vote.hs
@@ -19,7 +19,6 @@ import Test.Cardano.CLI.Util
   ( execCardanoCLIWithEnvVars
   , noteInputFile
   , propertyOnce
-  , watchdogProp
   )
 
 import Hedgehog (MonadTest, Property)
@@ -30,7 +29,7 @@ import Hedgehog.Extras qualified as H
 -- @cabal test cardano-cli-test --test-options '-p "/governance vote create wrong hash fails/"'@
 hprop_governance_vote_create_wrong_hash_fails :: Property
 hprop_governance_vote_create_wrong_hash_fails =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> H.assertFailure_ $ do
     -- We modify the hash slightly so that the hash check fails
     alteredHash <- H.evalMaybe $ tamperBase16Hash exampleAnchorDataHash
     -- We run the test with the altered
@@ -42,7 +41,7 @@ hprop_governance_vote_create_wrong_hash_fails =
 -- @cabal test cardano-cli-test --test-options '-p "/governance vote create right hash works/"'@
 hprop_governance_vote_create_right_hash_works :: Property
 hprop_governance_vote_create_right_hash_works =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
     baseGovernanceVoteCreateHashCheck exampleAnchorDataHash tempDir
 
 baseGovernanceVoteCreateHashCheck

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Hash.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Hash.hs
@@ -25,7 +25,7 @@ import Hedgehog.Extras qualified as H
 -- @cabal test cardano-cli-test --test-options '-p "/generate anchor data hash from file/"'@
 hprop_generate_anchor_data_hash_from_file :: Property
 hprop_generate_anchor_data_hash_from_file =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     result <-
       execCardanoCLI
         [ "hash"
@@ -39,7 +39,7 @@ hprop_generate_anchor_data_hash_from_file =
 -- @cabal test cardano-cli-test --test-options '-p "/check anchor data hash from file/"'@
 hprop_check_anchor_data_hash_from_file :: Property
 hprop_check_anchor_data_hash_from_file =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     void $
       execCardanoCLI
         [ "hash"
@@ -54,7 +54,7 @@ hprop_check_anchor_data_hash_from_file =
 -- @cabal test cardano-cli-test --test-options '-p "/check anchor data hash from file fails/"'@
 hprop_check_anchor_data_hash_from_file_fails :: Property
 hprop_check_anchor_data_hash_from_file_fails =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     (ec, _, _) <-
       execDetailCardanoCLI
         [ "hash"
@@ -70,7 +70,7 @@ hprop_check_anchor_data_hash_from_file_fails =
 -- @cabal test cardano-cli-test --test-options '-p "/generate anchor data hash from file uri/"'@
 hprop_generate_anchor_data_hash_from_file_uri :: Property
 hprop_generate_anchor_data_hash_from_file_uri =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     cwd <- H.evalIO getCurrentDirectory
     posixCwd <- toPOSIX cwd
     result <-
@@ -101,7 +101,7 @@ hprop_generate_anchor_data_hash_from_file_uri =
 -- @cabal test cardano-cli-test --test-options '-p "/check anchor data hash from http uri/"'@
 hprop_check_anchor_data_hash_from_http_uri :: Property
 hprop_check_anchor_data_hash_from_http_uri =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     let relativeUrl = ["example", "url", "file.txt"]
 
     -- Create temporary HTTP server with files required by the call to `cardano-cli`
@@ -123,7 +123,7 @@ hprop_check_anchor_data_hash_from_http_uri =
 -- @cabal test cardano-cli-test --test-options '-p "/check anchor data hash from ipfs uri/"'@
 hprop_check_anchor_data_hash_from_ipfs_uri :: Property
 hprop_check_anchor_data_hash_from_ipfs_uri =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     let relativeUrl = ["ipfs", exampleAnchorDataIpfsHash]
 
     -- Create temporary HTTP server with files required by the call to `cardano-cli`

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/ITN.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/ITN.hs
@@ -38,7 +38,7 @@ itnSignKey = "ed25519_sk1yhnetcmla9pskrvp5z5ff2v8gkenhmluy736jd6nrxrlxcgn70zsy94
 --   2. Derive the haskell verification key from the haskell signing key.
 hprop_convertITNKeys :: Property
 hprop_convertITNKeys =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- ITN input file paths
     itnVerKeyFp <- noteTempFile tempDir "itnVerKey.key"
     itnSignKeyFp <- noteTempFile tempDir "itnSignKey.key"
@@ -81,7 +81,7 @@ hprop_convertITNKeys =
 -- | 1. Convert a bech32 ITN extended signing key to a haskell stake signing key
 hprop_convertITNExtendedSigningKey :: Property
 hprop_convertITNExtendedSigningKey =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     let itnExtendedSignKey =
           mconcat
             [ "ed25519e_sk1qpcplz38tg4fusw0fkqljzspe9qmj06ldu9lgcve99v4fphuk9a535kwj"
@@ -116,7 +116,7 @@ hprop_convertITNExtendedSigningKey =
 -- | 1. Convert a bech32 ITN BIP32 signing key to a haskell stake signing key
 hprop_convertITNBIP32SigningKey :: Property
 hprop_convertITNBIP32SigningKey =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     let itnExtendedSignKey =
           mconcat
             [ "xprv1spkw5suj39723c40mr55gwh7j3vryjv2zdm4e47xs0deka"
@@ -154,7 +154,7 @@ hprop_convertITNBIP32SigningKey =
 -- using 'itnVerKey' & 'itnSignKey' as inputs.
 hprop_golden_bech32Decode :: Property
 hprop_golden_bech32Decode =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     (vHumReadPart, vDataPart, _) <- H.evalEither $ decodeBech32 itnVerKey
     Just vDataPartBase16 <- pure (dataPartToBase16 vDataPart)
 

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Json.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Json.hs
@@ -24,8 +24,6 @@ import Test.Gen.Cardano.Api.Typed
   , genVerificationKeyHash
   )
 
-import Test.Cardano.CLI.Util (watchdogProp)
-
 import Hedgehog (Gen, Property, forAll, property, tripping)
 import Hedgehog.Gen as Gen
 import Hedgehog.Range as Range
@@ -33,7 +31,7 @@ import Hedgehog.Range as Range
 -- TODO: Move to cardano-api
 hprop_json_roundtrip_delegations_and_rewards :: Property
 hprop_json_roundtrip_delegations_and_rewards =
-  watchdogProp . property $ do
+  property $ do
     dAndG <- forAll genDelegationsAndRewards
     tripping dAndG encode eitherDecode
 
@@ -76,6 +74,7 @@ genKesPeriodInfoOutput =
     <*> genWord64
 
 hprop_roundtrip_kes_period_info_output_JSON :: Property
-hprop_roundtrip_kes_period_info_output_JSON = watchdogProp . property $ do
-  kesPeriodOutput <- forAll genKesPeriodInfoOutput
-  tripping kesPeriodOutput encode eitherDecode
+hprop_roundtrip_kes_period_info_output_JSON =
+  property $ do
+    kesPeriodOutput <- forAll genKesPeriodInfoOutput
+    tripping kesPeriodOutput encode eitherDecode

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/MonadWarning.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/MonadWarning.hs
@@ -8,14 +8,13 @@ import Cardano.CLI.Type.MonadWarning (MonadWarning, reportIssue, runWarningState
 import Control.Monad (when)
 import Control.Monad.Trans.State (State, runState)
 
-import Test.Cardano.CLI.Util (watchdogProp)
-
 import Hedgehog (Property, property, (===))
 
 hprop_monad_warning :: Property
-hprop_monad_warning = watchdogProp . property $ do
-  (-8, [warning]) === duplicateNumber (-4)
-  (4, []) === duplicateNumber 2
+hprop_monad_warning =
+  property $ do
+    (-8, [warning]) === duplicateNumber (-4)
+    (4, []) === duplicateNumber 2
  where
   duplicateNumber :: Int -> (Int, [String])
   duplicateNumber n = runState (runWarningStateT $ computeWithWarning n :: State [String] Int) []

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Parser.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Parser.hs
@@ -23,8 +23,6 @@ import Data.Either (isLeft, isRight)
 import Data.Text (Text)
 import Data.Word (Word16)
 
-import Test.Cardano.CLI.Util (watchdogProp)
-
 import Hedgehog (Gen, Property, assert, property, (===))
 import Hedgehog.Extras (assertWith, propertyOnce)
 import Hedgehog.Gen qualified as Gen
@@ -35,22 +33,23 @@ import Hedgehog.Range qualified as Range
 -- | Execute me with:
 -- @cabal test cardano-cli-test --test-options '-p "/integral reader/"'@
 hprop_integral_reader :: Property
-hprop_integral_reader = watchdogProp . property $ do
-  parse @Word "0" === Right 0
-  parse @Word "42" === Right 42
-  assertWith (parse @Word "-1") isLeft
-  assertWith (parse @Word "18446744073709551616") isLeft
-  assertWith (parse @Word "-1987090") isLeft
+hprop_integral_reader =
+  property $ do
+    parse @Word "0" === Right 0
+    parse @Word "42" === Right 42
+    assertWith (parse @Word "-1") isLeft
+    assertWith (parse @Word "18446744073709551616") isLeft
+    assertWith (parse @Word "-1987090") isLeft
 
-  w <- forAll $ Gen.word $ Gen.linear minBound maxBound
-  parse @Word (textShow w) === Right w
+    w <- forAll $ Gen.word $ Gen.linear minBound maxBound
+    parse @Word (textShow w) === Right w
 
-  parse @Word16 "0" === Right 0
-  parse @Word16 "42" === Right 42
-  assertWith (parse @Word16 "-1") isLeft
-  assertWith (parse @Word16 "65536") isLeft
-  assertWith (parse @Word16 "298709870987") isLeft
-  assertWith (parse @Word16 "-1987090") isLeft
+    parse @Word16 "0" === Right 0
+    parse @Word16 "42" === Right 42
+    assertWith (parse @Word16 "-1") isLeft
+    assertWith (parse @Word16 "65536") isLeft
+    assertWith (parse @Word16 "298709870987") isLeft
+    assertWith (parse @Word16 "-1987090") isLeft
  where
   parse :: (Typeable a, Integral a, Bits a) => Text -> Either String a
   parse = P.runParser integralParsecParser
@@ -58,9 +57,10 @@ hprop_integral_reader = watchdogProp . property $ do
 -- | Execute me with:
 -- @cabal test cardano-cli-test --test-options '-p "/integral pair reader positive/"'@
 hprop_integral_pair_reader_positive :: Property
-hprop_integral_pair_reader_positive = watchdogProp . property $ do
-  validArbitraryTuple <- forAll $ genNumberTuple (Proxy :: Proxy Word)
-  assert $ isRight $ parse @Word validArbitraryTuple
+hprop_integral_pair_reader_positive =
+  property $ do
+    validArbitraryTuple <- forAll $ genNumberTuple (Proxy :: Proxy Word)
+    assert $ isRight $ parse @Word validArbitraryTuple
  where
   parse :: (Typeable a, Integral a, Bits a) => Text -> Either String (a, a)
   parse = P.runParser pairIntegralParsecParser
@@ -84,7 +84,7 @@ genArbitrarySpace = Gen.text (Range.linear 0 5) (return ' ')
 -- @cabal test cardano-cli-test --test-options '-p "/integral pair reader negative/"'@
 hprop_integral_pair_reader_negative :: Property
 hprop_integral_pair_reader_negative =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     assertWith (parse @Word "(0, 0, 0)") isLeft
     assertWith (parse @Word "(-1, 0)") isLeft
     assertWith (parse @Word "(18446744073709551616, 0)") isLeft

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise1.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise1.hs
@@ -19,7 +19,7 @@ import Hedgehog.Extras.Test.File qualified as H
 --   3. We use the generated verification key to build a shelley payment address.
 hprop_buildShelleyPaymentAddress :: Property
 hprop_buildShelleyPaymentAddress =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Key filepaths
     verKey <- noteTempFile tempDir "payment-verification-key-file"
     signKey <- noteTempFile tempDir "payment-signing-key-file"
@@ -56,7 +56,7 @@ hprop_buildShelleyPaymentAddress =
 --      to build a shelley stake address.
 hprop_buildShelleyStakeAddress :: Property
 hprop_buildShelleyStakeAddress =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Key filepaths
     stakeVerKey <- noteTempFile tempDir "stake-verification-key-file"
     stakeSignKey <- noteTempFile tempDir "stake-signing-key-file"

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise2.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise2.hs
@@ -18,7 +18,7 @@ import Hedgehog.Extras.Test.File qualified as H
 --   3. We sign the tx body with the generated payment signing key
 hprop_createTransaction :: Property
 hprop_createTransaction =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Key filepaths
     paymentVerKey <- noteTempFile tempDir "payment-verification-key-file"
     paymentSignKey <- noteTempFile tempDir "payment-signing-key-file"

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise3.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise3.hs
@@ -19,7 +19,7 @@ import Hedgehog.Extras.Test.File qualified as H
 --   4. Create VRF key pair.
 hprop_createOperationalCertificate :: Property
 hprop_createOperationalCertificate =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Key filepaths
     kesVerKey <- noteTempFile tempDir "KES-verification-key-file"
     kesSignKey <- noteTempFile tempDir "KES-signing-key-file"

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise4.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise4.hs
@@ -17,7 +17,7 @@ import Hedgehog.Extras.Test.File qualified as H
 --   2. Create a stake address registration certificate
 hprop_createStakeAddressRegistrationCertificate :: Property
 hprop_createStakeAddressRegistrationCertificate =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Key filepaths
     verKey <- noteTempFile tempDir "stake-verification-key-file"
     signKey <- noteTempFile tempDir "stake-signing-key-file"

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise5.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise5.hs
@@ -18,7 +18,7 @@ import Hedgehog.Extras.Test.File qualified as H
 --   3. We sign the tx body with the generated payment signing key
 hprop_createLegacyZeroTxOutTransaction :: Property
 hprop_createLegacyZeroTxOutTransaction =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Key filepaths
     paymentVerKey <- noteTempFile tempDir "payment-verification-key-file"
     paymentSignKey <- noteTempFile tempDir "payment-signing-key-file"

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise6.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise6.hs
@@ -18,7 +18,7 @@ import Hedgehog.Extras.Test.File qualified as H
 --   3. We sign the tx body with the generated payment signing key
 hprop_createZeroLovelaceTxOutTransaction :: Property
 hprop_createZeroLovelaceTxOutTransaction =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Key filepaths
     paymentVerKey <- noteTempFile tempDir "payment-verification-key-file"
     paymentSignKey <- noteTempFile tempDir "payment-signing-key-file"

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Run/Hash.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Run/Hash.hs
@@ -17,7 +17,7 @@ import Hedgehog.Extras qualified as H
 
 hprop_hash_trip :: Property
 hprop_hash_trip =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     hash_trip_fun "foo"
     hash_trip_fun "longerText"
     hash_trip_fun "nonAscii: 你好"

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Run/Hash.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Run/Hash.hs
@@ -1,9 +1,11 @@
 {- HLINT ignore "Use camelCase" -}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Test.Cli.Run.Hash where
 
 import Control.Monad (void)
 import Control.Monad.Catch (MonadCatch)
+import Control.Monad.Trans.Control (MonadBaseControl)
 import Control.Monad.Trans.Resource (MonadResource)
 import GHC.Stack
 
@@ -24,7 +26,14 @@ hprop_hash_trip =
 -- Test that @cardano-cli hash --text > file1@ and
 -- @cardano-cli --text --out-file file2@ yields
 -- similar @file1@ and @file2@ files.
-hash_trip_fun :: (MonadTest m, MonadCatch m, MonadResource m, HasCallStack) => String -> m ()
+hash_trip_fun
+  :: HasCallStack
+  => MonadBaseControl IO m
+  => MonadCatch m
+  => MonadResource m
+  => MonadTest m
+  => String
+  -> m ()
 hash_trip_fun input =
   H.moduleWorkspace "tmp" $ \tempDir -> do
     hashFile <- noteTempFile tempDir "hash.txt"

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Run/Query.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Run/Query.hs
@@ -6,14 +6,12 @@ where
 import Cardano.CLI.EraBased.Query.Run qualified as Q
 import Cardano.Slotting.Time (RelativeTime (..))
 
-import Test.Cardano.CLI.Util (watchdogProp)
-
 import Hedgehog (Property, (===))
 import Hedgehog.Extras.Test.Base qualified as H
 
 hprop_percentage :: Property
 hprop_percentage =
-  watchdogProp . H.propertyOnce $ do
+  H.propertyOnce $ do
     Q.percentage (RelativeTime 10) (RelativeTime 1000) (RelativeTime 1000) === "100.00"
     Q.percentage (RelativeTime 10) (RelativeTime 990) (RelativeTime 1000) === "100.00"
     Q.percentage (RelativeTime 10) (RelativeTime 980) (RelativeTime 1000) === "99.00"

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Genesis/Create.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Genesis/Create.hs
@@ -70,7 +70,7 @@ parseTotalSupply = J.withObject "Object" $ \o -> do
 
 hprop_shelleyGenesisCreate :: Property
 hprop_shelleyGenesisCreate =
-  watchdogProp . propertyOnce $ do
+  propertyOnce $ do
     H.moduleWorkspace "tmp" $ \tempDir -> do
       sourceGenesisSpecFile <-
         noteInputFile "test/cardano-cli-test/files/input/shelley/genesis/genesis.spec.json"

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Transaction/Build.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Transaction/Build.hs
@@ -34,7 +34,7 @@ inputDir = "test/cardano-cli-test/files/input/shelley/transaction"
 -- @cabal test cardano-cli-test --test-options '-p "/conway transaction build one voter many votes/"'@
 hprop_conway_transaction_build_one_voter_many_votes :: Property
 hprop_conway_transaction_build_one_voter_many_votes =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     outFile <- H.noteTempFile tempDir "tx.traw"
 
     (exitCode, _stdout, stderr) <-
@@ -67,7 +67,7 @@ hprop_conway_transaction_build_one_voter_many_votes =
 -- @cabal test cardano-cli-test --test-options '-p "/conway transaction build raw negative txout/"'@
 hprop_conway_transaction_build_raw_negative_txout :: Property
 hprop_conway_transaction_build_raw_negative_txout =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     outFile <- H.noteTempFile tempDir "tx.traw"
 
     (exitCode, _stdout, stderr) <-
@@ -94,7 +94,7 @@ hprop_conway_transaction_build_raw_negative_txout =
 -- @cabal test cardano-cli-test --test-options '-p "/conway transaction build raw negative bits positive total txout/"'@
 hprop_conway_transaction_build_raw_negative_bits_positive_total_txout :: Property
 hprop_conway_transaction_build_raw_negative_bits_positive_total_txout =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     outFile <- H.noteTempFile tempDir "tx.traw"
 
     -- This checks that the command succeeds
@@ -117,7 +117,7 @@ hprop_conway_transaction_build_raw_negative_bits_positive_total_txout =
 -- @cabal test cardano-cli-test --test-options '-p "/conway calculate plutus script cost offline/"'@
 hprop_conway_calculate_plutus_script_cost_offline :: Property
 hprop_conway_calculate_plutus_script_cost_offline =
-  watchdogProp . propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     randomTxIdHash <- forAll genShelleyHash
     txIx <- forAll $ Gen.integral (Range.linear 0 10)
     AddressShelley scriptAddr <-

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/VerificationKey.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/VerificationKey.hs
@@ -17,19 +17,19 @@ import Hedgehog.Extras.Test.Base qualified as H
 -- @cabal test cardano-cli-test --test-options '-p "/verification key drep/"'@
 hprop_verification_key_drep :: Property
 hprop_verification_key_drep =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ runOne ["drep", "key-gen"]
+  propertyOnce . H.moduleWorkspace "tmp" $ runOne ["drep", "key-gen"]
 
 -- | Execute me with:
 -- @cabal test cardano-cli-test --test-options '-p "/verification key committee hot/"'@
 hprop_verification_key_committee_hot :: Property
 hprop_verification_key_committee_hot =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ runOne ["committee", "key-gen-hot"]
+  propertyOnce . H.moduleWorkspace "tmp" $ runOne ["committee", "key-gen-hot"]
 
 -- | Execute me with:
 -- @cabal test cardano-cli-test --test-options '-p "/verification key committee cold/"'@
 hprop_verification_key_committee_cold :: Property
 hprop_verification_key_committee_cold =
-  watchdogProp . propertyOnce . H.moduleWorkspace "tmp" $ runOne ["committee", "key-gen-cold"]
+  propertyOnce . H.moduleWorkspace "tmp" $ runOne ["committee", "key-gen-cold"]
 
 runOne
   :: ()

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1749631879,
-        "narHash": "sha256-H7dxW3fRA8/U4u4GaR+YVnu6aKkev4GPTPgY524V5uM=",
+        "lastModified": 1751010214,
+        "narHash": "sha256-bsyrGouyAlRkApXqnlXnJA/cNGeLo5HW3dDVqhJH17I=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "2d1517e42e1ed5b19deb29c1c4fc9e30d360b961",
+        "rev": "48a53f17a3b46390586e130705b853f0d73dbf5c",
         "type": "github"
       },
       "original": {
@@ -173,11 +173,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1750552134,
-        "narHash": "sha256-KC/e7tQOID9SgRkmH3BNlnPZ7sn3v5k5GyllLmSZicY=",
+        "lastModified": 1751070359,
+        "narHash": "sha256-bTZe0Sj8v49NAbdz4joUKfsPUpm5bxdhCXbBxJstLSI=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "a5d60b2d3c435cf26848e34b92e28f96e13cde7c",
+        "rev": "4cc7600ea17763460d1bf10e454a87e524160f53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Delete `watchdogProp` function
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

`watchdogProp` can be deleted because we are now using a new version of `hedgehog-extras` that fixes a hanging bug in `moduleWorkspace`.  After fixing this bug, tests do not hang anymore so we do not need `watchdogProp` to interrupt the hanging test.

The PR that fixed `moduleWorkspace` is here: https://github.com/input-output-hk/hedgehog-extras/pull/91

The reason the old version of `moduleWorkspace` hangs is not fully known, however it uses a combination of `ResourceT` and `recovering retryPolicy`, which causes the hang.

Aside from the fact that this combination hangs, it is problematic to use `ResourceT` when the intention is to cleanup resources in a timely manner.  The scope of `ResourceT` is `runResourceT` which is outside the call to `moduleWorkspace`.  This means that when `moduleWorkspace` returns, there is no guarantee that the module directory is cleaned up as it is supposed to.

In order to ensure timely cleanup of resources, the `bracket` family of functions should be used instead.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
