### PR TITLE
Fix broken tutorial link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can also download binaries of all versions of `cardano-cli` from [cardano-cl
 
 ## Documentation
 
-* [Tutorials](https://developers.cardano.org/docs/get-started/cli-operations/basic-operations/get-started)
+* [Tutorials](https://developers.cardano.org/docs/get-started/infrastructure/cardano-cli/basic-operations/get-started)
 
 Up to date command line help reference is available here:
 * [List of all commands](cardano-cli/test/cardano-cli-golden/files/golden/help.cli)


### PR DESCRIPTION
## Summary
  - Fixed the broken tutorial link in README.md that was returning a 404 error
  - Updated path from `/cli-operations/` to `/infrastructure/cardano-cli/`
\Fixes #1314