### PR TITLE
Improve error message for malformed timestamps

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Option.hs
@@ -387,8 +387,8 @@ pGenesisDir =
 pMaybeSystemStart :: Parser (Maybe SystemStart)
 pMaybeSystemStart =
   Opt.optional $
-    fmap (SystemStart . convertTime) $
-      Opt.strOption $
+    fmap SystemStart $
+      Opt.option timeReader $
         mconcat
           [ Opt.long "start-time"
           , Opt.metavar "UTC_TIME"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -579,11 +579,13 @@ pQuerySlotNumberCmd envCli =
       <*> pUtcTimestamp
  where
   pUtcTimestamp =
-    convertTime
-      <$> (Opt.strArgument . mconcat)
-        [ Opt.metavar "TIMESTAMP"
-        , Opt.help "UTC timestamp in YYYY-MM-DDThh:mm:ssZ format"
-        ]
+    Opt.argument
+      timeReader
+      ( mconcat
+          [ Opt.metavar "TIMESTAMP"
+          , Opt.help "UTC timestamp in YYYY-MM-DDThh:mm:ssZ format"
+          ]
+      )
 
 pQueryRefScriptSizeCmd :: forall era. IsEra era => EnvCli -> Parser (QueryCmds era)
 pQueryRefScriptSizeCmd envCli =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
@@ -486,8 +486,8 @@ systemStartPOSIX =
 
 systemStartUTC :: Parser SystemStart
 systemStartUTC =
-  SystemStart . convertTime
-    <$> ( Opt.strOption $
+  SystemStart
+    <$> ( Opt.option timeReader $
             mconcat
               [ Opt.long "start-time-utc"
               , Opt.metavar "UTC_TIME"

--- a/cardano-cli/src/Cardano/CLI/Legacy/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Option.hs
@@ -236,8 +236,8 @@ pGenesisCmds envCli =
   pMaybeSystemStart :: Parser (Maybe SystemStart)
   pMaybeSystemStart =
     Opt.optional $
-      fmap (SystemStart . convertTime) $
-        Opt.strOption $
+      fmap SystemStart $
+        Opt.option timeReader $
           mconcat
             [ Opt.long "start-time"
             , Opt.metavar "UTC_TIME"


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Improved error message for malformed timestamps
  type:
  - bugfix
```

# Context

See https://github.com/IntersectMBO/cardano-cli/issues/1166.

# How to trust this PR

It is reassuring that the golden files for the parameters didn't change, so the flags didn't change. The thing to check is whether the error is correct, and whether it parses normally when provided a right output. You can use the example in the original issue:

```bash
cardano-cli conway query slot-number 123456
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
