### PR TITLE
Bump `cardano-api` to version 10.19.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2025-09-24T20:00:55Z
-  , cardano-haskell-packages 2025-10-23T12:06:55Z
+  , cardano-haskell-packages 2025-11-04T08:57:00Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -241,7 +241,7 @@ library
     binary,
     bytestring,
     canonical-json,
-    cardano-api ^>=10.19,
+    cardano-api ^>=10.19.1,
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class ^>=2.2,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1761223949,
-        "narHash": "sha256-DIiZDtdHkA88XxUXHz1xzDmunBuNA5PJJi5isOsKdHM=",
+        "lastModified": 1762250773,
+        "narHash": "sha256-J4EXWt5u16eS9EsbsofXA9pN71CbZ2cAkJD1MzOEhis=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "bf256bc553e43d5b91f6467cf20f8c0f6b09f175",
+        "rev": "715fad3b318fa1dd9b8a9497107c447875d77ac0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update `cardano-ledger-api` to fix bug in `queryPoolState`, where current Pool parameters were returned instead of the future ones.
  type:
  - bugfix
```

# Context

See https://github.com/IntersectMBO/cardano-haskell-packages/pull/1164

# How to trust this PR

Just a version bump.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
