### PR TITLE
Print estimated transaction fee in `transaction build-estimate`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
@@ -510,7 +510,7 @@ runTransactionBuildEstimateCmd -- TODO change type
                 collectTxBodyScriptWitnesses sbe txBodyContent
             ]
 
-    BalancedTxBody _ balancedTxBody _ _ <-
+    BalancedTxBody _ balancedTxBody _ fee <-
       fromEitherCli $
         first TxCmdFeeEstimationError $
           estimateBalancedTxBody
@@ -534,6 +534,8 @@ runTransactionBuildEstimateCmd -- TODO change type
         if isCborOutCanonical == TxCborCanonical
           then writeTxFileTextEnvelopeCanonical sbe txBodyOutFile noWitTx
           else writeTxFileTextEnvelope sbe txBodyOutFile noWitTx
+
+    liftIO . putStrLn . docToString $ "Estimated transaction fee:" <+> pretty fee
 
 -- TODO: Update type in cardano-api to be more generic then delete this
 toShelleyLedgerPParamsShim


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Print estimated transaction fee in `transaction build-estimate`
  type:
    - feature
```

# Context

See https://github.com/IntersectMBO/cardano-cli/issues/1198

# How to trust this PR

You can test it with this command assuming you are in `cardano-cli` and have `cardano-api` in a sibling folder:

```bash
$ cabal run cardano-cli -- latest transaction build-estimate --out-file cosa.tx --shelley-key-witnesses 1 --protocol-params-file ../cardano-api/cardano-wasm/examples/basic/mainnet_pparams.json --tx-in e29e96a012c2443d59f2e53c156503a857c2f27c069ae003dab8125594038891#0 --total-utxo-value 100000000 --tx-out addr_test1qp39w0fa0ccdc4gmg87puydf2kxt5mgt0vteq4a22ktrcssg7ysmx64l90xa0k4z25wpuejngya833qeu9cdxvveynfscsskf5+10000000 --change-address addr_test1qp39w0fa0ccdc4gmg87puydf2kxt5mgt0vteq4a22ktrcssg7ysmx64l90xa0k4z25wpuejngya833qeu9cdxvveynfscsskf5
Estimated transaction fee: 168273 Lovelace
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
