### PR TITLE
Remove CLI-specific AnyPlutusScript, use Exp.AnyPlutusScript throughout

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Compatible/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Read.hs
@@ -8,23 +8,21 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Cardano.CLI.Compatible.Read
-  ( AnyPlutusScript (..)
-  , readFilePlutusScript
+  ( readFilePlutusScript
   , readFileSimpleScript
   )
 where
 
 import Cardano.Api as Api
+import Cardano.Api.Experimental.Plutus qualified as Exp
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.Read (readFileCli)
-import Cardano.CLI.Type.Error.PlutusScriptDecodeError
 import Cardano.CLI.Type.Error.ScriptDecodeError
 
 import Prelude
 
 import Data.Aeson qualified as Aeson
-import Data.Bifunctor
 import Data.ByteString qualified as BS
 import Data.Text qualified as Text
 
@@ -55,48 +53,21 @@ deserialiseSimpleScript bs =
   teType' :: FromSomeType HasTextEnvelope (Script SimpleScript')
   teType' = FromSomeType (AsScript AsSimpleScript) id
 
-data AnyPlutusScript where
-  AnyPlutusScript
-    :: IsPlutusScriptLanguage lang => PlutusScriptVersion lang -> PlutusScript lang -> AnyPlutusScript
-
 readFilePlutusScript
-  :: FilePath
-  -> CIO e AnyPlutusScript
-readFilePlutusScript plutusScriptFp = do
-  bs <-
-    readFileCli plutusScriptFp
-  fromEitherCli $ deserialisePlutusScript bs
-
-deserialisePlutusScript
-  :: BS.ByteString
-  -> Either PlutusScriptDecodeError AnyPlutusScript
-deserialisePlutusScript bs = do
-  te <- first PlutusScriptJsonDecodeError $ deserialiseFromJSON bs
-  case teType te of
-    TextEnvelopeType s -> case s of
-      "PlutusScriptV1" -> deserialiseAnyPlutusScriptVersion PlutusScriptV1 te
-      "PlutusScriptV2" -> deserialiseAnyPlutusScriptVersion PlutusScriptV2 te
-      "PlutusScriptV3" -> deserialiseAnyPlutusScriptVersion PlutusScriptV3 te
-      unknownScriptVersion ->
-        Left . PlutusScriptDecodeErrorUnknownVersion $ Text.pack unknownScriptVersion
- where
-  deserialiseAnyPlutusScriptVersion
-    :: IsPlutusScriptLanguage lang
-    => PlutusScriptVersion lang
-    -> TextEnvelope
-    -> Either PlutusScriptDecodeError AnyPlutusScript
-  deserialiseAnyPlutusScriptVersion lang tEnv =
-    first PlutusScriptDecodeTextEnvelopeError $
-      deserialiseFromTextEnvelopeAnyOf [teTypes (AnyPlutusScriptVersion lang)] tEnv
-
-  teTypes :: AnyPlutusScriptVersion -> FromSomeType HasTextEnvelope AnyPlutusScript
-  teTypes =
-    \case
-      AnyPlutusScriptVersion PlutusScriptV1 ->
-        FromSomeType (AsPlutusScript AsPlutusScriptV1) (AnyPlutusScript PlutusScriptV1)
-      AnyPlutusScriptVersion PlutusScriptV2 ->
-        FromSomeType (AsPlutusScript AsPlutusScriptV2) (AnyPlutusScript PlutusScriptV2)
-      AnyPlutusScriptVersion PlutusScriptV3 ->
-        FromSomeType (AsPlutusScript AsPlutusScriptV3) (AnyPlutusScript PlutusScriptV3)
-      AnyPlutusScriptVersion PlutusScriptV4 ->
-        FromSomeType (AsPlutusScript AsPlutusScriptV4) (AnyPlutusScript PlutusScriptV4)
+  :: forall era e
+   . ShelleyBasedEra era
+  -> FilePath
+  -> CIO e (Exp.AnyPlutusScript (ShelleyLedgerEra era))
+readFilePlutusScript sbe plutusScriptFp = do
+  bs <- readFileCli plutusScriptFp
+  te <- fromEitherCli $ deserialiseFromJSON bs
+  let scriptBs = teRawCBOR te
+      TextEnvelopeType anyScriptType = teType te
+  case Exp.textToPlutusLanguage (Text.pack anyScriptType) of
+    Just lang ->
+      fromEitherCli
+        ( shelleyBasedEraConstraints sbe (Exp.decodeAnyPlutusScript scriptBs lang)
+            :: Either DecoderError (Exp.AnyPlutusScript (ShelleyLedgerEra era))
+        )
+    Nothing ->
+      throwCliError $ "Unsupported script language: " <> anyScriptType

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
@@ -38,7 +38,6 @@ import Cardano.CLI.Read
 import Cardano.CLI.Type.Common
 
 import Control.Monad
