### PR TITLE
Fix tutorial link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can also download binaries of all versions of `cardano-cli` from [cardano-cl
 
 ## Documentation
 
-* [Tutorials](https://developers.cardano.org/docs/get-started/cli-operations/basic-operations/get-started)
+* [Tutorials](https://developers.cardano.org/docs/get-started/infrastructure/cardano-cli/basic-operations/get-started)
 
 Up to date command line help reference is available here:
 * [List of all commands](cardano-cli/test/cardano-cli-golden/files/golden/help.cli)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix tutorial link in README
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
   - documentation  # change in code docs, haddocks...
```

# Context

https://github.com/IntersectMBO/cardano-cli/pull/1315 author is not responding

Fixes: https://github.com/IntersectMBO/cardano-cli/issues/1314

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
