### PR TITLE
Modify readAnyScript to handle text envelope formatted simple scripts

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -227,7 +227,12 @@ readAnyScript anyScriptFp = do
             Right (Exp'.AnyPlutusScript plutusScript) -> return $ Exp.AnyPlutusScript plutusScript
             Left e ->
               throwCliError $ "Failed to decode Plutus script: " <> show e
-        Nothing -> throwCliError $ "Unsupported script language: " <> anyScriptType
+        -- Simple script text envelope format
+        Nothing ->
+          case Exp.obtainCommonConstraints (Exp.useEra @era) (Exp.deserialiseSimpleScript scriptBs) of
+            Right ss -> return $ Exp.AnySimpleScript ss
+            Left e ->
+              throwCliError $ "Failed to decode Simple script: " <> show (e :: CBOR.DecoderError)
 
 -- | Read a script file. The file can either be in the text envelope format
 -- wrapping the binary representation of any of the supported script languages,


### PR DESCRIPTION
# Changelog
Fixes #1332 
```yaml
- description: |
    Modify readAnyScript to handle text envelope formatted simple scripts
  type:
   - bugfix    
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
