### PR TITLE
chore(test): migrate to tasty-discover Flavored API for platform-specific test filtering

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -452,6 +452,7 @@ test-suite cardano-cli-golden
     regex-tdfa,
     rio,
     tasty,
+    tasty-discover,
     tasty-hedgehog,
     text,
 

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Run/Hash.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Run/Hash.hs
@@ -17,15 +17,15 @@ import Hedgehog.Extras qualified as H
 hprop_hash_trip :: Property
 hprop_hash_trip =
   watchdogProp . propertyOnce $ do
-    hash_trip_fun "foo"
-    hash_trip_fun "longerText"
-    hash_trip_fun "nonAscii: 你好"
-    hash_trip_fun "nonAscii: à la mode de Cæn"
+    hashTripFun "foo"
+    hashTripFun "longerText"
+    hashTripFun "nonAscii: 你好"
+    hashTripFun "nonAscii: à la mode de Cæn"
 
 -- Test that @cardano-cli hash --text > file1@ and
 -- @cardano-cli --text --out-file file2@ yields
 -- similar @file1@ and @file2@ files.
-hash_trip_fun
+hashTripFun
   :: ( MonadBaseControl IO m
      , MonadTest m
      , MonadCatch m
@@ -34,7 +34,7 @@ hash_trip_fun
      , HasCallStack
      )
   => String -> m ()
-hash_trip_fun input =
+hashTripFun input =
   H.moduleWorkspace "tmp" $ \tempDir -> do
     hashFile <- noteTempFile tempDir "hash.txt"
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Migrate test suite to use the newer tasty-discover API which supports
    Flavored test monads for platform-specific test filtering
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
    - test           # fixes/modifies tests
    - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Motivation

## Background: Platform-Specific Testing Challenges

The cardano-cli help text tests needed to be skipped on Windows because the CLI executable has platform-specific differences in its output:
- On Unix-like systems: `cardano-cli`
- On Windows: `cardano-cli.exe`

## Previous Approach (Manual Runtime Check)

The old implementation used a manual runtime platform check:

```haskell
test_golden_HelpCmds :: IO TestTree
test_golden_HelpCmds =
  if isWin32
    then return $ testGroup "help-commands" []
    else do
      -- ... generate tests
```

**Problems with this approach:**
1. Required importing `Hedgehog.Extras.Stock.OS (isWin32)` for platform detection
2. Manual conditional logic scattered throughout test code
3. Less declarative - the platform constraint is hidden in imperative code
4. Doesn't leverage tasty's built-in test filtering capabilities

## New Approach (Flavored API with Platform Filter)

The new implementation uses tasty-discover's `Flavored` type and `platform` function:

```haskell
tasty_golden_HelpCmds :: Flavored (IO TestTree)
tasty_golden_HelpCmds =
  flavored (platform "!windows") $ do
    -- ... generate tests
```

**Benefits:**

1. **Declarative Platform Filtering**: The platform constraint `"!windows"` is expressed declaratively
2. **Standardized API**: Uses tasty-discover's standard platform expression syntax supporting complex logic (`!`, `&`, `|` operators)
3. **Consistent Skipping Behavior**: Skipped tests show uniformly as `[SKIPPED]` in yellow in test output
4. **Better Integration**: Works seamlessly with tasty's option system and test tree transformations
5. **Naming Convention**: The `tasty_` prefix (vs `test_`) signals that this test uses the custom Tasty instance mechanism, which is appropriate for Flavored transformations
6. The type of the second argument of `Flavored` is `IO TestTree` so the test monad hasn't changed for the actual test.

## Additional Context from tasty-discover 5.1.0

The tasty-discover 5.1.0 release added:

- **Platform-specific test filtering** with `platform` function and logical expressions  
- **`Flavored` type** for general-purpose test transformations with extensible design
- Support for complex platform expressions like `"!windows"`, `"linux | darwin"`, `"!windows & !darwin"`

The `Flavored` pattern is designed to be extensible for future use cases like:
- Setting test timeouts
- Adding test metadata
- Applying multiple transformations in sequence
- Custom test grouping with resource dependencies

# Context

This PR upgrades the test infrastructure to use the newer tasty-discover API with Flavored test support. The key changes include:

- **cardano-cli.cabal**: Added explicit `tasty-discover` dependency to the cardano-cli-golden test suite
- **Test/Golden/Help.hs**: Migrated from the legacy `test_*` naming convention to `tasty_*` with the new `Flavored` API for platform-specific test filtering

The migration replaces the manual platform check (`isWin32`) with the cleaner `flavored (platform "!windows")` API, which provides better declarative platform filtering. Tests are conditionally executed based on platform constraints, preserving the existing behavior of skipping help text tests on Windows due to platform-specific output differences (e.g., cardano-cli.exe vs cardano-cli).

# How to trust this PR

To verify this change works correctly:

1. **Build the project**: `cabal build all --enable-tests`
2. **Run the golden tests**: `cabal test cardano-cli-golden --enable-tests`
3. **Verify platform filtering**: The help command golden tests should be skipped on Windows and run on other platforms

The tests should pass with the same coverage as before, but now use the updated test discovery mechanism with cleaner platform filtering.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff