### PR TITLE
Defensive mempool

### DIFF
--- a/.github/workflows/release-upload.yml
+++ b/.github/workflows/release-upload.yml
@@ -159,13 +159,13 @@ jobs:
               derivation+="${{ matrix.arch }}"
               ;;
             "x86_64-linux")
-              derivation+="x86_64-linux.ghc967-x86_64-unknown-linux-musl"
+              derivation+="x86_64-linux.ghc9122-x86_64-unknown-linux-musl"
               ;;
             "aarch64-linux")
-              derivation+="x86_64-linux.ghc967-aarch64-unknown-linux-musl"
+              derivation+="x86_64-linux.ghc9122-aarch64-unknown-linux-musl"
               ;;
             "win64")
-              derivation+="x86_64-linux.ghc967-x86_64-w64-mingw32"
+              derivation+="x86_64-linux.ghc9122-x86_64-w64-mingw32"
               ;;
             *)
               echo "Unexpected matrix.arch value: ${{ matrix.arch }}"

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2025-12-02T22:23:29Z
-  , cardano-haskell-packages 2026-01-26T18:50:24Z
+  , cardano-haskell-packages 2026-01-29T01:19:14Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -242,7 +242,7 @@ library
     binary,
     bytestring,
     canonical-json,
-    cardano-api ^>=10.22,
+    cardano-api ^>=10.23,
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class ^>=2.2.3.2,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1769459742,
-        "narHash": "sha256-nS+nujs7nocUpWgQ9qvsB5V1BcP4mbVpkoksskwkwQY=",
+        "lastModified": 1769651866,
+        "narHash": "sha256-5zf9YWt584gC+M7uxvJAVmkZ7CzJQdmFqH8CMtPjBZ4=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "2ece2c26fab870bf822dc67e956aaf0dcad8d324",
+        "rev": "50cc893217a20b78e7c260a73d6831364ec05890",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION

# Changelog

```yaml
- description: |
    Bumped `cardano-api-10.23.0.0`
  type:
    - maintenance
```

# Context

This PR updates `cardano-api` to use the latest version of ouroboros-consensus that includes this patch: https://github.com/IntersectMBO/ouroboros-consensus/pull/1836

Related PRs:

- [cardano-api] - https://github.com/IntersectMBO/cardano-api/pull/1087
- [cardano-node] - https://github.com/IntersectMBO/cardano-node/pull/6417

# How to trust this PR

Changes are small, but worth checking they make sense if you have good context about them.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
