### PR TITLE
Improve query stake-address-info output

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Compatible/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Json/Friendly.hs
@@ -44,6 +44,7 @@ import Cardano.CLI.Type.Common (FormatJson (..), FormatYaml (..))
 import Cardano.CLI.Type.MonadWarning (MonadWarning, runWarningIO)
 import Cardano.Crypto.Hash (hashToTextAsHex)
 import Cardano.Ledger.Core qualified as C
+import Cardano.Ledger.Credential (credKeyHash, credScriptHash)
 
 import Data.Aeson (Value (..), object, (.=))
 import Data.Aeson qualified as Aeson
@@ -926,10 +927,13 @@ friendlyDRep L.DRepAlwaysAbstain = "alwaysAbstain"
 friendlyDRep L.DRepAlwaysNoConfidence = "alwaysNoConfidence"
 friendlyDRep (L.DRepCredential sch@(L.ScriptHashObj (C.ScriptHash _))) =
   Aeson.object
-    [ "scriptHashHex" .= UsingRawBytesHex sch
+    [ "scriptHash" .= credScriptHash sch
+    , "cip129Hex" .= cip129SerialiseRaw sch
+    , "cip129Bech32" .= serialiseToBech32Cip129 sch
     ]
 friendlyDRep (L.DRepCredential kh@(L.KeyHashObj (C.KeyHash _))) =
   Aeson.object
-    [ "keyHashHex" .= UsingRawBytesHex kh
-    , "keyHashBech32" .= serialiseToBech32Cip129 kh
+    [ "keyHash" .= credKeyHash kh
+    , "cip129Hex" .= cip129SerialiseRaw kh
+    , "cip129Bech32" .= serialiseToBech32Cip129 kh
     ]


### PR DESCRIPTION
query stake-address-info now includes the correct cip129 hex format as well as the Ledger state format. This is still needed, for example, to further queries based on this output.

# Changelog

```yaml
- description: |
    query stake-address-info now includes the correct cip129 hex format as well as the Ledger State format.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/1311

# How to trust this PR

The output provides the 3 formats used by explorers and tools: CIP129Bech32, CIP129Hex and LedgerStateHex, both for Dreps with keys and for script based ones:

```shell
cardano-cli conway query stake-address-info --address stake1u8c4jt34q0hzs6pdzky26da0g03fdqxpzne84s0q40twjpgcsfpz3
[
    {
        "address": "stake1u8c4jt34q0hzs6pdzky26da0g03fdqxpzne84s0q40twjpgcsfpz3",
        "govActionDeposits": {},
        "rewardAccountBalance": 827782,
        "stakeDelegation": {
            "stakePoolBech32": "pool14wk2m2af7y4gk5uzlsmsunn7d9ppldvcxxa5an9r5ywek8330fg",
            "stakePoolHex": "abacadaba9f12a8b5382fc370e4e7e69421fb59831bb4ecca3a11d9b"
        },
        "stakeRegistrationDeposit": 2000000,
        "voteDelegation": {
            "keyHashBech32": "drep1ygne2h7vn5ghnpz06mg0g8zehy0euz8daxhpmsekvc8encsfd5ac9",
            "keyHashHex": "2227955fcc9d1179844fd6d0f41c59b91f9e08ede9ae1dc336660f99e2",
            "keyHashLedger": "27955fcc9d1179844fd6d0f41c59b91f9e08ede9ae1dc336660f99e2"
        }
    }
]
```
```shell
cardano-cli conway query stake-address-info --address stake1u8h3ygf3vc8jz9ju4ea63cy0ugcx03mwfxqlkqhxdnhnavqna2vcj
[
    {
        "address": "stake1u8h3ygf3vc8jz9ju4ea63cy0ugcx03mwfxqlkqhxdnhnavqna2vcj",
        "govActionDeposits": {},
        "rewardAccountBalance": 27665,
        "stakeDelegation": {
            "stakePoolBech32": "pool1gqgyta9sku3crjzfl9kj7kxsgfkt98y98yeu09kx22zscrezuj7",
            "stakePoolHex": "401045f4b0b72381c849f96d2f58d0426cb29c853933c796c652850c"
        },
        "stakeRegistrationDeposit": 2000000,
        "voteDelegation": {
            "scriptHashBech32": "drep1yv4uesaj92wk8ljlsh4p7jzndnzrflchaz5fzug3zxg4naqkpeas3",
            "scriptHashHex": "232bccc3b22a9d63fe5f85ea1f48536cc434ff17e8a8917111119159f4",
            "scriptHashLedger": "2bccc3b22a9d63fe5f85ea1f48536cc434ff17e8a8917111119159f4"
        }
    }
]
```


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
