### PR TITLE
refactor: Include genesis name in the genesis decoding error

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Internal/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Internal/Common.hs
@@ -42,6 +42,7 @@ import Data.Coerce (coerce)
 import Data.Map.Strict (Map)
 import Data.Text qualified as Text
 import Data.Time (NominalDiffTime, UTCTime, addUTCTime, getCurrentTime)
+import Data.Typeable
 import Data.Word (Word64)
 
 import Crypto.Random (getRandomBytes)
@@ -68,7 +69,9 @@ decodeConwayGenesisFile
 decodeConwayGenesisFile = readAndDecodeGenesisFileWith A.eitherDecode
 
 readAndDecodeGenesisFileWith
-  :: MonadIOTransError GenesisCmdError t m
+  :: forall t m a
+   . Typeable a
+  => MonadIOTransError GenesisCmdError t m
   => (LBS.ByteString -> Either String a)
   -> FilePath
   -> t m a
@@ -78,7 +81,7 @@ readAndDecodeGenesisFileWith decode' fpath = do
       LBS.readFile
         fpath
   modifyError
-    (GenesisCmdGenesisFileDecodeError fpath . Text.pack)
+    (GenesisCmdGenesisFileDecodeError (typeRep $ Proxy @a) fpath . Text.pack)
     . hoistEither
     $ decode' lbs
 

--- a/cardano-cli/src/Cardano/CLI/Type/Error/GenesisCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/GenesisCmdError.hs
@@ -14,6 +14,7 @@ import Cardano.CLI.Type.Error.StakePoolCmdError
 
 import Control.Exception
 import Data.Text (Text)
+import Data.Typeable
 
 data GenesisCmdError
   = GenesisCmdByronError !ByronGenesisError
@@ -23,7 +24,7 @@ data GenesisCmdError
   | GenesisCmdFileDecodeError !FilePath !Text
   | GenesisCmdFilesDupIndex [FilePath]
   | GenesisCmdFilesNoIndex [FilePath]
-  | GenesisCmdGenesisFileDecodeError !FilePath !Text
+  | GenesisCmdGenesisFileDecodeError !TypeRep !FilePath !Text
   | GenesisCmdGenesisFileError !(FileError ())
   | GenesisCmdMismatchedGenesisKeyFiles [Int] [Int] [Int]
   | GenesisCmdNodeCmdError !NodeCmdError
@@ -79,8 +80,10 @@ instance Error GenesisCmdError where
       renderNodeCmdError e
     GenesisCmdStakePoolCmdError e ->
       prettyError e
-    GenesisCmdGenesisFileDecodeError fp e ->
-      "Error while decoding Shelley genesis at: "
+    GenesisCmdGenesisFileDecodeError ty fp e ->
+      "Error while decoding "
+        <> pretty ty
+        <> " at: "
         <> pretty fp
         <> " Error: "
         <> pretty e


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    refactor: Include genesis name in the genesis decoding error
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR changes the error message printed on genesis decoding error to include the correct genesis name instaed of generic "Shelley".

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
