### PR TITLE
Unit tests should only run once

### DIFF
--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/SigningKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/SigningKeys.hs
@@ -28,7 +28,7 @@ import Data.ByteString.Lazy qualified as LB
 
 import Test.Cardano.CLI.Util
 
-import Hedgehog (Property, property, success)
+import Hedgehog (Property, success)
 import Hedgehog qualified as H
 import Hedgehog.Extras.Test.Base qualified as H
 import Hedgehog.Internal.Property (failWith)
@@ -99,7 +99,7 @@ hprop_print_nonLegacy_signing_key_address =
 
 hprop_generate_and_read_nonlegacy_signingkeys :: Property
 hprop_generate_and_read_nonlegacy_signingkeys =
-  watchdogProp . property $ do
+  watchdogProp . propertyOnce $ do
     byronSkey <- H.evalIO $ generateSigningKey AsByronKey
     case deserialiseFromRawBytes (AsSigningKey AsByronKey) (serialiseToRawBytes byronSkey) of
       Left _ -> failWith Nothing "Failed to deserialise non-legacy Byron signing key. "

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/Witness.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/Witness.hs
@@ -1,8 +1,11 @@
 module Test.Golden.Shelley.TextEnvelope.Tx.Witness where
 
-import Hedgehog (Property, property, success)
+import Test.Cardano.CLI.Util (propertyOnce)
+
+import Hedgehog (Property, success)
 
 {- HLINT ignore "Use camelCase" -}
 
 hprop_golden_shelleyWitness :: Property
-hprop_golden_shelleyWitness = property success
+hprop_golden_shelleyWitness =
+  propertyOnce success


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Modify `hprop_generate_and_read_nonlegacy_signingkeys` test to only run once.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
