### PR TITLE
Replace parameterized ScriptRequirements GADT with flat unparameterized ADTs

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Command.hs
@@ -12,7 +12,6 @@ module Cardano.CLI.Compatible.Transaction.Command
 where
 
 import Cardano.Api
-import Cardano.Api.Experimental
 
 import Cardano.CLI.EraBased.Script.Type
 import Cardano.CLI.Type.Common
@@ -28,15 +27,15 @@ data CompatibleTransactionCmds era
       [TxOutAnyEra]
       !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
       !( Maybe
-           (Featured ConwayEraOnwards era [(ProposalFile In, Maybe (ScriptRequirements ProposalItem))])
+           (Featured ConwayEraOnwards era [(ProposalFile In, Maybe AnyNonAssetScript)])
        )
-      ![(VoteFile In, Maybe (ScriptRequirements VoterItem))]
+      ![(VoteFile In, Maybe AnyNonAssetScript)]
       [WitnessSigningData]
       -- ^ Signing keys
       (Maybe NetworkId)
       !Coin
       -- ^ Tx fee
-      ![(CertificateFile, Maybe (ScriptRequirements CertItem))]
+      ![(CertificateFile, Maybe AnyNonAssetScript)]
       -- ^ stake registering certs
       !(File () Out)
 

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Option.hs
@@ -11,7 +11,6 @@ module Cardano.CLI.Compatible.Transaction.Option
 where
 
 import Cardano.Api
-import Cardano.Api.Experimental
 
 import Cardano.CLI.Compatible.Transaction.Command
 import Cardano.CLI.Environment
@@ -161,7 +160,7 @@ pRefScriptFp =
 pVoteFiles
   :: ShelleyBasedEra era
   -> BalanceTxExecUnits
-  -> Parser [(VoteFile In, Maybe (ScriptRequirements VoterItem))]
+  -> Parser [(VoteFile In, Maybe AnyNonAssetScript)]
 pVoteFiles sbe bExUnits =
   caseShelleyToBabbageOrConwayEraOnwards
     (const $ pure [])

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
@@ -28,7 +28,6 @@ import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.Compatible.Read qualified as Compatible
 import Cardano.CLI.Compatible.Transaction.Command
 import Cardano.CLI.Compatible.Transaction.TxOut
-import Cardano.CLI.EraBased.Script.Certificate.Type
 import Cardano.CLI.EraBased.Script.Proposal.Read
 import Cardano.CLI.EraBased.Script.Read.Common
 import Cardano.CLI.EraBased.Script.Type
@@ -128,7 +127,7 @@ runCompatibleTransactionCmd
 
 readCertificateScriptWitnesses'
   :: ShelleyBasedEra era
-  -> [(CertificateFile, Maybe (ScriptRequirements Exp.CertItem))]
+  -> [(CertificateFile, Maybe AnyNonAssetScript)]
   -> CIO e [(CertificateFile, Exp.AnyWitness (ShelleyLedgerEra era))]
 readCertificateScriptWitnesses' sbe =
   mapM
@@ -143,66 +142,55 @@ readCertificateScriptWitnesses' sbe =
 readCertificateScriptWitnessSbe
   :: forall era e
    . ShelleyBasedEra era
-  -> ScriptRequirements Exp.CertItem
+  -> AnyNonAssetScript
   -> CIO e (Exp.AnyWitness (ShelleyLedgerEra era))
-readCertificateScriptWitnessSbe sbe (OnDiskSimpleScript scriptFp) = do
-  let sFp = unFile scriptFp
-  ss <- Compatible.readFileSimpleScript sFp
-  let serialisedSS = serialiseToCBOR ss
-  let simpleScriptE :: Either DecoderError (Exp.SimpleScript (ShelleyLedgerEra era)) = shelleyBasedEraConstraints sbe $ Exp.deserialiseSimpleScript serialisedSS
-  simpleScript <- fromEitherCli simpleScriptE
-  return $ Exp.AnySimpleScriptWitness $ Exp.SScript simpleScript
-readCertificateScriptWitnessSbe
-  sbe
-  ( OnDiskPlutusScript
-      (OnDiskPlutusScriptCliArgs scriptFp Exp.NoScriptDatumAllowed redeemerFile execUnits)
-    ) = do
-    let plutusScriptFp = unFile scriptFp
-    Exp.Plutus.AnyPlutusScript anyPlutusScript <- Compatible.readFilePlutusScript sbe plutusScriptFp
-    let
-      lang = Exp.Plutus.plutusScriptInEraSLanguage anyPlutusScript
-    let script' = Exp.PScript anyPlutusScript
+readCertificateScriptWitnessSbe sbe (AnyNonAssetScriptSimple simpleReq) =
+  case simpleReq of
+    OnDiskSimpleScript scriptFp -> do
+      let sFp = unFile scriptFp
+      ss <- Compatible.readFileSimpleScript sFp
+      let serialisedSS = serialiseToCBOR ss
+      let simpleScriptE :: Either DecoderError (Exp.SimpleScript (ShelleyLedgerEra era)) = shelleyBasedEraConstraints sbe $ Exp.deserialiseSimpleScript serialisedSS
+      simpleScript <- fromEitherCli simpleScriptE
+      return $ Exp.AnySimpleScriptWitness $ Exp.SScript simpleScript
+    ReferenceSimpleScript refTxin ->
+      return . Exp.AnySimpleScriptWitness $ Exp.SReferenceScript refTxin
+readCertificateScriptWitnessSbe sbe (AnyNonAssetScriptPlutus plutusReq) =
+  case plutusReq of
+    OnDiskPlutusNonAssetScript scriptFp redeemerFile execUnits -> do
+      let plutusScriptFp = unFile scriptFp
+      Exp.Plutus.AnyPlutusScript anyPlutusScript <- Compatible.readFilePlutusScript sbe plutusScriptFp
+      let
+        lang = Exp.Plutus.plutusScriptInEraSLanguage anyPlutusScript
+      let script' = Exp.PScript anyPlutusScript
 
-    redeemer <-
-      fromExceptTCli $
-        readScriptDataOrFile redeemerFile
+      redeemer <-
+        fromExceptTCli $
+          readScriptDataOrFile redeemerFile
 
-    let sw =
-          Exp.PlutusScriptWitness
-            lang
-            script'
-            Exp.NoScriptDatum
-            redeemer
-            execUnits
-    return $
-      Exp.AnyPlutusScriptWitness $
-        Exp.AnyPlutusCertifyingScriptWitness sw
-readCertificateScriptWitnessSbe
-  _
-  ( PlutusReferenceScript
-      ( PlutusRefScriptCliArgs
-          refInput
-          (AnySLanguage lang)
-          Exp.NoScriptDatumAllowed
-          NoPolicyId
-          redeemerFile
-          execUnits
-        )
-    ) = do
-    redeemer <-
-      fromExceptTCli $
-        readScriptDataOrFile redeemerFile
-    return $
-      Exp.AnyPlutusScriptWitness $
-        Exp.AnyPlutusCertifyingScriptWitness $
-          Exp.PlutusScriptWitness
-            lang
-            (Exp.PReferenceScript refInput)
-            Exp.NoScriptDatum
-            redeemer
-            execUnits
-readCertificateScriptWitnessSbe _ (SimpleReferenceScript (SimpleRefScriptArgs refTxin NoPolicyId)) =
-  return . Exp.AnySimpleScriptWitness $ Exp.SReferenceScript refTxin
+      let sw =
+            Exp.Plutus.PlutusScriptWitness
+              lang
+              script'
+              Exp.Plutus.NoScriptDatum
+              redeemer
+              execUnits
+      return $
+        Exp.AnyPlutusScriptWitness $
+          Exp.AnyPlutusCertifyingScriptWitness sw
+    ReferencePlutusNonAssetScript refInput (AnySLanguage lang) redeemerFile execUnits -> do
+      redeemer <-
+        fromExceptTCli $
+          readScriptDataOrFile redeemerFile
+      return $
+        Exp.AnyPlutusScriptWitness $
+          Exp.AnyPlutusCertifyingScriptWitness $
+            Exp.Plutus.PlutusScriptWitness
+              lang
+              (Exp.Plutus.PReferenceScript refInput)
+              Exp.Plutus.NoScriptDatum
+              redeemer
+              execUnits
 
 -- | Create 'TxCertificates'. Note that 'Certificate era' will be deduplicated. Only Certificates with a
 -- stake credential will be in the result.
@@ -240,7 +228,7 @@ readUpdateProposalFile (Featured sToB (Just updateProposalFile)) = do
 
 readProposalProcedureFile
   :: forall e era
-   . Featured ConwayEraOnwards era [(ProposalFile In, Maybe (ScriptRequirements Exp.ProposalItem))]
+   . Featured ConwayEraOnwards era [(ProposalFile In, Maybe AnyNonAssetScript)]
   -> CIO e (AnyProtocolUpdate era)
 readProposalProcedureFile (Featured cEraOnwards []) =
   let sbe = convert cEraOnwards

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/ScriptWitness.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/ScriptWitness.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
@@ -27,11 +26,9 @@ import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.Compatible.Read (readFilePlutusScript, readFileSimpleScript)
 import Cardano.CLI.EraBased.Script.Read.Common (readScriptDataOrFile)
 import Cardano.CLI.EraBased.Script.Type
-  ( NoPolicyId (..)
-  , OnDiskPlutusScriptCliArgs (..)
-  , PlutusRefScriptCliArgs (..)
-  , ScriptRequirements (..)
-  , SimpleRefScriptCliArgs (..)
+  ( AnyNonAssetScript (..)
+  , PlutusNonAssetScriptRequirements (..)
+  , SimpleScriptRequirements (..)
   )
 import Cardano.CLI.Type.Common (AnySLanguage (..), CertificateFile)
 
@@ -40,7 +37,7 @@ import Control.Monad
 readCertificateScriptWitnesses
   :: forall era e
    . ShelleyBasedEra era
-  -> [(CertificateFile, Maybe (ScriptRequirements Exp.CertItem))]
+  -> [(CertificateFile, Maybe AnyNonAssetScript)]
   -> CIO e [(CertificateFile, Maybe (Exp.AnyWitness (ShelleyLedgerEra era)))]
 readCertificateScriptWitnesses sbe =
   mapM
@@ -51,57 +48,52 @@ readCertificateScriptWitnesses sbe =
 readCertificateScriptWitness
   :: forall era e
    . ShelleyBasedEra era
-  -> ScriptRequirements Exp.CertItem
+  -> AnyNonAssetScript
   -> CIO e (Exp.AnyWitness (ShelleyLedgerEra era))
 readCertificateScriptWitness sbe certScriptReq =
   case certScriptReq of
-    OnDiskSimpleScript scriptFp -> do
-      let sFp = unFile scriptFp
-      ss <- readFileSimpleScript sFp
-      let serialisedSS = serialiseToCBOR ss
-      simpleScript <-
-        fromEitherCli
-          ( shelleyBasedEraConstraints sbe (Exp.deserialiseSimpleScript serialisedSS)
-              :: Either DecoderError (Exp.SimpleScript (ShelleyLedgerEra era))
-          )
-      return $ Exp.AnySimpleScriptWitness $ Exp.SScript simpleScript
-    OnDiskPlutusScript
-      (OnDiskPlutusScriptCliArgs scriptFp Exp.NoScriptDatumAllowed redeemerFile execUnits) -> do
-        let plutusScriptFp = unFile scriptFp
-        Exp.Plutus.AnyPlutusScript anyPlutusScript <- readFilePlutusScript sbe plutusScriptFp
-        let lang = Exp.Plutus.plutusScriptInEraSLanguage anyPlutusScript
-            script' = Exp.PScript anyPlutusScript
-        redeemer <-
-          fromExceptTCli $
-            readScriptDataOrFile redeemerFile
-        let sw =
-              Exp.PlutusScriptWitness
-                lang
-                script'
-                Exp.NoScriptDatum
-                redeemer
-                execUnits
-        return $ Exp.AnyPlutusScriptWitness $ Exp.AnyPlutusCertifyingScriptWitness sw
-    SimpleReferenceScript (SimpleRefScriptArgs refTxIn NoPolicyId) ->
-      return . Exp.AnySimpleScriptWitness $ Exp.SReferenceScript refTxIn
-    PlutusReferenceScript
-      ( PlutusRefScriptCliArgs
-          refInput
-          (AnySLanguage lang)
-          Exp.NoScriptDatumAllowed
-          NoPolicyId
-          redeemerFile
-          execUnits
-        ) -> do
-        redeemer <-
-          fromExceptTCli $
-            readScriptDataOrFile redeemerFile
-        return $
-          Exp.AnyPlutusScriptWitness $
-            Exp.AnyPlutusCertifyingScriptWitness $
-              Exp.PlutusScriptWitness
-                lang
-                (Exp.PReferenceScript refInput)
-                Exp.NoScriptDatum
-                redeemer
-                execUnits
+    AnyNonAssetScriptSimple simpleReq ->
+      case simpleReq of
+        OnDiskSimpleScript scriptFp -> do
+          let sFp = unFile scriptFp
+          ss <- readFileSimpleScript sFp
+          let serialisedSS = serialiseToCBOR ss
+          simpleScript <-
+            fromEitherCli
+              ( shelleyBasedEraConstraints sbe (Exp.deserialiseSimpleScript serialisedSS)
+                  :: Either DecoderError (Exp.SimpleScript (ShelleyLedgerEra era))
+              )
+          return $ Exp.AnySimpleScriptWitness $ Exp.SScript simpleScript
+        ReferenceSimpleScript refTxIn ->
+          return . Exp.AnySimpleScriptWitness $ Exp.SReferenceScript refTxIn
+    AnyNonAssetScriptPlutus plutusReq ->
+      case plutusReq of
+        OnDiskPlutusNonAssetScript scriptFp redeemerFile execUnits -> do
+          let plutusScriptFp = unFile scriptFp
+          Exp.Plutus.AnyPlutusScript anyPlutusScript <- readFilePlutusScript sbe plutusScriptFp
+          let lang = Exp.Plutus.plutusScriptInEraSLanguage anyPlutusScript
+              script' = Exp.PScript anyPlutusScript
+          redeemer <-
+            fromExceptTCli $
+              readScriptDataOrFile redeemerFile
+          let sw =
+                Exp.PlutusScriptWitness
+                  lang
+                  script'
+                  Exp.NoScriptDatum
+                  redeemer
+                  execUnits
+          return $ Exp.AnyPlutusScriptWitness $ Exp.AnyPlutusCertifyingScriptWitness sw
+        ReferencePlutusNonAssetScript refInput (AnySLanguage lang) redeemerFile execUnits -> do
+          redeemer <-
+            fromExceptTCli $
+              readScriptDataOrFile redeemerFile
+          return $
+            Exp.AnyPlutusScriptWitness $
+              Exp.AnyPlutusCertifyingScriptWitness $
+                Exp.PlutusScriptWitness
+                  lang
+                  (Exp.PReferenceScript refInput)
+                  Exp.NoScriptDatum
+                  redeemer
+                  execUnits

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -21,7 +21,7 @@ import Cardano.CLI.EraBased.Script.Mint.Type
 import Cardano.CLI.EraBased.Script.Proposal.Type qualified as Proposing
 import Cardano.CLI.EraBased.Script.Spend.Type qualified as PlutusSpend
 import Cardano.CLI.EraBased.Script.Type
-import Cardano.CLI.EraBased.Script.Type qualified as PlutusSpend
+import Cardano.CLI.EraBased.Script.Type qualified as ScriptT
 import Cardano.CLI.EraBased.Script.Vote.Type qualified as Voting
 import Cardano.CLI.EraBased.Script.Withdrawal.Type qualified as Withdrawal
 import Cardano.CLI.EraBased.Transaction.Command (IncludeCurrentTreasuryValue (..))
@@ -961,7 +961,7 @@ pSimpleScriptOrPlutusSpendingScriptWitness
   -- ^ Potential deprecated script flag prefix
   -> String
   -- ^ Help text
-  -> Parser (ScriptRequirements TxInItem)
+  -> Parser AnySpendScript
 pSimpleScriptOrPlutusSpendingScriptWitness autoBalanceExecUnits scriptFlagPrefix scriptFlagPrefixDeprecated help =
   PlutusSpend.createSimpleOrPlutusScriptFromCliArgs
     <$> pScriptFor
@@ -996,13 +996,13 @@ pScriptRedeemerOrFile scriptFlagPrefix =
     "The script redeemer file."
 
 pScriptDatumOrFileSpendingCip69
-  :: String -> Parser PlutusSpend.ScriptDatumOrFileSpending
+  :: String -> Parser ScriptDatumOrFileSpending
 pScriptDatumOrFileSpendingCip69 scriptFlagPrefix =
   datumOptional
  where
   datumOptional =
     asum
-      [ PlutusSpend.PotentialDatum
+      [ ScriptT.PotentialDatum
           <$> optional datumParser
       , pInlineDatumPresent
       ]
@@ -1013,9 +1013,9 @@ pScriptDatumOrFileSpendingCip69 scriptFlagPrefix =
       "The script datum."
       "The script datum file."
 
-  pInlineDatumPresent :: Parser PlutusSpend.ScriptDatumOrFileSpending
+  pInlineDatumPresent :: Parser ScriptDatumOrFileSpending
   pInlineDatumPresent =
-    flag' PlutusSpend.InlineDatum $
+    flag' ScriptT.InlineDatum $
       mconcat
         [ long (scriptFlagPrefix ++ "-inline-datum-present")
         , Opt.help "Inline datum present at transaction input."
@@ -1086,19 +1086,19 @@ pScriptDataOrFile dataFlagPrefix helpTextForValue helpTextForFile =
 
 pVoteFiles
   :: BalanceTxExecUnits
-  -> Parser [(VoteFile In, Maybe (ScriptRequirements VoterItem))]
+  -> Parser [(VoteFile In, Maybe AnyNonAssetScript)]
 pVoteFiles bExUnits = many $ pVoteFile bExUnits
 
 pVoteFile
   :: BalanceTxExecUnits
-  -> Parser (VoteFile In, Maybe (ScriptRequirements VoterItem))
+  -> Parser (VoteFile In, Maybe AnyNonAssetScript)
 pVoteFile balExUnits =
   (,)
     <$> pFileInDirection "vote-file" "Filepath of the vote."
     <*> optional (pVoteScriptOrReferenceScriptWitness balExUnits)
  where
   pVoteScriptOrReferenceScriptWitness
-    :: BalanceTxExecUnits -> Parser (ScriptRequirements VoterItem)
+    :: BalanceTxExecUnits -> Parser AnyNonAssetScript
   pVoteScriptOrReferenceScriptWitness bExUnits =
     pVoteScriptWitness
       bExUnits
@@ -1112,7 +1112,7 @@ pVoteScriptWitness
   -> String
   -> Maybe String
   -> String
-  -> Parser (ScriptRequirements VoterItem)
+  -> Parser AnyNonAssetScript
 pVoteScriptWitness bExecUnits scriptFlagPrefix scriptFlagPrefixDeprecated help =
   Voting.createSimpleOrPlutusScriptFromCliArgs
     <$> pScriptFor
@@ -1129,7 +1129,7 @@ pVoteScriptWitness bExecUnits scriptFlagPrefix scriptFlagPrefixDeprecated help =
       )
 
 pVoteReferencePlutusScriptWitness
-  :: String -> BalanceTxExecUnits -> Parser (ScriptRequirements VoterItem)
+  :: String -> BalanceTxExecUnits -> Parser AnyNonAssetScript
 pVoteReferencePlutusScriptWitness prefix autoBalanceExecUnits =
   let appendedPrefix = prefix ++ "-"
    in Voting.createPlutusReferenceScriptFromCliArgs
@@ -1143,20 +1143,20 @@ pVoteReferencePlutusScriptWitness prefix autoBalanceExecUnits =
 
 pProposalFiles
   :: BalanceTxExecUnits
-  -> Parser [(ProposalFile In, Maybe (ScriptRequirements ProposalItem))]
+  -> Parser [(ProposalFile In, Maybe AnyNonAssetScript)]
 pProposalFiles balExUnits =
   many (pProposalFile balExUnits)
 
 pProposalFile
   :: BalanceTxExecUnits
-  -> Parser (ProposalFile In, Maybe (ScriptRequirements ProposalItem))
+  -> Parser (ProposalFile In, Maybe AnyNonAssetScript)
 pProposalFile balExUnits =
   (,)
     <$> pFileInDirection "proposal-file" "Filepath of the proposal."
     <*> optional (pProposingScriptOrReferenceScriptWitness balExUnits)
  where
   pProposingScriptOrReferenceScriptWitness
-    :: BalanceTxExecUnits -> Parser (ScriptRequirements ProposalItem)
+    :: BalanceTxExecUnits -> Parser AnyNonAssetScript
   pProposingScriptOrReferenceScriptWitness bExUnits =
     pProposalScriptWitness
       bExUnits
@@ -1170,7 +1170,7 @@ pProposalScriptWitness
   -> String
   -> Maybe String
   -> String
-  -> Parser (ScriptRequirements ProposalItem)
+  -> Parser AnyNonAssetScript
 pProposalScriptWitness bExecUnits scriptFlagPrefix scriptFlagPrefixDeprecated help =
   Proposing.createSimpleOrPlutusScriptFromCliArgs
     <$> pScriptFor
@@ -1187,7 +1187,7 @@ pProposalScriptWitness bExecUnits scriptFlagPrefix scriptFlagPrefixDeprecated he
       )
 
 pProposalReferencePlutusScriptWitness
-  :: String -> BalanceTxExecUnits -> Parser (ScriptRequirements ProposalItem)
+  :: String -> BalanceTxExecUnits -> Parser AnyNonAssetScript
 pProposalReferencePlutusScriptWitness prefix autoBalanceExecUnits =
   let appendedPrefix = prefix ++ "-"
    in Proposing.createPlutusReferenceScriptFromCliArgs
@@ -1350,7 +1350,7 @@ pTxBuildOutputOptions =
 
 pCertificateFile
   :: BalanceTxExecUnits
-  -> Parser (CertificateFile, Maybe (ScriptRequirements CertItem))
+  -> Parser (CertificateFile, Maybe AnyNonAssetScript)
 pCertificateFile balanceExecUnits =
   (,)
     <$> ( fmap CertificateFile $
@@ -1362,7 +1362,7 @@ pCertificateFile balanceExecUnits =
     <*> optional (pCertifyingScriptOrReferenceScriptWit balanceExecUnits)
  where
   pCertifyingScriptOrReferenceScriptWit
-    :: BalanceTxExecUnits -> Parser (ScriptRequirements CertItem)
+    :: BalanceTxExecUnits -> Parser AnyNonAssetScript
   pCertifyingScriptOrReferenceScriptWit bExecUnits =
     pCertificatePlutusScriptWitness
       balanceExecUnits
@@ -1379,7 +1379,7 @@ pCertificateFile balanceExecUnits =
       ]
 
 pCertificatePlutusScriptWitness
-  :: BalanceTxExecUnits -> String -> Maybe String -> String -> Parser (ScriptRequirements CertItem)
+  :: BalanceTxExecUnits -> String -> Maybe String -> String -> Parser AnyNonAssetScript
 pCertificatePlutusScriptWitness bExecUnits scriptFlagPrefix scriptFlagPrefixDeprecated help =
   Certifying.createSimpleOrPlutusScriptFromCliArgs
     <$> pScriptFor
@@ -1396,7 +1396,7 @@ pCertificatePlutusScriptWitness bExecUnits scriptFlagPrefix scriptFlagPrefixDepr
       )
 
 pCertificateReferencePlutusScriptWitness
-  :: String -> BalanceTxExecUnits -> Parser (ScriptRequirements CertItem)
+  :: String -> BalanceTxExecUnits -> Parser AnyNonAssetScript
 pCertificateReferencePlutusScriptWitness prefix autoBalanceExecUnits =
   let appendedPrefix = prefix ++ "-"
    in Certifying.createPlutusReferenceScriptFromCliArgs
