### PR TITLE
Propagate new `Certificate` data definition

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -65,3 +65,10 @@ if impl (ghc >= 9.12)
     -- https://github.com/kapralVV/Unique/issues/11
     , Unique:hashable
 
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/cardano-api
+  tag: 63a3570493b366e8236b78265bb32d8360d65b80
+  --sha256: sha256-UXyOYh8rVau7POidPSBDvVGSlNurdAdUZJw4Ug+OdV8=
+  subdir:
+      cardano-api

--- a/cardano-cli/src/Cardano/CLI/Compatible/StakeAddress/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/StakeAddress/Run.hs
@@ -11,6 +11,7 @@ module Cardano.CLI.Compatible.StakeAddress.Run
 where
 
 import Cardano.Api
+import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Compatible.Exception
@@ -106,17 +107,17 @@ createStakeDelegationCertificate
   :: ShelleyBasedEra era
   -> StakeCredential
   -> Hash StakePoolKey
-  -> Certificate era
+  -> Exp.Certificate (ShelleyLedgerEra era)
 createStakeDelegationCertificate sbe stakeCredential stakePoolHash = do
   caseShelleyToBabbageOrConwayEraOnwards
     ( \w ->
         shelleyToBabbageEraConstraints w $
-          ShelleyRelatedCertificate w $
+          Exp.Certificate $
             L.mkDelegStakeTxCert (toShelleyStakeCredential stakeCredential) (toLedgerHash stakePoolHash)
     )
     ( \w ->
         conwayEraOnwardsConstraints w $
-          ConwayCertificate w $
+          Exp.Certificate $
             L.mkDelegTxCert
               (toShelleyStakeCredential stakeCredential)
               (L.DelegStake (toLedgerHash stakePoolHash))

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Command.hs
@@ -42,13 +42,13 @@ data StakeAddressCmds era
       StakePoolKeyHashSource
       (File () Out)
   | StakeAddressStakeAndVoteDelegationCertificateCmd
-      (ConwayEraOnwards era)
+      (Exp.Era era)
       StakeIdentifier
       StakePoolKeyHashSource
       VoteDelegationTarget
       (File () Out)
   | StakeAddressVoteDelegationCertificateCmd
-      (ConwayEraOnwards era)
+      (Exp.Era era)
       StakeIdentifier
       VoteDelegationTarget
       (File () Out)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Internal/HashCheck.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Internal/HashCheck.hs
@@ -15,11 +15,11 @@ import Cardano.Api
   , convert
   , except
   , firstExceptT
-  , getAnchorDataFromCertificate
   , getAnchorDataFromGovernanceAction
   , shelleyBasedEraConstraints
   , withExceptT
   )
+import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L
 
@@ -43,13 +43,13 @@ checkAnchorMetadataHash anchor =
 -- | Find references to anchor data and check the hashes are valid
 -- and they match the linked data.
 checkCertificateHashes
-  :: Exp.IsEra era => Exp.Certificate (Exp.LedgerEra era) -> ExceptT TxCmdError IO ()
+  :: forall era. Exp.IsEra era => Exp.Certificate (Exp.LedgerEra era) -> ExceptT TxCmdError IO ()
 checkCertificateHashes cert = do
   mAnchor <-
     withExceptT TxCmdPoolMetadataHashError $
       except $
-        getAnchorDataFromCertificate $
-          Exp.convertToOldApiCertificate Exp.useEra cert
+        obtainCommonConstraints (Exp.useEra @era) $
+          Exp.getAnchorDataFromCertificate Exp.useEra cert
   maybe (return mempty) checkAnchorMetadataHash mAnchor
 
 -- | Find references to anchor data in voting procedures and check the hashes are valid

--- a/cardano-cli/src/Cardano/CLI/Type/Error/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/TxCmdError.hs
@@ -67,7 +67,7 @@ data TxCmdError
   | -- Validation errors
     forall era. TxCmdTxGovDuplicateVotes (TxGovDuplicateVotes era)
   | forall era. TxCmdFeeEstimationError (TxFeeEstimationError era)
-  | TxCmdPoolMetadataHashError AnchorDataFromCertificateError
+  | TxCmdPoolMetadataHashError Exp.AnchorDataFromCertificateError
   | TxCmdHashCheckError L.Url HashCheckError
   | TxCmdUnregisteredStakeAddress !(Set StakeCredential)
   | forall era. TxCmdAlonzoEraOnwardsRequired !(CardanoEra era)


### PR DESCRIPTION
Resolves #1281 

# Changelog

```yaml
- description: |
    Propagate new `Certificate` data definition
  type:
 - compatible    
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