-import Data.ByteString.Short qualified as SBS
 import Data.Map.Ordered.Strict qualified as OMap
 import Lens.Micro
 
@@ -159,17 +158,7 @@ readCertificateScriptWitnessSbe
       (OnDiskPlutusScriptCliArgs scriptFp Exp.NoScriptDatumAllowed redeemerFile execUnits)
     ) = do
     let plutusScriptFp = unFile scriptFp
-    Compatible.AnyPlutusScript plutusScriptVer (PlutusScriptSerialised sBytes) <-
-      Compatible.readFilePlutusScript plutusScriptFp
-    let anyLang :: Exp.AnyPlutusScriptLanguage = case plutusScriptVer of
-          PlutusScriptV1 -> Exp.AnyPlutusScriptLanguage L.SPlutusV1
-          PlutusScriptV2 -> Exp.AnyPlutusScriptLanguage L.SPlutusV2
-          PlutusScriptV3 -> Exp.AnyPlutusScriptLanguage L.SPlutusV3
-          PlutusScriptV4 -> Exp.AnyPlutusScriptLanguage L.SPlutusV4
-        bs = SBS.fromShort sBytes
-
-        eAnyPlutusScript :: Either DecoderError (Exp.AnyPlutusScript (ShelleyLedgerEra era)) = shelleyBasedEraConstraints sbe $ Exp.decodeAnyPlutusScript bs anyLang
-    Exp.AnyPlutusScript anyPlutusScript <- fromEitherCli eAnyPlutusScript
+    Exp.AnyPlutusScript anyPlutusScript <- Compatible.readFilePlutusScript sbe plutusScriptFp
     let
       lang = Exp.plutusScriptInEraSLanguage anyPlutusScript
     let script' = Exp.PScript anyPlutusScript

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/ScriptWitness.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/ScriptWitness.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 
 module Cardano.CLI.Compatible.Transaction.ScriptWitness
@@ -11,48 +12,36 @@ module Cardano.CLI.Compatible.Transaction.ScriptWitness
 where
 
 import Cardano.Api
