### PR TITLE
Update cardano-cli to the new limit for stake pool metadata url 

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -2642,11 +2642,11 @@ pStakePoolMetadataReference =
 
 pStakePoolMetadataUrl :: Parser Text
 pStakePoolMetadataUrl =
-  Opt.option (readURIOfMaxLength 64) $
+  Opt.option (readURIOfMaxLength 128) $
     mconcat
       [ Opt.long "metadata-url"
       , Opt.metavar "URL"
-      , Opt.help "Pool metadata URL (maximum length of 64 characters)."
+      , Opt.help "Pool metadata URL (maximum length of 128 characters)."
       ]
 
 pStakePoolMetadataHash :: Parser (Hash StakePoolMetadata)

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -71,7 +71,7 @@ readStringOfMaxLength maxLen = do
     else
       fail $
         mconcat
-          [ "The provided string must have at most 64 characters, but it has "
+          [ "The provided string must have at most 128 characters, but it has "
           , show strLen
           , " characters."
           ]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_stake-pool_registration-certificate.cli
@@ -68,7 +68,7 @@ Available options:
   --multi-host-pool-relay STRING
                            The stake pool relay's DNS name that corresponds to
                            an SRV DNS record
-  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-url URL       Pool metadata URL (maximum length of 128 characters).
   --metadata-hash HASH     Pool metadata hash.
   --check-metadata-hash    Verify that the expected stake pool metadata hash
                            provided in --metadata-hash matches the hash of the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_stake-pool_registration-certificate.cli
@@ -68,7 +68,7 @@ Available options:
   --multi-host-pool-relay STRING
                            The stake pool relay's DNS name that corresponds to
                            an SRV DNS record
-  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-url URL       Pool metadata URL (maximum length of 128 characters).
   --metadata-hash HASH     Pool metadata hash.
   --check-metadata-hash    Verify that the expected stake pool metadata hash
                            provided in --metadata-hash matches the hash of the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_stake-pool_registration-certificate.cli
@@ -68,7 +68,7 @@ Available options:
   --multi-host-pool-relay STRING
                            The stake pool relay's DNS name that corresponds to
                            an SRV DNS record
-  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-url URL       Pool metadata URL (maximum length of 128 characters).
   --metadata-hash HASH     Pool metadata hash.
   --check-metadata-hash    Verify that the expected stake pool metadata hash
                            provided in --metadata-hash matches the hash of the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_stake-pool_registration-certificate.cli
@@ -68,7 +68,7 @@ Available options:
   --multi-host-pool-relay STRING
                            The stake pool relay's DNS name that corresponds to
                            an SRV DNS record
-  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-url URL       Pool metadata URL (maximum length of 128 characters).
   --metadata-hash HASH     Pool metadata hash.
   --check-metadata-hash    Verify that the expected stake pool metadata hash
                            provided in --metadata-hash matches the hash of the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_stake-pool_registration-certificate.cli
@@ -68,7 +68,7 @@ Available options:
   --multi-host-pool-relay STRING
                            The stake pool relay's DNS name that corresponds to
                            an SRV DNS record
-  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-url URL       Pool metadata URL (maximum length of 128 characters).
   --metadata-hash HASH     Pool metadata hash.
   --check-metadata-hash    Verify that the expected stake pool metadata hash
                            provided in --metadata-hash matches the hash of the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_stake-pool_registration-certificate.cli
@@ -68,7 +68,7 @@ Available options:
   --multi-host-pool-relay STRING
                            The stake pool relay's DNS name that corresponds to
                            an SRV DNS record
-  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-url URL       Pool metadata URL (maximum length of 128 characters).
   --metadata-hash HASH     Pool metadata hash.
   --check-metadata-hash    Verify that the expected stake pool metadata hash
                            provided in --metadata-hash matches the hash of the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_registration-certificate.cli
@@ -68,7 +68,7 @@ Available options:
   --multi-host-pool-relay STRING
                            The stake pool relay's DNS name that corresponds to
                            an SRV DNS record
-  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-url URL       Pool metadata URL (maximum length of 128 characters).
   --metadata-hash HASH     Pool metadata hash.
   --check-metadata-hash    Verify that the expected stake pool metadata hash
                            provided in --metadata-hash matches the hash of the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_registration-certificate.cli
@@ -68,7 +68,7 @@ Available options:
   --multi-host-pool-relay STRING
                            The stake pool relay's DNS name that corresponds to
                            an SRV DNS record
-  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-url URL       Pool metadata URL (maximum length of 128 characters).
   --metadata-hash HASH     Pool metadata hash.
   --check-metadata-hash    Verify that the expected stake pool metadata hash
                            provided in --metadata-hash matches the hash of the


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update cardano-cli to the new limit for stake pool metadata url on pair with https://github.com/IntersectMBO/cardano-ledger/issues/3941
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

More than a year ago this change occurred in ledger https://github.com/IntersectMBO/cardano-ledger/issues/3941, we implemented for Conway URLs but failed to do so for stake pool metadata. 

> It has been decided to increase the length limit for Url type from 64 bytes to 128 bytes. We can't really go much higher than 128 bytes because that would be very disruptive for hardware wallet engineers.
> 
> This limit should be increased at the deserialization level starting with protocol version 9
> 
> A new QuickCheck generator also needs to be implemented for the roundtrip tests and CDDL needs to be adjusted for Conway for Anchors and StakePool params. 

# How to trust this PR
With 129 bytes url 

```
cardano-cli conway stake-pool registration-certificate \
--cold-verification-key-file cold.vkey --vrf-verification-key-file vrf.vkey --pool-pledge 9000000000 --pool-cost 340000000 --pool-margin 05/100 --pool-reward-account-verification-key-file stake.vkey --pool-owner-stake-verification-key-file stake.vkey --testnet-magic 2 --pool-relay-ipv4 10.1.1.1 --pool-relay-port 5000 \
--metadata-url "https://raw.githubusercontent.com/carloslodelar/proposals/refs/heads/main/sample-metadata-creating-a-129-bytes-url-111111111.json" \
--metadata-hash "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348" \
--out-file pool-registration.cert

option --metadata-url: The provided string must have at most 128 characters, but it has 129 characters.
```
with 128 bytes url 
```
cardano-cli conway stake-pool registration-certificate \
--cold-verification-key-file cold.vkey \
--vrf-verification-key-file vrf.vkey \
--pool-pledge 9000000000 \
--pool-cost 340000000 \
--pool-margin 05/100 \
--pool-reward-account-verification-key-file stake.vkey \
--pool-owner-stake-verification-key-file stake.vkey \
--testnet-magic 2 \
--pool-relay-ipv4 10.1.1.1 \
--pool-relay-port 5000 \
--metadata-url "https://raw.githubusercontent.com/carloslodelar/proposals/refs/heads/main/sample-metadata-creating-a-128-bytes-url-11111111.json" \
--metadata-hash "e061d2e7d5900eb775554b918e85a1e12e34f864a62c611f96e09477ec472944" \
--out-file pool-registration.cert

cardano-cli conway transaction build \
--tx-in bdc0acc28c9feb05cacfd8e36a0f2502e671af0a7908b8301201f3a18d553f11#0 \
--change-address addr_test1vqtt24w6gzsknx2h0rdsje80auc0wthdng4jlwuxpm5wrlgsezmwf \
--certificate-file ~/test128byteurl/pool-registration.cert \
--out-file tx.raw
Estimated transaction fee: 934 Lovelace

cardano-cli conway transaction sign \
--tx-file tx.raw --signing-key-file utxo.skey \
--signing-key-file ~/test128byteurl/cold.skey \
--signing-key-file ~/test128byteurl/stake.skey \
--out-file tx.signed

cardano-cli conway transaction submit \
--tx-file tx.signed 
Transaction successfully submitted. Transaction hash is:
{"txhash":"5acae395104d6acb68fdad10237f380267547eeae74564e0bf5911b33fc93c71"}
```


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