@@ -1466,7 +1466,7 @@ pWithdrawal
   -> Parser
        ( StakeAddress
        , Lovelace
-       , Maybe (ScriptRequirements WithdrawalItem)
+       , Maybe AnyNonAssetScript
        )
 pWithdrawal balance =
   (\(stakeAddr, lovelace) maybeScriptFp -> (stakeAddr, lovelace, maybeScriptFp))
@@ -1478,7 +1478,7 @@ pWithdrawal balance =
       )
     <*> optional pWithdrawalScriptOrReferenceScriptWit
  where
-  pWithdrawalScriptOrReferenceScriptWit :: Parser (ScriptRequirements WithdrawalItem)
+  pWithdrawalScriptOrReferenceScriptWit :: Parser AnyNonAssetScript
   pWithdrawalScriptOrReferenceScriptWit =
     pWithdrawalScriptWitness
       balance
@@ -1504,7 +1504,7 @@ pWithdrawalScriptWitness
   -> String
   -> Maybe String
   -> String
-  -> Parser (ScriptRequirements WithdrawalItem)
+  -> Parser AnyNonAssetScript
 pWithdrawalScriptWitness bExecUnits scriptFlagPrefix scriptFlagPrefixDeprecated help =
   Withdrawal.createSimpleOrPlutusScriptFromCliArgs
     <$> pScriptFor
@@ -1521,7 +1521,7 @@ pWithdrawalScriptWitness bExecUnits scriptFlagPrefix scriptFlagPrefixDeprecated 
       )
 
 pWithdrawalReferencePlutusScriptWitness
-  :: String -> BalanceTxExecUnits -> Parser (ScriptRequirements WithdrawalItem)
+  :: String -> BalanceTxExecUnits -> Parser AnyNonAssetScript
 pWithdrawalReferencePlutusScriptWitness prefix autoBalanceExecUnits =
   let appendedPrefix = prefix ++ "-"
    in Withdrawal.createPlutusReferenceScriptFromCliArgs
@@ -1972,7 +1972,7 @@ pTxSubmitFile = parseFilePath "tx-file" "Filepath of the transaction you intend 
 
 pTxIn
   :: BalanceTxExecUnits
-  -> Parser (TxIn, Maybe (ScriptRequirements TxInItem))
+  -> Parser (TxIn, Maybe AnySpendScript)
 pTxIn balance =
   (,)
     <$> Opt.option
@@ -1987,13 +1987,13 @@ pTxIn balance =
           <|> pOnDiskSimpleOrPlutusScriptWitness
       )
  where
-  pSimpleReferenceSpendingScriptWitess :: Parser (ScriptRequirements TxInItem)
+  pSimpleReferenceSpendingScriptWitess :: Parser AnySpendScript
   pSimpleReferenceSpendingScriptWitess =
     PlutusSpend.createSimpleReferenceScriptFromCliArgs
       <$> pReferenceTxIn "simple-script-" "simple"
 
   pPlutusReferenceSpendScriptWitness
-    :: BalanceTxExecUnits -> Parser (ScriptRequirements TxInItem)
+    :: BalanceTxExecUnits -> Parser AnySpendScript
   pPlutusReferenceSpendScriptWitness autoBalanceExecUnits =
     PlutusSpend.createPlutusReferenceScriptFromCliArgs
       <$> pReferenceTxIn "spending-" "plutus"
@@ -2005,7 +2005,7 @@ pTxIn balance =
               ManualBalance -> pExecutionUnits "spending-reference-tx-in"
           )
 
-  pOnDiskSimpleOrPlutusScriptWitness :: Parser (ScriptRequirements TxInItem)
+  pOnDiskSimpleOrPlutusScriptWitness :: Parser AnySpendScript
   pOnDiskSimpleOrPlutusScriptWitness =
     pSimpleScriptOrPlutusSpendingScriptWitness
       balance
@@ -2174,7 +2174,7 @@ pMintMultiAsset
   :: forall era
    . IsEra era
   => BalanceTxExecUnits
-  -> Parser (Maybe (L.MultiAsset, [ScriptRequirements MintItem]))
+  -> Parser (Maybe (L.MultiAsset, [AnyMintScript]))
 pMintMultiAsset balanceExecUnits =
   let mintAssets =
         Opt.option
@@ -2192,20 +2192,20 @@ pMintMultiAsset balanceExecUnits =
           )
    in Just <$> ((,) <$> mintAssets <*> mintWitnesses)
  where
-  pMintingScript :: Parser (ScriptRequirements MintItem)
+  pMintingScript :: Parser AnyMintScript
   pMintingScript =
     createSimpleOrPlutusScriptFromCliArgs
       <$> pMintScriptFile
       <*> optional (pPlutusMintScriptWitnessData WitCtxMint balanceExecUnits)
 
-  pSimpleReferenceMintingScriptWitness :: Parser (ScriptRequirements MintItem)
+  pSimpleReferenceMintingScriptWitness :: Parser AnyMintScript
   pSimpleReferenceMintingScriptWitness =
     createSimpleReferenceScriptFromCliArgs
       <$> pReferenceTxIn "simple-minting-script-" "simple"
       <*> pPolicyId
 
   pPlutusMintReferenceScriptWitnessFiles
-    :: BalanceTxExecUnits -> Parser (ScriptRequirements MintItem)
+    :: BalanceTxExecUnits -> Parser AnyMintScript
   pPlutusMintReferenceScriptWitnessFiles autoBalanceExecUnits =
     createPlutusReferenceScriptFromCliArgs
       <$> pReferenceTxIn "mint-" "plutus"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Read.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -13,7 +12,6 @@ where
 
 import Cardano.Api (File (..))
 import Cardano.Api.Experimental
-import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Experimental.AnyScriptWitness
 import Cardano.Api.Experimental.Plutus qualified as Exp.Plutus
 
@@ -27,66 +25,57 @@ import Cardano.CLI.Type.Common (AnySLanguage (..), CertificateFile)
 readCertificateScriptWitness
   :: forall era e
    . IsEra era
-  => ScriptRequirements Exp.CertItem
+  => AnyNonAssetScript
   -> CIO e (AnyWitness (LedgerEra era))
-readCertificateScriptWitness (OnDiskSimpleScript scriptFp) = do
-  let sFp = unFile scriptFp
-  AnySimpleScriptWitness . SScript <$> readFileSimpleScript sFp useEra
-readCertificateScriptWitness
-  ( OnDiskPlutusScript
-      (OnDiskPlutusScriptCliArgs scriptFp Exp.NoScriptDatumAllowed redeemerFile execUnits)
-    ) = do
-    let plutusScriptFp = unFile scriptFp
-    Exp.Plutus.AnyPlutusScript script <-
-      readFilePlutusScript @_ @era plutusScriptFp
+readCertificateScriptWitness (AnyNonAssetScriptSimple simpleReq) =
+  case simpleReq of
+    OnDiskSimpleScript scriptFp -> do
+      let sFp = unFile scriptFp
+      AnySimpleScriptWitness . SScript <$> readFileSimpleScript sFp useEra
+    ReferenceSimpleScript refTxin ->
+      return . AnySimpleScriptWitness $ SReferenceScript refTxin
+readCertificateScriptWitness (AnyNonAssetScriptPlutus plutusReq) =
+  case plutusReq of
+    OnDiskPlutusNonAssetScript scriptFp redeemerFile execUnits -> do
+      let plutusScriptFp = unFile scriptFp
+      Exp.Plutus.AnyPlutusScript script <-
+        readFilePlutusScript @_ @era plutusScriptFp
 
-    let
-      lang = Exp.Plutus.plutusScriptInEraSLanguage script
-      script' = PScript script
+      let
+        lang = Exp.Plutus.plutusScriptInEraSLanguage script
+        script' = PScript script
 
-    redeemer <-
-      fromExceptTCli $
-        readScriptDataOrFile redeemerFile
+      redeemer <-
+        fromExceptTCli $
+          readScriptDataOrFile redeemerFile
 
-    let sw =
-          PlutusScriptWitness
-            lang
-            script'
-            NoScriptDatum
-            redeemer
-            execUnits
-    return $
-      AnyPlutusScriptWitness $
-        AnyPlutusCertifyingScriptWitness sw
-readCertificateScriptWitness
-  ( PlutusReferenceScript
-      ( PlutusRefScriptCliArgs
-          refInput
-          (AnySLanguage lang)
-          Exp.NoScriptDatumAllowed
-          NoPolicyId
-          redeemerFile
-          execUnits
-        )
-    ) = do
-    redeemer <-
-      fromExceptTCli $
-        readScriptDataOrFile redeemerFile
-    return $
-      AnyPlutusScriptWitness $
-        AnyPlutusCertifyingScriptWitness $
-          PlutusScriptWitness
-            lang
-            (PReferenceScript refInput)
-            NoScriptDatum
-            redeemer
-            execUnits
-readCertificateScriptWitness (SimpleReferenceScript (SimpleRefScriptArgs refTxin NoPolicyId)) =
-  return . AnySimpleScriptWitness $ SReferenceScript refTxin
+      let sw =
+            PlutusScriptWitness
+              lang
+              script'
+              NoScriptDatum
+              redeemer
+              execUnits
+      return $
+        AnyPlutusScriptWitness $
+          AnyPlutusCertifyingScriptWitness sw
+    ReferencePlutusNonAssetScript refInput (AnySLanguage lang) redeemerFile execUnits -> do
+      redeemer <-
+        fromExceptTCli $
+          readScriptDataOrFile redeemerFile
+      return $
+        AnyPlutusScriptWitness $
+          AnyPlutusCertifyingScriptWitness $
+            PlutusScriptWitness
+              lang
+              (PReferenceScript refInput)
+              NoScriptDatum
+              redeemer
+              execUnits
 
 readCertificateScriptWitnesses
   :: IsEra era
-  => [(CertificateFile, Maybe (ScriptRequirements Exp.CertItem))]
+  => [(CertificateFile, Maybe AnyNonAssetScript)]
   -> CIO e [(CertificateFile, AnyWitness (LedgerEra era))]
 readCertificateScriptWitnesses =
   mapM

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Type.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Type.hs
@@ -1,18 +1,13 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
 
 module Cardano.CLI.EraBased.Script.Certificate.Type
   ( CertificateScriptWitness (..)
-  , PlutusRefScriptCliArgs (..)
   , createSimpleOrPlutusScriptFromCliArgs
   , createPlutusReferenceScriptFromCliArgs
   )
 where
 
 import Cardano.Api
-import Cardano.Api.Experimental
 
 import Cardano.CLI.EraBased.Script.Type
 import Cardano.CLI.Type.Common (AnySLanguage (..), ScriptDataOrFile)
@@ -24,18 +19,17 @@ newtype CertificateScriptWitness era
 createSimpleOrPlutusScriptFromCliArgs
   :: File ScriptInAnyLang In
   -> Maybe (ScriptDataOrFile, ExecutionUnits)
-  -> ScriptRequirements CertItem
+  -> AnyNonAssetScript
 createSimpleOrPlutusScriptFromCliArgs scriptFp (Just (redeemer, execUnits)) =
-  OnDiskPlutusScript $ OnDiskPlutusScriptCliArgs scriptFp NoScriptDatumAllowed redeemer execUnits
+  AnyNonAssetScriptPlutus $ OnDiskPlutusNonAssetScript scriptFp redeemer execUnits
 createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing =
-  OnDiskSimpleScript scriptFp
+  AnyNonAssetScriptSimple $ OnDiskSimpleScript scriptFp
 
 createPlutusReferenceScriptFromCliArgs
   :: TxIn
   -> AnySLanguage
   -> ScriptDataOrFile
   -> ExecutionUnits
-  -> ScriptRequirements CertItem
+  -> AnyNonAssetScript
 createPlutusReferenceScriptFromCliArgs txIn l redeemer execUnits =
-  PlutusReferenceScript $
-    PlutusRefScriptCliArgs txIn l NoScriptDatumAllowed NoPolicyId redeemer execUnits
+  AnyNonAssetScriptPlutus $ ReferencePlutusNonAssetScript txIn l redeemer execUnits

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -14,7 +13,6 @@ import Cardano.Api hiding (AnyScriptWitness)
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Experimental.AnyScriptWitness
 import Cardano.Api.Experimental.Plutus qualified as Exp.Plutus
-import Cardano.Api.Experimental.Plutus qualified as L
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Compatible.Exception
@@ -27,65 +25,52 @@ import Cardano.Ledger.Core qualified as L
 readMintScriptWitness
   :: forall era e
    . Exp.IsEra era
-  => ScriptRequirements Exp.MintItem -> CIO e (PolicyId, AnyScriptWitness (Exp.LedgerEra era))
-readMintScriptWitness (OnDiskSimpleScript scriptFp) = do
+  => AnyMintScript -> CIO e (PolicyId, AnyScriptWitness (Exp.LedgerEra era))
+readMintScriptWitness (AnyMintScriptSimpleOnDisk scriptFp) = do
   let sFp = unFile scriptFp
   s <- readFileSimpleScript sFp (Exp.useEra @era)
   let sHash :: L.ScriptHash =
         Exp.hashSimpleScript (s :: Exp.SimpleScript (Exp.LedgerEra era))
   return (fromMaryPolicyID $ L.PolicyID sHash, AnyScriptWitnessSimple $ Exp.SScript s)
-readMintScriptWitness
-  ( OnDiskPlutusScript
-      (OnDiskPlutusScriptCliArgs scriptFp Exp.NoScriptDatumAllowed redeemerFile execUnits)
-    ) = do
-    let plutusScriptFp = unFile scriptFp
-    Exp.Plutus.AnyPlutusScript script <-
-      readFilePlutusScript @_ @era plutusScriptFp
-    let polId = fromMaryPolicyID . L.PolicyID $ L.hashPlutusScriptInEra script
-    redeemer <-
-      fromExceptTCli $
-        readScriptDataOrFile redeemerFile
-
-    let pScript = Exp.PScript script
-        lang = Exp.Plutus.plutusScriptInEraSLanguage script
-    let sw =
-          Exp.PlutusScriptWitness
-            lang
-            pScript
-            Exp.NoScriptDatum
-            redeemer
-            execUnits
-    return
-      ( polId
-      , AnyScriptWitnessPlutus $
-          AnyPlutusMintingScriptWitness sw
-      )
-readMintScriptWitness
-  ( PlutusReferenceScript
-      ( PlutusRefScriptCliArgs
-          refTxIn
-          (AnySLanguage lang)
-          Exp.NoScriptDatumAllowed
-          polId
-          redeemerFile
-          execUnits
-        )
-    ) = do
-    redeemer <-
-      fromExceptTCli $ readScriptDataOrFile redeemerFile
-
-    let sw =
-          Exp.PlutusScriptWitness
-            lang
-            (Exp.PReferenceScript refTxIn)
-            Exp.NoScriptDatum
-            redeemer
-            execUnits
-    return
-      ( polId
-      , AnyScriptWitnessPlutus $
-          AnyPlutusMintingScriptWitness
-            sw
-      )
-readMintScriptWitness (SimpleReferenceScript (SimpleRefScriptArgs refTxIn polId)) =
+readMintScriptWitness (AnyMintScriptSimpleRef refTxIn polId) =
   return (polId, AnyScriptWitnessSimple $ Exp.SReferenceScript refTxIn)
+readMintScriptWitness (AnyMintScriptPlutus plutusReq) =
+  case plutusReq of
+    OnDiskPlutusMintingScript scriptFp redeemerFile execUnits -> do
+      let plutusScriptFp = unFile scriptFp
+      Exp.Plutus.AnyPlutusScript script <-
+        readFilePlutusScript @_ @era plutusScriptFp
+      let polId = fromMaryPolicyID . L.PolicyID $ Exp.Plutus.hashPlutusScriptInEra script
+      redeemer <-
+        fromExceptTCli $
+          readScriptDataOrFile redeemerFile
+      let pScript = Exp.Plutus.PScript script
+          lang = Exp.Plutus.plutusScriptInEraSLanguage script
+          sw =
+            Exp.Plutus.PlutusScriptWitness
+              lang
+              pScript
+              Exp.Plutus.NoScriptDatum
+              redeemer
+              execUnits
+      return
+        ( polId
+        , AnyScriptWitnessPlutus $
+            AnyPlutusMintingScriptWitness sw
+        )
+    ReferencePlutusMintingScript refTxIn (AnySLanguage lang) polId redeemerFile execUnits -> do
+      redeemer <-
+        fromExceptTCli $ readScriptDataOrFile redeemerFile
+      let sw =
+            Exp.Plutus.PlutusScriptWitness
+              lang
+              (Exp.Plutus.PReferenceScript refTxIn)
+              Exp.Plutus.NoScriptDatum
+              redeemer
+              execUnits
+      return
+        ( polId
+        , AnyScriptWitnessPlutus $
+            AnyPlutusMintingScriptWitness
+              sw
+        )

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Type.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Type.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.EraBased.Script.Mint.Type
   ( createSimpleOrPlutusScriptFromCliArgs
@@ -12,8 +9,6 @@ module Cardano.CLI.EraBased.Script.Mint.Type
 where
 
 import Cardano.Api
-import Cardano.Api.Experimental
-import Cardano.Api.Experimental qualified as Exp
 
 import Cardano.CLI.EraBased.Script.Type
 import Cardano.CLI.Type.Common (AnySLanguage (..), ScriptDataOrFile)
@@ -31,19 +26,18 @@ data MintScriptWitnessWithPolicyId era
 createSimpleOrPlutusScriptFromCliArgs
   :: File ScriptInAnyLang In
   -> Maybe (ScriptDataOrFile, ExecutionUnits)
-  -> ScriptRequirements MintItem
+  -> AnyMintScript
 createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing =
-  OnDiskSimpleScript scriptFp
+  AnyMintScriptSimpleOnDisk scriptFp
 createSimpleOrPlutusScriptFromCliArgs scriptFp (Just (redeemerFile, execUnits)) =
-  OnDiskPlutusScript $
-    OnDiskPlutusScriptCliArgs scriptFp Exp.NoScriptDatumAllowed redeemerFile execUnits
+  AnyMintScriptPlutus $ OnDiskPlutusMintingScript scriptFp redeemerFile execUnits
 
 createSimpleReferenceScriptFromCliArgs
   :: TxIn
   -> PolicyId
-  -> ScriptRequirements MintItem
-createSimpleReferenceScriptFromCliArgs txin polid =
-  SimpleReferenceScript $ SimpleRefScriptArgs txin polid
+  -> AnyMintScript
+createSimpleReferenceScriptFromCliArgs txin polId =
+  AnyMintScriptSimpleRef txin polId
 
 createPlutusReferenceScriptFromCliArgs
   :: TxIn
@@ -51,7 +45,7 @@ createPlutusReferenceScriptFromCliArgs
   -> ScriptDataOrFile
   -> ExecutionUnits
   -> PolicyId
-  -> ScriptRequirements MintItem
-createPlutusReferenceScriptFromCliArgs txin scriptVersion scriptData execUnits polid =
-  PlutusReferenceScript $
-    PlutusRefScriptCliArgs txin scriptVersion Exp.NoScriptDatumAllowed polid scriptData execUnits
+  -> AnyMintScript
+createPlutusReferenceScriptFromCliArgs txin scriptVersion scriptData execUnits polId =
+  AnyMintScriptPlutus $
+    ReferencePlutusMintingScript txin scriptVersion polId scriptData execUnits

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Proposal/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Proposal/Read.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -20,7 +19,6 @@ import Cardano.Api.Experimental.AnyScriptWitness
 import Cardano.Api.Experimental.Plutus qualified as Exp.Plutus
 
 import Cardano.CLI.Compatible.Exception
-import Cardano.CLI.EraBased.Script.Proposal.Type
 import Cardano.CLI.EraBased.Script.Read.Common
 import Cardano.CLI.EraBased.Script.Type
 import Cardano.CLI.Read
@@ -29,7 +27,7 @@ import Cardano.CLI.Type.Common
 readProposalScriptWitness
   :: forall e era
    . Exp.IsEra era
-  => (ProposalFile In, Maybe (ScriptRequirements Exp.ProposalItem))
+  => (ProposalFile In, Maybe AnyNonAssetScript)
   -> CIO e (Proposal era, Exp.AnyWitness (Exp.LedgerEra era))
 readProposalScriptWitness (propFp, Nothing) = do
   proposal <-
@@ -44,69 +42,60 @@ readProposalScriptWitness (propFp, Just certScriptReq) =
         fromEitherIOCli @(FileError TextEnvelopeError) $
           readFileTextEnvelope propFp
     case certScriptReq of
-      OnDiskSimpleScript scriptFp -> do
-        let sFp = unFile scriptFp
-        s <-
-          Exp.AnySimpleScriptWitness . Exp.SScript <$> readFileSimpleScript sFp (Exp.useEra @era)
+      AnyNonAssetScriptSimple simpleReq ->
+        case simpleReq of
+          OnDiskSimpleScript scriptFp -> do
+            let sFp = unFile scriptFp
+            s <-
+              Exp.AnySimpleScriptWitness . Exp.SScript <$> readFileSimpleScript sFp (Exp.useEra @era)
+            return (proposal, s)
+          ReferenceSimpleScript refTxIn ->
+            return
+              ( proposal
+              , Exp.AnySimpleScriptWitness $ Exp.SReferenceScript refTxIn
+              )
+      AnyNonAssetScriptPlutus plutusReq ->
+        case plutusReq of
+          OnDiskPlutusNonAssetScript scriptFp redeemerFile execUnits -> do
+            let plutusScriptFp = unFile scriptFp
+            Exp.Plutus.AnyPlutusScript plutusScript <-
+              readFilePlutusScript @_ @era plutusScriptFp
+            let lang = Exp.Plutus.plutusScriptInEraSLanguage plutusScript
+            redeemer <-
+              fromExceptTCli $
+                readScriptDataOrFile redeemerFile
 
-        return
-          ( proposal
-          , s
-          )
-      OnDiskPlutusScript
-        (OnDiskPlutusScriptCliArgs scriptFp Exp.NoScriptDatumAllowed redeemerFile execUnits) -> do
-          let plutusScriptFp = unFile scriptFp
-          Exp.Plutus.AnyPlutusScript plutusScript <-
-            readFilePlutusScript @_ @era plutusScriptFp
-          let lang = Exp.Plutus.plutusScriptInEraSLanguage plutusScript
-          redeemer <-
-            fromExceptTCli $
-              readScriptDataOrFile redeemerFile
+            let pScript = Exp.Plutus.PScript plutusScript
+                sw =
+                  Exp.Plutus.PlutusScriptWitness
+                    lang
+                    pScript
+                    Exp.Plutus.NoScriptDatum
+                    redeemer
+                    execUnits
+            return
+              ( proposal
+              , Exp.AnyPlutusScriptWitness $
+                  AnyPlutusProposingScriptWitness sw
+              )
+          ReferencePlutusNonAssetScript refTxIn (AnySLanguage lang) redeemerFile execUnits -> do
+            let pScript = Exp.Plutus.PReferenceScript refTxIn
+            redeemer <-
+              fromExceptTCli $
+                readScriptDataOrFile redeemerFile
 
-          let pScript = Exp.PScript plutusScript
-              sw =
-                Exp.PlutusScriptWitness
-                  lang
-                  pScript
-                  Exp.NoScriptDatum
-                  redeemer
-                  execUnits
-          return
-            ( proposal
-            , Exp.AnyPlutusScriptWitness $
-                AnyPlutusProposingScriptWitness sw
-            )
-      SimpleReferenceScript (SimpleRefScriptArgs refTxIn NoPolicyId) ->
-        return
-          ( proposal
-          , Exp.AnySimpleScriptWitness $ Exp.SReferenceScript refTxIn
-          )
-      PlutusReferenceScript
-        ( PlutusRefScriptCliArgs
-            refTxIn
-            (AnySLanguage lang)
-            Exp.NoScriptDatumAllowed
-            NoPolicyId
-            redeemerFile
-            execUnits
-          ) -> do
-          let pScript = Exp.PReferenceScript refTxIn
-          redeemer <-
-            fromExceptTCli $
-              readScriptDataOrFile redeemerFile
-
-          return
-            ( proposal
-            , Exp.AnyPlutusScriptWitness $
-                AnyPlutusProposingScriptWitness
-                  ( Exp.PlutusScriptWitness
-                      lang
-                      pScript
-                      Exp.NoScriptDatum
-                      redeemer
-                      execUnits
-                  )
-            )
+            return
+              ( proposal
+              , Exp.AnyPlutusScriptWitness $
+                  AnyPlutusProposingScriptWitness
+                    ( Exp.Plutus.PlutusScriptWitness
+                        lang
+                        pScript
+                        Exp.Plutus.NoScriptDatum
+                        redeemer
+                        execUnits
+                    )
+              )
 
 newtype ProposalError
   = ProposalErrorFile (FileError CliScriptWitnessError)
@@ -117,13 +106,13 @@ instance Error ProposalError where
 
 readProposal
   :: Exp.IsEra era
-  => (ProposalFile In, Maybe (ScriptRequirements Exp.ProposalItem))
+  => (ProposalFile In, Maybe AnyNonAssetScript)
   -> CIO e (Proposal era, Exp.AnyWitness (Exp.LedgerEra era))
 readProposal (fp, mScriptWit) = do
   readProposalScriptWitness (fp, mScriptWit)
 
 readTxGovernanceActions
   :: Exp.IsEra era
-  => [(ProposalFile In, Maybe (ScriptRequirements Exp.ProposalItem))]
+  => [(ProposalFile In, Maybe AnyNonAssetScript)]
   -> CIO e [(Proposal era, Exp.AnyWitness (Exp.LedgerEra era))]
 readTxGovernanceActions = mapM readProposal

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Proposal/Type.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Proposal/Type.hs
@@ -1,17 +1,12 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
 
 module Cardano.CLI.EraBased.Script.Proposal.Type
-  ( PlutusRefScriptCliArgs (..)
-  , createSimpleOrPlutusScriptFromCliArgs
+  ( createSimpleOrPlutusScriptFromCliArgs
   , createPlutusReferenceScriptFromCliArgs
   )
 where
 
 import Cardano.Api
-import Cardano.Api.Experimental
-import Cardano.Api.Experimental qualified as Exp
 
 import Cardano.CLI.EraBased.Script.Type
 import Cardano.CLI.Type.Common (AnySLanguage (..), ScriptDataOrFile)
@@ -19,18 +14,17 @@ import Cardano.CLI.Type.Common (AnySLanguage (..), ScriptDataOrFile)
 createSimpleOrPlutusScriptFromCliArgs
   :: File ScriptInAnyLang In
   -> Maybe (ScriptDataOrFile, ExecutionUnits)
-  -> ScriptRequirements ProposalItem
+  -> AnyNonAssetScript
 createSimpleOrPlutusScriptFromCliArgs scriptFp (Just (redeemer, execUnits)) =
-  OnDiskPlutusScript $ OnDiskPlutusScriptCliArgs scriptFp Exp.NoScriptDatumAllowed redeemer execUnits
+  AnyNonAssetScriptPlutus $ OnDiskPlutusNonAssetScript scriptFp redeemer execUnits
 createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing =
-  OnDiskSimpleScript scriptFp
+  AnyNonAssetScriptSimple $ OnDiskSimpleScript scriptFp
 
 createPlutusReferenceScriptFromCliArgs
   :: TxIn
   -> AnySLanguage
   -> ScriptDataOrFile
   -> ExecutionUnits
-  -> ScriptRequirements ProposalItem
+  -> AnyNonAssetScript
 createPlutusReferenceScriptFromCliArgs txIn anySLang redeemer execUnits =
-  PlutusReferenceScript $
-    PlutusRefScriptCliArgs txIn anySLang Exp.NoScriptDatumAllowed NoPolicyId redeemer execUnits
+  AnyNonAssetScriptPlutus $ ReferencePlutusNonAssetScript txIn anySLang redeemer execUnits

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Read.hs
@@ -45,64 +45,62 @@ instance Error CliSpendScriptWitnessError where
 
 readSpendScriptWitnesses
   :: IsEra era
-  => [(TxIn, Maybe (ScriptRequirements TxInItem))]
+  => [(TxIn, Maybe AnySpendScript)]
   -> CIO e [(TxIn, Exp.AnyWitness (LedgerEra era))]
 readSpendScriptWitnesses =
   mapM (\(txin, mWit) -> (txin,) <$> readSpendScriptWitness mWit)
 
 readSpendScriptWitness
   :: forall era e
-   . IsEra era => Maybe (ScriptRequirements TxInItem) -> CIO e (Exp.AnyWitness (LedgerEra era))
+   . IsEra era => Maybe AnySpendScript -> CIO e (Exp.AnyWitness (LedgerEra era))
 readSpendScriptWitness Nothing = return Exp.AnyKeyWitnessPlaceholder
 readSpendScriptWitness (Just spendScriptReq) =
   case spendScriptReq of
-    OnDiskSimpleScript simpleFp -> do
-      let sFp = unFile simpleFp
-      Exp.AnySimpleScriptWitness . Exp.SScript <$> readFileSimpleScript sFp (useEra @era)
-    OnDiskPlutusScript
-      (OnDiskPlutusScriptCliArgs plutusScriptFp mScriptDatum redeemerFile execUnits) -> do
-        anyScript <-
-          readFilePlutusScript @_ @era (unFile plutusScriptFp)
-        case anyScript of
-          Exp.Plutus.AnyPlutusScript script -> do
-            redeemer <-
-              fromExceptTCli $
-                readScriptDataOrFile redeemerFile
-            let lang = Exp.Plutus.plutusScriptInEraSLanguage script
-            mDatum <- handlePotentialScriptDatum mScriptDatum lang
-
-            let pScript = Exp.PScript script
-                plutusScriptWitness = Exp.PlutusScriptWitness lang pScript mDatum redeemer execUnits
-            return $
-              Exp.AnyPlutusScriptWitness $
-                Exp.AnyPlutusSpendingScriptWitness $
-                  Exp.createPlutusSpendingScriptWitness lang plutusScriptWitness
-    SimpleReferenceScript (SimpleRefScriptArgs refTxIn NoPolicyId) ->
-      return $
-        Exp.AnySimpleScriptWitness $
-          Exp.SReferenceScript refTxIn
-    PlutusReferenceScript
-      (PlutusRefScriptCliArgs refTxIn (AnySLanguage lang) mScriptDatum NoPolicyId redeemerFile execUnits) -> do
-        let pRefScript = Exp.PReferenceScript refTxIn
-        redeemer <-
-          fromExceptTCli $ readScriptDataOrFile redeemerFile
-
-        mDatum <- handlePotentialScriptDatum mScriptDatum lang
-        let plutusScriptWitness = Exp.PlutusScriptWitness lang pRefScript mDatum redeemer execUnits
-        return $
-          Exp.AnyPlutusScriptWitness $
-            Exp.AnyPlutusSpendingScriptWitness $
-              Exp.createPlutusSpendingScriptWitness lang plutusScriptWitness
+    AnySpendScriptSimple simpleReq ->
+      case simpleReq of
+        OnDiskSimpleScript simpleFp -> do
+          let sFp = unFile simpleFp
+          Exp.AnySimpleScriptWitness . Exp.SScript <$> readFileSimpleScript sFp (useEra @era)
+        ReferenceSimpleScript refTxIn ->
+          return $ Exp.AnySimpleScriptWitness $ Exp.SReferenceScript refTxIn
+    AnySpendScriptPlutus plutusReq ->
+      case plutusReq of
+        OnDiskPlutusSpendingScript plutusScriptFp mScriptDatum redeemerFile execUnits -> do
+          anyScript <-
+            readFilePlutusScript @_ @era (unFile plutusScriptFp)
+          case anyScript of
+            Exp.Plutus.AnyPlutusScript script -> do
+              redeemer <-
+                fromExceptTCli $
+                  readScriptDataOrFile redeemerFile
+              let lang = Exp.Plutus.plutusScriptInEraSLanguage script
+              mDatum <- handlePotentialScriptDatum mScriptDatum lang
+              let pScript = Exp.Plutus.PScript script
+                  plutusScriptWitness = Exp.Plutus.PlutusScriptWitness lang pScript mDatum redeemer execUnits
+              return $
+                Exp.AnyPlutusScriptWitness $
+                  Exp.AnyPlutusSpendingScriptWitness $
+                    Exp.createPlutusSpendingScriptWitness lang plutusScriptWitness
+        ReferencePlutusSpendingScript refTxIn (AnySLanguage lang) mScriptDatum redeemerFile execUnits -> do
+          let pRefScript = Exp.Plutus.PReferenceScript refTxIn
+          redeemer <-
+            fromExceptTCli $ readScriptDataOrFile redeemerFile
+          mDatum <- handlePotentialScriptDatum mScriptDatum lang
+          let plutusScriptWitness = Exp.Plutus.PlutusScriptWitness lang pRefScript mDatum redeemer execUnits
+          return $
+            Exp.AnyPlutusScriptWitness $
+              Exp.AnyPlutusSpendingScriptWitness $
+                Exp.createPlutusSpendingScriptWitness lang plutusScriptWitness
 
 handlePotentialScriptDatum
   :: ScriptDatumOrFileSpending
   -> L.SLanguage lang
-  -> CIO e (Exp.PlutusScriptDatum lang Exp.SpendingScript)
-handlePotentialScriptDatum InlineDatum _ = return Exp.InlineDatum
+  -> CIO e (Exp.Plutus.PlutusScriptDatum lang Exp.Plutus.SpendingScript)
+handlePotentialScriptDatum InlineDatum _ = return Exp.Plutus.InlineDatum
 handlePotentialScriptDatum (PotentialDatum (Just sDatFp)) lang = do
   d <- fromExceptTCli $ readScriptDataOrFile sDatFp
   return $
-    Exp.SpendingScriptDatum
+    Exp.Plutus.SpendingScriptDatum
       ( case lang of
           L.SPlutusV1 -> d
           L.SPlutusV2 -> d
@@ -117,5 +115,5 @@ handlePotentialScriptDatum (PotentialDatum Nothing) lang =
     L.SPlutusV2 ->
       throwCliError @String
         "handlePotentialScriptDatum: You must provide a script datum for Plutus V2 scripts."
-    L.SPlutusV3 -> return Exp.NoScriptDatum
-    L.SPlutusV4 -> return Exp.NoScriptDatum
+    L.SPlutusV3 -> return Exp.Plutus.NoScriptDatum
+    L.SPlutusV4 -> return Exp.Plutus.NoScriptDatum

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Type.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Type.hs
@@ -1,18 +1,13 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
 
 module Cardano.CLI.EraBased.Script.Spend.Type
-  ( PlutusRefScriptCliArgs (..)
-  , SimpleRefScriptCliArgs (..)
-  , createSimpleOrPlutusScriptFromCliArgs
+  ( createSimpleOrPlutusScriptFromCliArgs
   , createPlutusReferenceScriptFromCliArgs
   , createSimpleReferenceScriptFromCliArgs
   )
 where
 
 import Cardano.Api
-import Cardano.Api.Experimental
 
 import Cardano.CLI.EraBased.Script.Type
 import Cardano.CLI.Type.Common (AnySLanguage, ScriptDataOrFile)
@@ -20,13 +15,15 @@ import Cardano.CLI.Type.Common (AnySLanguage, ScriptDataOrFile)
 createSimpleOrPlutusScriptFromCliArgs
   :: File ScriptInAnyLang In
   -> Maybe (ScriptDatumOrFileSpending, ScriptDataOrFile, ExecutionUnits)
-  -> ScriptRequirements TxInItem
+  -> AnySpendScript
 createSimpleOrPlutusScriptFromCliArgs scriptFp (Just (datumFile, redeemerFile, execUnits)) =
-  OnDiskPlutusScript $ OnDiskPlutusScriptCliArgs scriptFp datumFile redeemerFile execUnits
-createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing = OnDiskSimpleScript scriptFp
+  AnySpendScriptPlutus $ OnDiskPlutusSpendingScript scriptFp datumFile redeemerFile execUnits
+createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing =
+  AnySpendScriptSimple $ OnDiskSimpleScript scriptFp
 
-createSimpleReferenceScriptFromCliArgs :: TxIn -> ScriptRequirements TxInItem
-createSimpleReferenceScriptFromCliArgs = SimpleReferenceScript . flip SimpleRefScriptArgs NoPolicyId
+createSimpleReferenceScriptFromCliArgs :: TxIn -> AnySpendScript
+createSimpleReferenceScriptFromCliArgs txin =
+  AnySpendScriptSimple $ ReferenceSimpleScript txin
 
 createPlutusReferenceScriptFromCliArgs
   :: TxIn
@@ -34,6 +31,6 @@ createPlutusReferenceScriptFromCliArgs
   -> ScriptDatumOrFileSpending
   -> ScriptDataOrFile
   -> ExecutionUnits
-  -> ScriptRequirements TxInItem
+  -> AnySpendScript
 createPlutusReferenceScriptFromCliArgs txin v mDatum redeemer execUnits =
-  PlutusReferenceScript $ PlutusRefScriptCliArgs txin v mDatum NoPolicyId redeemer execUnits
+  AnySpendScriptPlutus $ ReferencePlutusSpendingScript txin v mDatum redeemer execUnits

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Type.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Type.hs
@@ -1,19 +1,19 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeFamilies #-}
 
 module Cardano.CLI.EraBased.Script.Type
-  ( -- * New experimental api
-    ScriptRequirements (..)
-  , OnDiskPlutusScriptCliArgs (..)
-  , PlutusRefScriptCliArgs (..)
-  , MintPolicyId
-  , NoPolicyId (..)
-  , OptionalDatum
-  , SimpleRefScriptCliArgs (..)
+  ( -- * Script requirements per context
+    SimpleScriptRequirements (..)
+  , PlutusSpendingScriptRequirements (..)
+  , PlutusMintingScriptRequirements (..)
+  , PlutusNonAssetScriptRequirements (..)
+
+    -- * Command-level sum types
+  , AnySpendScript (..)
+  , AnyMintScript (..)
+  , AnyNonAssetScript (..)
+
+    -- * Datum
   , ScriptDatumOrFileSpending (..)
 
     -- * Errors
@@ -22,7 +22,6 @@ module Cardano.CLI.EraBased.Script.Type
 where
 
 import Cardano.Api
-import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Type.Common
@@ -38,110 +37,99 @@ instance Error CliScriptWitnessError where
     PlutusScriptWitnessLanguageNotSupportedInEra version era ->
       "Plutus script version " <> pshow version <> " is not supported in era " <> pshow era
 
--- | Encapsulates the requirements for a simple or plutus script being read from disk.
-data ScriptRequirements (witnessable :: Exp.WitnessableItem) where
-  OnDiskSimpleScript :: File ScriptInAnyLang In -> ScriptRequirements witnessable
-  OnDiskPlutusScript
-    :: OnDiskPlutusScriptCliArgs witnessable -> ScriptRequirements witnessable
-  PlutusReferenceScript
-    :: PlutusRefScriptCliArgs witnessable -> ScriptRequirements witnessable
-  SimpleReferenceScript
-    :: SimpleRefScriptCliArgs witnessable -> ScriptRequirements witnessable
-
-deriving instance Show (ScriptRequirements Exp.VoterItem)
-
-deriving instance Show (ScriptRequirements Exp.MintItem)
-
-deriving instance Show (ScriptRequirements Exp.CertItem)
-
-deriving instance Show (ScriptRequirements Exp.TxInItem)
-
-deriving instance Show (ScriptRequirements Exp.ProposalItem)
-
-deriving instance Show (ScriptRequirements Exp.WithdrawalItem)
-
-data OnDiskPlutusScriptCliArgs (witnessable :: Exp.WitnessableItem) where
-  OnDiskPlutusScriptCliArgs
-    :: (File ScriptInAnyLang In)
-    -> (OptionalDatum witnessable)
-    -- ^ Optional Datum (CIP-69)
-    -> ScriptDataOrFile
-    -- ^ Redeemer
-    -> ExecutionUnits
-    -> OnDiskPlutusScriptCliArgs witnessable
-
-type family OptionalDatum (a :: Exp.WitnessableItem) where
-  OptionalDatum Exp.TxInItem = ScriptDatumOrFileSpending
-  OptionalDatum Exp.CertItem = Exp.NoScriptDatum
-  OptionalDatum Exp.MintItem = Exp.NoScriptDatum
-  OptionalDatum Exp.WithdrawalItem = Exp.NoScriptDatum
-  OptionalDatum Exp.VoterItem = Exp.NoScriptDatum
-  OptionalDatum Exp.ProposalItem = Exp.NoScriptDatum
-
 data ScriptDatumOrFileSpending
   = PotentialDatum (Maybe ScriptDataOrFile)
   | InlineDatum
   deriving Show
 
-deriving instance Show (OnDiskPlutusScriptCliArgs Exp.VoterItem)
+-- | Simple script provided either on disk or as a reference input.
+-- Shared across all script contexts since simple scripts have no
+-- context-specific fields.
+data SimpleScriptRequirements
+  = OnDiskSimpleScript (File ScriptInAnyLang In)
+  | ReferenceSimpleScript TxIn
+  deriving Show
 
-deriving instance Show (OnDiskPlutusScriptCliArgs Exp.MintItem)
+-- | Plutus script requirements for spending. Spending is the only context
+-- that carries an optional datum (CIP-69).
+data PlutusSpendingScriptRequirements
+  = OnDiskPlutusSpendingScript
+      (File ScriptInAnyLang In)
+      ScriptDatumOrFileSpending
+      -- ^ Optional Datum (CIP-69)
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  | ReferencePlutusSpendingScript
+      TxIn
+      -- ^ TxIn with reference script
+      AnySLanguage
+      ScriptDatumOrFileSpending
+      -- ^ Optional Datum (CIP-69)
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  deriving Show
 
-deriving instance Show (OnDiskPlutusScriptCliArgs Exp.ProposalItem)
+-- | Plutus script requirements for minting. Minting requires a 'PolicyId' so
+-- the CLI can validate that every policy being minted has a corresponding
+-- script witness and vice versa (see @createTxMintValue@). For on-disk scripts
+-- the 'PolicyId' is computed from the script hash; for reference scripts the
+-- user must supply it because the script bytes aren't available locally.
+data PlutusMintingScriptRequirements
+  = OnDiskPlutusMintingScript
+      (File ScriptInAnyLang In)
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  | ReferencePlutusMintingScript
+      TxIn
+      -- ^ TxIn with reference script
+      AnySLanguage
+      PolicyId
+      -- ^ Needed for plutus minting scripts
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  deriving Show
 
-deriving instance Show (OnDiskPlutusScriptCliArgs Exp.CertItem)
+-- | Plutus script requirements for non-asset contexts (certificates, voting,
+-- withdrawals, proposals). These contexts need neither a datum nor a policy id,
+-- so they share a single type.
+data PlutusNonAssetScriptRequirements
+  = OnDiskPlutusNonAssetScript
+      (File ScriptInAnyLang In)
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  | ReferencePlutusNonAssetScript
+      TxIn
+      -- ^ TxIn with reference script
+      AnySLanguage
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  deriving Show
 
-deriving instance Show (OnDiskPlutusScriptCliArgs Exp.TxInItem)
+-- | A spending script witness — simple or Plutus.
+data AnySpendScript
+  = AnySpendScriptSimple SimpleScriptRequirements
+  | AnySpendScriptPlutus PlutusSpendingScriptRequirements
+  deriving Show
 
-deriving instance Show (OnDiskPlutusScriptCliArgs Exp.WithdrawalItem)
+-- | A minting script witness — simple or Plutus.
+-- Simple minting scripts are split into on-disk and reference variants because
+-- the 'PolicyId' for on-disk scripts is computed from the script hash at read
+-- time, while reference scripts require the user to supply it via the CLI.
+data AnyMintScript
+  = AnyMintScriptSimpleOnDisk (File ScriptInAnyLang In)
+  | AnyMintScriptSimpleRef TxIn PolicyId
+  | AnyMintScriptPlutus PlutusMintingScriptRequirements
+  deriving Show
 
-data PlutusRefScriptCliArgs (witnessable :: Exp.WitnessableItem) where
-  PlutusRefScriptCliArgs
-    :: TxIn
-    -- ^ TxIn with reference script
-    -> AnySLanguage
-    -> OptionalDatum witnessable
-    -- ^ Optional Datum (CIP-69)
-    -> MintPolicyId witnessable
-    -- ^ Needed for plutus minting scripts
-    -> ScriptDataOrFile
-    -- ^ Redeemer
-    -> ExecutionUnits
-    -> PlutusRefScriptCliArgs witnessable
-
-deriving instance Show (PlutusRefScriptCliArgs Exp.VoterItem)
-
-deriving instance Show (PlutusRefScriptCliArgs Exp.MintItem)
-
-deriving instance Show (PlutusRefScriptCliArgs Exp.ProposalItem)
-
-deriving instance Show (PlutusRefScriptCliArgs Exp.CertItem)
-
-deriving instance Show (PlutusRefScriptCliArgs Exp.TxInItem)
-
-deriving instance Show (PlutusRefScriptCliArgs Exp.WithdrawalItem)
-
-data SimpleRefScriptCliArgs witnessable where
-  SimpleRefScriptArgs :: TxIn -> MintPolicyId witnessable -> SimpleRefScriptCliArgs witnessable
-
-deriving instance Show (SimpleRefScriptCliArgs Exp.VoterItem)
-
-deriving instance Show (SimpleRefScriptCliArgs Exp.MintItem)
-
-deriving instance Show (SimpleRefScriptCliArgs Exp.ProposalItem)
-
-deriving instance Show (SimpleRefScriptCliArgs Exp.CertItem)
-
-deriving instance Show (SimpleRefScriptCliArgs Exp.TxInItem)
-
-deriving instance Show (SimpleRefScriptCliArgs Exp.WithdrawalItem)
-
-type family MintPolicyId (a :: Exp.WitnessableItem) where
-  MintPolicyId Exp.TxInItem = NoPolicyId
-  MintPolicyId Exp.CertItem = NoPolicyId
-  MintPolicyId Exp.MintItem = PolicyId
-  MintPolicyId Exp.WithdrawalItem = NoPolicyId
-  MintPolicyId Exp.VoterItem = NoPolicyId
-  MintPolicyId Exp.ProposalItem = NoPolicyId
-
-data NoPolicyId = NoPolicyId deriving Show
+-- | A non-asset script witness — simple or Plutus.
+-- Used for certificates, voting, withdrawals, and proposals.
+data AnyNonAssetScript
+  = AnyNonAssetScriptSimple SimpleScriptRequirements
+  | AnyNonAssetScriptPlutus PlutusNonAssetScriptRequirements
+  deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Vote/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Vote/Read.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -19,7 +18,6 @@ import Cardano.Api.Experimental.Plutus qualified as Exp.Plutus
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.EraBased.Script.Read.Common
 import Cardano.CLI.EraBased.Script.Type
-import Cardano.CLI.EraBased.Script.Type qualified as Exp
 import Cardano.CLI.Read
 import Cardano.CLI.Type.Common (AnySLanguage (..))
 import Cardano.CLI.Type.Governance
@@ -29,7 +27,7 @@ import Control.Monad
 readVoteScriptWitness
   :: forall era e
    . Exp.IsEra era
-  => (VoteFile In, Maybe (ScriptRequirements Exp.VoterItem))
+  => (VoteFile In, Maybe AnyNonAssetScript)
   -> CIO e (VotingProcedures era, Exp.AnyWitness (Exp.LedgerEra era))
 readVoteScriptWitness (voteFp, Nothing) = do
   votProceds <-
@@ -43,65 +41,56 @@ readVoteScriptWitness (voteFp, Just certScriptReq) = do
       fromEitherIOCli $
         readFileTextEnvelope voteFp
   case certScriptReq of
-    OnDiskSimpleScript scriptFp -> do
-      let sFp = unFile scriptFp
-      s <-
-        Exp.AnySimpleScriptWitness . Exp.SScript <$> readFileSimpleScript sFp (Exp.useEra @era)
+    AnyNonAssetScriptSimple simpleReq ->
+      case simpleReq of
+        OnDiskSimpleScript scriptFp -> do
+          let sFp = unFile scriptFp
+          s <-
+            Exp.AnySimpleScriptWitness . Exp.SScript <$> readFileSimpleScript sFp (Exp.useEra @era)
+          return (votProceds, s)
+        ReferenceSimpleScript refTxIn ->
+          return
+            ( votProceds
+            , Exp.AnySimpleScriptWitness $ Exp.SReferenceScript refTxIn
+            )
+    AnyNonAssetScriptPlutus plutusReq ->
+      case plutusReq of
+        OnDiskPlutusNonAssetScript scriptFp redeemerFile execUnits -> do
+          let plutusScriptFp = unFile scriptFp
+          Exp.Plutus.AnyPlutusScript script <-
+            readFilePlutusScript @_ @era plutusScriptFp
+          redeemer <-
+            fromExceptTCli $
+              readScriptDataOrFile redeemerFile
 
-      return
-        ( votProceds
-        , s
-        )
-    OnDiskPlutusScript
-      (OnDiskPlutusScriptCliArgs scriptFp Exp.NoScriptDatumAllowed redeemerFile execUnits) -> do
-        let plutusScriptFp = unFile scriptFp
-        Exp.Plutus.AnyPlutusScript script <-
-          readFilePlutusScript @_ @era plutusScriptFp
-        redeemer <-
-          fromExceptTCli $
-            readScriptDataOrFile redeemerFile
-
-        let pScript = Exp.PScript script
-            lang = Exp.Plutus.plutusScriptInEraSLanguage script
-        let sw =
-              Exp.PlutusScriptWitness
-                lang
-                pScript
-                Exp.NoScriptDatum
-                redeemer
-                execUnits
-        return
-          ( votProceds
-          , Exp.AnyPlutusScriptWitness $ AnyPlutusCertifyingScriptWitness sw
-          )
-    PlutusReferenceScript
-      ( PlutusRefScriptCliArgs
-          refTxIn
-          (AnySLanguage lang)
-          Exp.NoScriptDatumAllowed
-          Exp.NoPolicyId
-          redeemerFile
-          execUnits
-        ) -> do
-        redeemer <-
-          fromExceptTCli $ readScriptDataOrFile redeemerFile
-
-        return
-          ( votProceds
-          , Exp.AnyPlutusScriptWitness $
-              AnyPlutusCertifyingScriptWitness $
-                Exp.PlutusScriptWitness
+          let pScript = Exp.Plutus.PScript script
+              lang = Exp.Plutus.plutusScriptInEraSLanguage script
+          let sw =
+                Exp.Plutus.PlutusScriptWitness
                   lang
-                  (Exp.PReferenceScript refTxIn)
-                  Exp.NoScriptDatum
+                  pScript
+                  Exp.Plutus.NoScriptDatum
                   redeemer
                   execUnits
-          )
-    SimpleReferenceScript (SimpleRefScriptArgs refTxIn _) ->
-      return
-        ( votProceds
-        , Exp.AnySimpleScriptWitness $ Exp.SReferenceScript refTxIn
-        )
+          return
+            ( votProceds
+            , Exp.AnyPlutusScriptWitness $ AnyPlutusCertifyingScriptWitness sw
+            )
+        ReferencePlutusNonAssetScript refTxIn (AnySLanguage lang) redeemerFile execUnits -> do
+          redeemer <-
+            fromExceptTCli $ readScriptDataOrFile redeemerFile
+
+          return
+            ( votProceds
+            , Exp.AnyPlutusScriptWitness $
+                AnyPlutusCertifyingScriptWitness $
+                  Exp.Plutus.PlutusScriptWitness
+                    lang
+                    (Exp.Plutus.PReferenceScript refTxIn)
+                    Exp.Plutus.NoScriptDatum
+                    redeemer
+                    execUnits
+            )
 
 -- Because the 'Voter' type is contained only in the 'VotingProcedures'
 -- type, we must read a single vote as 'VotingProcedures'. The cli will
@@ -110,7 +99,7 @@ readVoteScriptWitness (voteFp, Just certScriptReq) = do
 -- when it comes to script witnessed votes.
 readVotingProceduresFiles
   :: Exp.IsEra era
-  => [(VoteFile In, Maybe (ScriptRequirements Exp.VoterItem))]
+  => [(VoteFile In, Maybe AnyNonAssetScript)]
   -> CIO e [(VotingProcedures era, Exp.AnyWitness (Exp.LedgerEra era))]
 readVotingProceduresFiles files =
   forM files readVoteScriptWitness

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Vote/Type.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Vote/Type.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
 
 module Cardano.CLI.EraBased.Script.Vote.Type
   ( createSimpleOrPlutusScriptFromCliArgs
@@ -15,33 +13,26 @@ import Cardano.Api
   , ScriptInAnyLang
   , TxIn
   )
-import Cardano.Api.Experimental qualified as Exp
 
-import Cardano.CLI.EraBased.Script.Type qualified as Latest
+import Cardano.CLI.EraBased.Script.Type
 import Cardano.CLI.Type.Common (AnySLanguage, ScriptDataOrFile)
 
 createSimpleOrPlutusScriptFromCliArgs
   :: File ScriptInAnyLang In
   -> Maybe (ScriptDataOrFile, ExecutionUnits)
-  -> Latest.ScriptRequirements Exp.VoterItem
+  -> AnyNonAssetScript
 createSimpleOrPlutusScriptFromCliArgs scriptFp (Just (redeemer, execUnits)) =
-  Latest.OnDiskPlutusScript $
-    Latest.OnDiskPlutusScriptCliArgs scriptFp Exp.NoScriptDatumAllowed redeemer execUnits
+  AnyNonAssetScriptPlutus $
+    OnDiskPlutusNonAssetScript scriptFp redeemer execUnits
 createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing =
-  Latest.OnDiskSimpleScript scriptFp
+  AnyNonAssetScriptSimple $ OnDiskSimpleScript scriptFp
 
 createPlutusReferenceScriptFromCliArgs
   :: TxIn
   -> AnySLanguage
   -> ScriptDataOrFile
   -> ExecutionUnits
-  -> Latest.ScriptRequirements Exp.VoterItem
+  -> AnyNonAssetScript
 createPlutusReferenceScriptFromCliArgs txIn anySLang redeemer execUnits =
-  Latest.PlutusReferenceScript $
-    Latest.PlutusRefScriptCliArgs
-      txIn
-      anySLang
-      Exp.NoScriptDatumAllowed
-      Latest.NoPolicyId
-      redeemer
-      execUnits
+  AnyNonAssetScriptPlutus $
+    ReferencePlutusNonAssetScript txIn anySLang redeemer execUnits

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Withdrawal/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Withdrawal/Read.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -15,8 +14,6 @@ import Cardano.Api.Experimental
   ( AnyWitness (..)
   , IsEra (..)
   , LedgerEra
-  , NoScriptDatum (..)
-  , WitnessableItem (..)
   )
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Experimental.AnyScriptWitness
@@ -31,73 +28,64 @@ import Cardano.CLI.Type.Common (AnySLanguage (..))
 readWithdrawalScriptWitness
   :: forall e era
    . IsEra era
-  => (StakeAddress, Coin, Maybe (ScriptRequirements WithdrawalItem))
+  => (StakeAddress, Coin, Maybe AnyNonAssetScript)
   -> CIO e (StakeAddress, Coin, AnyWitness (LedgerEra era))
 readWithdrawalScriptWitness (stakeAddr, withdrawalAmt, Nothing) =
   return (stakeAddr, withdrawalAmt, Exp.AnyKeyWitnessPlaceholder)
 readWithdrawalScriptWitness (stakeAddr, withdrawalAmt, Just certScriptReq) =
   case certScriptReq of
-    OnDiskSimpleScript scriptFp -> do
-      let sFp = unFile scriptFp
-      sWit <- AnySimpleScriptWitness . Exp.SScript <$> readFileSimpleScript sFp (Exp.useEra @era)
+    AnyNonAssetScriptSimple simpleReq ->
+      case simpleReq of
+        OnDiskSimpleScript scriptFp -> do
+          let sFp = unFile scriptFp
+          sWit <- AnySimpleScriptWitness . Exp.SScript <$> readFileSimpleScript sFp (Exp.useEra @era)
+          return (stakeAddr, withdrawalAmt, sWit)
+        ReferenceSimpleScript refTxIn ->
+          return
+            ( stakeAddr
+            , withdrawalAmt
+            , AnySimpleScriptWitness $ Exp.SReferenceScript refTxIn
+            )
+    AnyNonAssetScriptPlutus plutusReq ->
+      case plutusReq of
+        OnDiskPlutusNonAssetScript scriptFp redeemerFile execUnits -> do
+          let plutusScriptFp = unFile scriptFp
+          Exp.Plutus.AnyPlutusScript script <-
+            readFilePlutusScript @_ @era plutusScriptFp
+          redeemer <-
+            fromExceptTCli $
+              readScriptDataOrFile redeemerFile
 
-      return
-        ( stakeAddr
-        , withdrawalAmt
-        , sWit
-        )
-    OnDiskPlutusScript (OnDiskPlutusScriptCliArgs scriptFp NoScriptDatumAllowed redeemerFile execUnits) -> do
-      let plutusScriptFp = unFile scriptFp
-      Exp.Plutus.AnyPlutusScript script <-
-        readFilePlutusScript @_ @era plutusScriptFp
-      redeemer <-
-        fromExceptTCli $
-          readScriptDataOrFile redeemerFile
-
-      let lang = Exp.Plutus.plutusScriptInEraSLanguage script
-          pScript = Exp.PScript script
-          sw =
-            Exp.PlutusScriptWitness
-              lang
-              pScript
-              Exp.NoScriptDatum
-              redeemer
-              execUnits
-      return
-        ( stakeAddr
-        , withdrawalAmt
-        , AnyPlutusScriptWitness $
-            AnyPlutusCertifyingScriptWitness sw
-        )
-    SimpleReferenceScript (SimpleRefScriptArgs refTxIn NoPolicyId) ->
-      return
-        ( stakeAddr
-        , withdrawalAmt
-        , AnySimpleScriptWitness $ Exp.SReferenceScript refTxIn
-        )
-    PlutusReferenceScript
-      ( PlutusRefScriptCliArgs
-          refTxIn
-          (AnySLanguage lang)
-          NoScriptDatumAllowed
-          NoPolicyId
-          redeemerFile
-          execUnits
-        ) -> do
-        redeemer <-
-          fromExceptTCli $
-            readScriptDataOrFile redeemerFile
-        let sWit =
-              Exp.AnyPlutusScriptWitness $
-                AnyPlutusCertifyingScriptWitness $
-                  Exp.PlutusScriptWitness
-                    lang
-                    (Exp.PReferenceScript refTxIn)
-                    Exp.NoScriptDatum
-                    redeemer
-                    execUnits
-        return
-          ( stakeAddr
-          , withdrawalAmt
-          , sWit
-          )
+          let lang = Exp.Plutus.plutusScriptInEraSLanguage script
+              pScript = Exp.Plutus.PScript script
+              sw =
+                Exp.Plutus.PlutusScriptWitness
+                  lang
+                  pScript
+                  Exp.Plutus.NoScriptDatum
+                  redeemer
+                  execUnits
+          return
+            ( stakeAddr
+            , withdrawalAmt
+            , AnyPlutusScriptWitness $
+                AnyPlutusCertifyingScriptWitness sw
+            )
+        ReferencePlutusNonAssetScript refTxIn (AnySLanguage lang) redeemerFile execUnits -> do
+          redeemer <-
+            fromExceptTCli $
+              readScriptDataOrFile redeemerFile
+          let sWit =
+                Exp.AnyPlutusScriptWitness $
+                  AnyPlutusCertifyingScriptWitness $
+                    Exp.Plutus.PlutusScriptWitness
+                      lang
+                      (Exp.Plutus.PReferenceScript refTxIn)
+                      Exp.Plutus.NoScriptDatum
+                      redeemer
+                      execUnits
+          return
+            ( stakeAddr
+            , withdrawalAmt
+            , sWit
+            )

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Withdrawal/Type.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Withdrawal/Type.hs
@@ -1,16 +1,12 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
 
 module Cardano.CLI.EraBased.Script.Withdrawal.Type
-  ( PlutusRefScriptCliArgs (..)
-  , createSimpleOrPlutusScriptFromCliArgs
+  ( createSimpleOrPlutusScriptFromCliArgs
   , createPlutusReferenceScriptFromCliArgs
   )
 where
 
 import Cardano.Api
-import Cardano.Api.Experimental
 
 import Cardano.CLI.EraBased.Script.Type
 import Cardano.CLI.Type.Common (AnySLanguage (..), ScriptDataOrFile)
@@ -18,18 +14,17 @@ import Cardano.CLI.Type.Common (AnySLanguage (..), ScriptDataOrFile)
 createSimpleOrPlutusScriptFromCliArgs
   :: File ScriptInAnyLang In
   -> Maybe (ScriptDataOrFile, ExecutionUnits)
-  -> ScriptRequirements WithdrawalItem
+  -> AnyNonAssetScript
 createSimpleOrPlutusScriptFromCliArgs scriptFp (Just (redeemer, execUnits)) =
-  OnDiskPlutusScript $ OnDiskPlutusScriptCliArgs scriptFp NoScriptDatumAllowed redeemer execUnits
+  AnyNonAssetScriptPlutus $ OnDiskPlutusNonAssetScript scriptFp redeemer execUnits
 createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing =
-  OnDiskSimpleScript scriptFp
+  AnyNonAssetScriptSimple $ OnDiskSimpleScript scriptFp
 
 createPlutusReferenceScriptFromCliArgs
   :: TxIn
   -> AnySLanguage
   -> ScriptDataOrFile
   -> ExecutionUnits
-  -> ScriptRequirements WithdrawalItem
+  -> AnyNonAssetScript
 createPlutusReferenceScriptFromCliArgs txIn version redeemer execUnits =
-  PlutusReferenceScript $
-    PlutusRefScriptCliArgs txIn version NoScriptDatumAllowed NoPolicyId redeemer execUnits
+  AnyNonAssetScriptPlutus $ ReferencePlutusNonAssetScript txIn version redeemer execUnits

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
@@ -60,7 +60,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   { eon :: !(Exp.Era era)
   , mScriptValidity :: !(Maybe ScriptValidity)
   -- ^ Mark script as expected to pass or fail validation
-  , txIns :: ![(TxIn, Maybe (ScriptRequirements Exp.TxInItem))]
+  , txIns :: ![(TxIn, Maybe AnySpendScript)]
   -- ^ Transaction inputs with optional spending scripts
   , readOnlyRefIns :: ![TxIn]
   -- ^ Read only reference inputs
@@ -73,7 +73,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   , requiredSigners :: ![RequiredSigner]
   -- ^ Required signers
   , txouts :: ![TxOutAnyEra]
-  , mMintedAssets :: !(Maybe (L.MultiAsset, [ScriptRequirements Exp.MintItem]))
+  , mMintedAssets :: !(Maybe (L.MultiAsset, [AnyMintScript]))
   -- ^ Multi-Asset minted value with script witness
   , mValidityLowerBound :: !(Maybe SlotNo)
   -- ^ Transaction validity lower bound
@@ -81,17 +81,17 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   -- ^ Transaction validity upper bound
   , fee :: !Coin
   -- ^ Transaction fee
-  , certificates :: ![(CertificateFile, Maybe (ScriptRequirements Exp.CertItem))]
+  , certificates :: ![(CertificateFile, Maybe AnyNonAssetScript)]
   -- ^ Certificates with potential script witness
-  , withdrawals :: ![(StakeAddress, Coin, Maybe (ScriptRequirements Exp.WithdrawalItem))]
+  , withdrawals :: ![(StakeAddress, Coin, Maybe AnyNonAssetScript)]
   , metadataSchema :: !TxMetadataJsonSchema
   , scriptFiles :: ![ScriptFile]
   -- ^ Auxiliary scripts
   , metadataFiles :: ![MetadataFile]
   , mProtocolParamsFile :: !(Maybe ProtocolParamsFile)
   , mUpdateProprosalFile :: !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
-  , voteFiles :: ![(VoteFile In, Maybe (ScriptRequirements Exp.VoterItem))]
-  , proposalFiles :: ![(ProposalFile In, Maybe (ScriptRequirements Exp.ProposalItem))]
+  , voteFiles :: ![(VoteFile In, Maybe AnyNonAssetScript)]
+  , proposalFiles :: ![(ProposalFile In, Maybe AnyNonAssetScript)]
   , mCurrentTreasuryValue :: !(Maybe TxCurrentTreasuryValue)
   , mTreasuryDonation :: !(Maybe TxTreasuryDonation)
   , isCborOutCanonical :: !TxCborFormat
@@ -132,7 +132,7 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   -- ^ Mark script as expected to pass or fail validation
   , mOverrideWitnesses :: !(Maybe Word)
   -- ^ Override the required number of tx witnesses
-  , txins :: ![(TxIn, Maybe (ScriptRequirements Exp.TxInItem))]
+  , txins :: ![(TxIn, Maybe AnySpendScript)]
   -- ^ Transaction inputs with optional spending scripts
   , readOnlyReferenceInputs :: ![TxIn]
   -- ^ Read only reference inputs
@@ -148,23 +148,23 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   -- ^ Normal outputs
   , changeAddresses :: !TxOutChangeAddress
   -- ^ A change output
-  , mMintedAssets :: !(Maybe (L.MultiAsset, [ScriptRequirements Exp.MintItem]))
+  , mMintedAssets :: !(Maybe (L.MultiAsset, [AnyMintScript]))
   -- ^ Multi-Asset minted value with script witness
   , mValidityLowerBound :: !(Maybe SlotNo)
   -- ^ Transaction validity lower bound
   , mValidityUpperBound :: !(TxValidityUpperBound era)
   -- ^ Transaction validity upper bound
-  , certificates :: ![(CertificateFile, Maybe (ScriptRequirements Exp.CertItem))]
+  , certificates :: ![(CertificateFile, Maybe AnyNonAssetScript)]
   -- ^ Certificates with potential script witness
-  , withdrawals :: ![(StakeAddress, Coin, Maybe (ScriptRequirements Exp.WithdrawalItem))]
+  , withdrawals :: ![(StakeAddress, Coin, Maybe AnyNonAssetScript)]
   -- ^ Withdrawals with potential script witness
   , metadataSchema :: !TxMetadataJsonSchema
   , scriptFiles :: ![ScriptFile]
   -- ^ Auxiliary scripts
   , metadataFiles :: ![MetadataFile]
   , mUpdateProposalFile :: !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
-  , voteFiles :: ![(VoteFile In, Maybe (ScriptRequirements Exp.VoterItem))]
-  , proposalFiles :: ![(ProposalFile In, Maybe (ScriptRequirements Exp.ProposalItem))]
+  , voteFiles :: ![(VoteFile In, Maybe AnyNonAssetScript)]
+  , proposalFiles :: ![(ProposalFile In, Maybe AnyNonAssetScript)]
   , includeCurrentTreasuryValue :: !IncludeCurrentTreasuryValue
   , mTreasuryDonation :: !(Maybe TxTreasuryDonation)
   , isCborOutCanonical :: !TxCborFormat
@@ -182,7 +182,7 @@ data TransactionBuildEstimateCmdArgs era = TransactionBuildEstimateCmdArgs
   , mByronWitnesses :: !(Maybe Int)
   , protocolParamsFile :: !ProtocolParamsFile
   , totalUTxOValue :: !Value
-  , txins :: ![(TxIn, Maybe (ScriptRequirements Exp.TxInItem))]
+  , txins :: ![(TxIn, Maybe AnySpendScript)]
   -- ^ Transaction inputs with optional spending scripts
   , readOnlyReferenceInputs :: ![TxIn]
   -- ^ Read only reference inputs
@@ -196,15 +196,15 @@ data TransactionBuildEstimateCmdArgs era = TransactionBuildEstimateCmdArgs
   -- ^ Normal outputs
   , changeAddress :: !TxOutChangeAddress
   -- ^ A change output
-  , mMintedAssets :: !(Maybe (L.MultiAsset, [ScriptRequirements Exp.MintItem]))
+  , mMintedAssets :: !(Maybe (L.MultiAsset, [AnyMintScript]))
   -- ^ Multi-Asset value with script witness
   , mValidityLowerBound :: !(Maybe SlotNo)
   -- ^ Transaction validity lower bound
   , mValidityUpperBound :: !(TxValidityUpperBound era)
   -- ^ Transaction validity upper bound
-  , certificates :: ![(CertificateFile, Maybe (ScriptRequirements Exp.CertItem))]
+  , certificates :: ![(CertificateFile, Maybe AnyNonAssetScript)]
   -- ^ Certificates with potential script witness
-  , withdrawals :: ![(StakeAddress, Coin, Maybe (ScriptRequirements Exp.WithdrawalItem))]
+  , withdrawals :: ![(StakeAddress, Coin, Maybe AnyNonAssetScript)]
   -- ^ Withdrawals with potential script witness
   , plutusCollateral :: !(Maybe Coin)
   -- ^ Total collateral
@@ -214,8 +214,8 @@ data TransactionBuildEstimateCmdArgs era = TransactionBuildEstimateCmdArgs
   , scriptFiles :: ![ScriptFile]
   -- ^ Auxiliary scripts
   , metadataFiles :: ![MetadataFile]
-  , voteFiles :: ![(VoteFile In, Maybe (ScriptRequirements Exp.VoterItem))]
-  , proposalFiles :: ![(ProposalFile In, Maybe (ScriptRequirements Exp.ProposalItem))]
+  , voteFiles :: ![(VoteFile In, Maybe AnyNonAssetScript)]
+  , proposalFiles :: ![(ProposalFile In, Maybe AnyNonAssetScript)]
   , currentTreasuryValue :: !(Maybe TxCurrentTreasuryValue)
   , treasuryDonation :: !(Maybe TxTreasuryDonation)
   , isCborOutCanonical :: !TxCborFormat


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Replace parameterized ScriptRequirements GADT with flat unparameterized ADTs
  type:
  - refactoring
```

# Context

Replaces the parameterized `ScriptRequirements` GADT and its associated type families (`OptionalDatum`, `MintPolicyId`) with flat, context-specific ADTs that make invalid states unrepresentable — in particular, `NoScriptDatum` can no longer appear in types where a datum is expected.

Closes #1082

## Commit structure

1. **Introduce flat unparameterized ADTs** — core type definitions in `Script/Type.hs`
2. **Update shared option parsers and read utilities** — `Common/Option.hs`, `Read/Common.hs`, `Type/Common.hs`
3. **Spend** — Type + Read
4. **Mint** — Type + Read
5. **Certificate** — Type + Read
6. **Vote** — Type + Read
7. **Withdrawal** — Type + Read
8. **Proposal** — Type + Read
9. **Propagate to consumers** — Compatible layer, runners, build config, tests

# How to trust this PR

Each per-script-type commit touches only the `Type.hs` and `Read.hs` for that script context, making it easy to review in isolation. The final consumer propagation commit covers the mechanical updates needed to wire everything together. The overall diff is a net reduction in code (~100 fewer lines) due to eliminating standalone deriving instances and type family machinery.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Self-reviewed the diff