-  ( AnyPlutusScriptVersion (..)
-  , AnyShelleyBasedEra (..)
-  , File (..)
-  , IsPlutusScriptLanguage
-  , PlutusScriptOrReferenceInput (..)
-  , PlutusScriptVersion (..)
-  , Script (..)
-  , ScriptDatum (..)
-  , ScriptLanguage (..)
-  , ScriptWitness (..)
+  ( DecoderError
+  , SerialiseAsCBOR (serialiseToCBOR)
   , ShelleyBasedEra
-  , SimpleScriptOrReferenceInput (..)
-  , sbeToSimpleScriptLanguageInEra
-  , scriptLanguageSupportedInEra
+  , ShelleyLedgerEra
   , shelleyBasedEraConstraints
-  , toAlonzoScriptLanguage
+  , unFile
   )
 import Cardano.Api.Experimental qualified as Exp
-import Cardano.Api.Experimental.Plutus (fromPlutusSLanguage)
+import Cardano.Api.Experimental.AnyScriptWitness qualified as Exp
 import Cardano.Api.Experimental.Plutus qualified as Exp
 
 import Cardano.CLI.Compatible.Exception
-import Cardano.CLI.Compatible.Read
-import Cardano.CLI.EraBased.Script.Certificate.Type
+import Cardano.CLI.Compatible.Read (readFilePlutusScript, readFileSimpleScript)
 import Cardano.CLI.EraBased.Script.Read.Common (readScriptDataOrFile)
 import Cardano.CLI.EraBased.Script.Type
-  ( CliScriptWitnessError (..)
-  , NoPolicyId (..)
+  ( NoPolicyId (..)
   , OnDiskPlutusScriptCliArgs (..)
+  , PlutusRefScriptCliArgs (..)
   , ScriptRequirements (..)
   , SimpleRefScriptCliArgs (..)
   )
-import Cardano.CLI.EraBased.Script.Type qualified as Exp
 import Cardano.CLI.Type.Common (AnySLanguage (..), CertificateFile)
-import Cardano.Ledger.Plutus.Language qualified as L
 
 import Control.Monad
 
 readCertificateScriptWitnesses
-  :: ShelleyBasedEra era
+  :: forall era e
+   . ShelleyBasedEra era
   -> [(CertificateFile, Maybe (ScriptRequirements Exp.CertItem))]
-  -> CIO e [(CertificateFile, Maybe (CertificateScriptWitness era))]
+  -> CIO e [(CertificateFile, Maybe (Exp.AnyWitness (ShelleyLedgerEra era)))]
 readCertificateScriptWitnesses sbe =
   mapM
     ( \(certFile, mSWit) -> do
@@ -60,94 +49,59 @@ readCertificateScriptWitnesses sbe =
     )
 
 readCertificateScriptWitness
-  :: ShelleyBasedEra era -> ScriptRequirements Exp.CertItem -> CIO e (CertificateScriptWitness era)
+  :: forall era e
+   . ShelleyBasedEra era
+  -> ScriptRequirements Exp.CertItem
+  -> CIO e (Exp.AnyWitness (ShelleyLedgerEra era))
 readCertificateScriptWitness sbe certScriptReq =
   case certScriptReq of
     OnDiskSimpleScript scriptFp -> do
       let sFp = unFile scriptFp
-      s <-
-        readFileSimpleScript sFp
-      case s of
-        SimpleScript ss -> do
-          return $
-            CertificateScriptWitness $
-              SimpleScriptWitness (sbeToSimpleScriptLanguageInEra sbe) $
-                SScript ss
+      ss <- readFileSimpleScript sFp
+      let serialisedSS = serialiseToCBOR ss
+      simpleScript <-
+        fromEitherCli
+          ( shelleyBasedEraConstraints sbe (Exp.deserialiseSimpleScript serialisedSS)
+              :: Either DecoderError (Exp.SimpleScript (ShelleyLedgerEra era))
+          )
+      return $ Exp.AnySimpleScriptWitness $ Exp.SScript simpleScript
     OnDiskPlutusScript
       (OnDiskPlutusScriptCliArgs scriptFp Exp.NoScriptDatumAllowed redeemerFile execUnits) -> do
         let plutusScriptFp = unFile scriptFp
-        plutusScript <- readFilePlutusScript plutusScriptFp
+        Exp.AnyPlutusScript anyPlutusScript <- readFilePlutusScript sbe plutusScriptFp
+        let lang = Exp.plutusScriptInEraSLanguage anyPlutusScript
+            script' = Exp.PScript anyPlutusScript
         redeemer <-
           fromExceptTCli $
             readScriptDataOrFile redeemerFile
-        case plutusScript of
-          AnyPlutusScript lang script -> do
-            let pScript = PScript script
-            sLangSupported <-
-              fromMaybeCli
-                ( PlutusScriptWitnessLanguageNotSupportedInEra
-                    (toAlonzoScriptLanguage $ AnyPlutusScriptVersion lang)
-                    (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
-                )
-                $ scriptLanguageSupportedInEra sbe
-                $ PlutusScriptLanguage lang
-            return $
-              CertificateScriptWitness $
-                PlutusScriptWitness
-                  sLangSupported
-                  lang
-                  pScript
-                  NoScriptDatumForStake
-                  redeemer
-                  execUnits
+        let sw =
+              Exp.PlutusScriptWitness
+                lang
+                script'
+                Exp.NoScriptDatum
+                redeemer
+                execUnits
+        return $ Exp.AnyPlutusScriptWitness $ Exp.AnyPlutusCertifyingScriptWitness sw
     SimpleReferenceScript (SimpleRefScriptArgs refTxIn NoPolicyId) ->
-      return $
-        CertificateScriptWitness $
-          SimpleScriptWitness
-            (sbeToSimpleScriptLanguageInEra sbe)
-            (SReferenceScript refTxIn)
+      return . Exp.AnySimpleScriptWitness $ Exp.SReferenceScript refTxIn
     PlutusReferenceScript
       ( PlutusRefScriptCliArgs
-          refTxIn
+          refInput
           (AnySLanguage lang)
           Exp.NoScriptDatumAllowed
-          Exp.NoPolicyId
+          NoPolicyId
           redeemerFile
           execUnits
         ) -> do
-        let pScript = PReferenceScript refTxIn
         redeemer <-
           fromExceptTCli $
             readScriptDataOrFile redeemerFile
-        sLangSupported <-
-          fromMaybeCli
-            ( PlutusScriptWitnessLanguageNotSupportedInEra
-                (L.plutusLanguage lang)
-                (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
-            )
-            $ scriptLanguageSupportedInEra sbe
-            $ obtainIsPlutusScriptLanguage (fromPlutusSLanguage lang)
-            $ PlutusScriptLanguage
-            $ Exp.fromPlutusSLanguage lang
-
         return $
-          CertificateScriptWitness $
-            obtainIsPlutusScriptLanguage (fromPlutusSLanguage lang) $
-              PlutusScriptWitness
-                sLangSupported
-                (Exp.fromPlutusSLanguage lang)
-                pScript
-                NoScriptDatumForStake
+          Exp.AnyPlutusScriptWitness $
+            Exp.AnyPlutusCertifyingScriptWitness $
+              Exp.PlutusScriptWitness
+                lang
+                (Exp.PReferenceScript refInput)
+                Exp.NoScriptDatum
                 redeemer
                 execUnits
-
-obtainIsPlutusScriptLanguage
-  :: PlutusScriptVersion lang
-  -> (IsPlutusScriptLanguage lang => a)
-  -> a
-obtainIsPlutusScriptLanguage lang f =
-  case lang of
-    PlutusScriptV1 -> f
-    PlutusScriptV2 -> f
-    PlutusScriptV3 -> f
-    PlutusScriptV4 -> f


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Replace the CLI-specific `AnyPlutusScript` GADT with `Cardano.Api.Experimental.Plutus.AnyPlutusScript` throughout the `Compatible` subsystem.
  type:
  - refactoring
```

# Context

Closes #1328.

`Compatible/Read.hs` defined a CLI-specific `AnyPlutusScript` GADT that existentially wrapped `PlutusScriptVersion lang + PlutusScript lang`. This pre-dated `Cardano.Api.Experimental.Plutus.AnyPlutusScript`, which is the proper era-parameterised type. This PR removes the CLI-specific type and replaces it with the cardano-api experimental one throughout the three affected files.

# How to trust this PR

This is a pure internal refactoring — no user-visible behaviour changes.

- Only 3 files are modified: `Compatible/Read.hs`, `Compatible/Transaction/Run.hs`, `Compatible/Transaction/ScriptWitness.hs`
- The diff is net -89 lines: the old `AnyPlutusScript` definition, `deserialisePlutusScript` helper, and `obtainIsPlutusScriptLanguage` helper are all deleted; the new `readFilePlutusScript` mirrors the pattern already used in `Cardano.CLI.Read`
- `Compatible/Transaction/ScriptWitness.hs` now mirrors the same experimental-API pattern as `Compatible/Transaction/Run.hs`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff