### PR TITLE
Release cardano-cli-10.13.1.0

### DIFF
--- a/.github/workflows/release-upload.yml
+++ b/.github/workflows/release-upload.yml
@@ -159,13 +159,13 @@ jobs:
               derivation+="${{ matrix.arch }}"
               ;;
             "x86_64-linux")
-              derivation+="x86_64-linux.ghc966-x86_64-unknown-linux-musl"
+              derivation+="x86_64-linux.ghc967-x86_64-unknown-linux-musl"
               ;;
             "aarch64-linux")
-              derivation+="x86_64-linux.ghc966-aarch64-unknown-linux-musl"
+              derivation+="x86_64-linux.ghc967-aarch64-unknown-linux-musl"
               ;;
             "win64")
-              derivation+="x86_64-linux.ghc966-x86_64-w64-mingw32"
+              derivation+="x86_64-linux.ghc967-x86_64-w64-mingw32"
               ;;
             *)
               echo "Unexpected matrix.arch value: ${{ matrix.arch }}"

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2025-09-24T20:00:55Z
-  , cardano-haskell-packages 2025-10-23T12:06:55Z
+  , cardano-haskell-packages 2025-11-04T08:57:00Z
 
 packages:
   cardano-cli

--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for cardano-cli
 
+## 10.13.1.0
+
+- Update `cardano-ledger-api` to fix bug in `queryPoolState`, where current Pool parameters were returned instead of the future ones.
+  (bugfix)
+  [PR 1298](https://github.com/IntersectMBO/cardano-cli/pull/1298)
+
 ## 10.13.0.0
 
 - Update cardano-api-10.19.0.0

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -241,7 +241,7 @@ library
     binary,
     bytestring,
     canonical-json,
-    cardano-api ^>=10.19,
+    cardano-api ^>=10.19.1,
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class ^>=2.2,

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.8
 name: cardano-cli
-version: 10.13.0.0
+version: 10.13.1.0
 synopsis: The Cardano command-line interface
 description: The Cardano command-line interface.
 copyright: 2020-2023 Input Output Global Inc (IOG).

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1761223949,
-        "narHash": "sha256-DIiZDtdHkA88XxUXHz1xzDmunBuNA5PJJi5isOsKdHM=",
+        "lastModified": 1762250773,
+        "narHash": "sha256-J4EXWt5u16eS9EsbsofXA9pN71CbZ2cAkJD1MzOEhis=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "bf256bc553e43d5b91f6467cf20f8c0f6b09f175",
+        "rev": "715fad3b318fa1dd9b8a9497107c447875d77ac0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Release cardano-cli 10.13.1.0
  type:
  - release
```

# Context

Bump cardano-api see: https://github.com/IntersectMBO/cardano-cli/pull/1298

Corresponding CHaP PR: https://github.com/IntersectMBO/cardano-haskell-packages/pull/1170

