### PR TITLE
create-testnet-data: use the same k for byron and shelley geneses

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Internal/Byron.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Internal/Byron.hs
@@ -11,6 +11,7 @@ import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Byron.Genesis qualified as Byron
 import Cardano.Crypto.ProtocolMagic qualified as Crypto
+import Cardano.Ledger.BaseTypes qualified as L
 
 import Data.Aeson (toJSON, (.=))
 import Data.Aeson qualified as Aeson
@@ -58,7 +59,7 @@ mkGenesisParameters numPools actualNetworkWord32 byronGenesisFp shelleyGenesis =
   byronPoolNumber = max 1 numPools -- byron genesis creation needs a >= 1 number of pools
   gpStartTime = Shelley.sgSystemStart shelleyGenesis
   gpProtocolParamsFile = byronGenesisFp
-  gpK = Byron.BlockCount 10
+  gpK = Byron.BlockCount . L.unNonZero $ Shelley.sgSecurityParam shelleyGenesis
   protocolMagicId = Crypto.ProtocolMagicId actualNetworkWord32
   gpProtocolMagic = Crypto.AProtocolMagic (L.Annotated protocolMagicId ()) Crypto.RequiresMagic
   gpTestnetBalance =


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    create-testnet-data: use the same k for byron and shelley geneses
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

When starting a testnet with different `k` value for byron and shelley, one can notice a following error in the log:

```
[2026-01-07 18:52:05.1256Z][monolake:Consensus.SanityCheck.SanityCheckIssue](Error,5) Configuration contains multiple security parameters: SecurityParam (NonZero {unNonZero = 10}) :| [SecurityParam (NonZero {unNonZero = 10}),SecurityParam (NonZero {unNonZero = 5}),SecurityParam (NonZero {unNonZero = 5}),SecurityParam (NonZero {unNonZero = 5}),SecurityParam (NonZero {unNonZero = 5}),SecurityParam (NonZero {unNonZero = 5}),SecurityParam (NonZero {unNonZero = 5}),SecurityParam (NonZero {unNonZero = 5})]
```

This PR make the security param the same for byron and shelley geneses.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
