### PR TITLE
Print friendly stderr message when future-pparams returns null

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -1671,6 +1671,10 @@ runQueryFuturePParams
     } = conwayEraOnwardsConstraints eon $ do
     futurePParams <- fromExceptTCli $ runQuery nodeConnInfo target $ queryFuturePParams eon
 
+    when (isNothing futurePParams) $
+      liftIO . T.hPutStrLn IO.stderr $
+        "No protocol parameter changes will be enacted at the next epoch boundary."
+
     let output =
           outputFormat
             & ( id


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Print friendly stderr message when query future-pparams returns null
  type:
    - feature
```

# Context

When `query future-pparams` returns `null` (no pending protocol parameter changes), the CLI now prints a human-friendly message to `stderr`:

> No protocol parameter changes will be enacted at the next epoch boundary.

`stdout` still outputs `null` for script compatibility, as discussed in the issue.

Closes #1061

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages