### PR TITLE
Get `AlonzoGenesis`, `costModelsValid`, and `getCostModelParams` through `cardano-api`

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -441,7 +441,6 @@ test-suite cardano-cli-golden
     cardano-cli,
     cardano-cli:cardano-cli-test-lib,
     cardano-crypto-wrapper,
-    cardano-ledger-alonzo,
     cardano-ledger-core,
     cardano-strict-containers ^>=0.1,
     cborg,

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Legacy/Genesis/Create.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Legacy/Genesis/Create.hs
@@ -2,8 +2,8 @@
 
 module Test.Golden.Legacy.Genesis.Create where
 
-import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
-import Cardano.Ledger.Plutus.CostModels (costModelsValid, getCostModelParams)
+import Cardano.Api.Ledger (AlonzoGenesis (AlonzoGenesis), costModelsValid, getCostModelParams)
+
 import Cardano.Ledger.Plutus.Language
 
 import Control.Monad (void)


### PR DESCRIPTION

# Changelog

```yaml
- description: |
    Got `AlonzoGenesis`, `costModelsValid`, and `getCostModelParams` from `cardano-api`
  type:
    - refactoring
```

# Context

See https://github.com/IntersectMBO/cardano-cli/issues/1266

# How to trust this PR

It is a very simple refactoring. It shouldn't change the way the code behaves at all.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
