### PR TITLE
fix(era-independent): correct max length in readStringOfMaxLength error message

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -71,7 +71,9 @@ readStringOfMaxLength maxLen = do
     else
       fail $
         mconcat
-          [ "The provided string must have at most 128 characters, but it has "
+          [ "The provided string must have at most "
+          , show maxLen
+          , " characters, but it has "
           , show strLen
           , " characters."
           ]


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fixed error message in readStringOfMaxLength to correctly display the actual maximum length parameter instead of hardcoded value "128"
# uncomment types applicable to the change:
  type:
  - bugfix         # fixes a defect
```

# Context

This PR fixes a bug in the error message generation for the `readStringOfMaxLength` function in the CLI parser. Previously, the error message always displayed "128 characters" as the maximum allowed length, regardless of the actual `maxLen` parameter value passed to the function. This caused confusion when the function was called with different maximum length constraints.

The fix ensures that the error message accurately reflects the configured maximum length by using the `maxLen` parameter value in the error message string construction.

# How to trust this PR

The change is minimal and focused on a single error message formatting issue. The modification:
- Replaces the hardcoded string `"The provided string must have at most 128 characters, but it has "` 
- With a dynamic construction using `show maxLen` to display the actual maximum length parameter

To verify this fix:
1. Call any CLI command that uses `readStringOfMaxLength` with a string exceeding the limit
2. Observe that the error message now correctly displays the actual maximum length instead of always showing "128"

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Self-reviewed the diff
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details