### PR TITLE
Release cardano-cli-10.15.1.0

### DIFF
--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog for cardano-cli
 
+## 10.15.1.0
+
+- Integrate cardano-cli with cardano-node 10.7 dependencies (ledger, consensus, network changes)
+  (maintenance, compatible)
+  [PR 1319](https://github.com/IntersectMBO/cardano-cli/pull/1319)
+
+- Print friendly stderr message when query future-pparams returns null
+  (feature)
+  [PR 1344](https://github.com/IntersectMBO/cardano-cli/pull/1344)
+
+- Removed requirement of "current treasury value" in transactions
+  (compatible)
+  [PR 1322](https://github.com/IntersectMBO/cardano-cli/pull/1322)
+
 ## 10.15.0.1
 
 - Fix supplemental datum propagation in transaction outputs

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.8
 name: cardano-cli
-version: 10.15.0.1
+version: 10.15.1.0
 synopsis: The Cardano command-line interface
 description: The Cardano command-line interface.
 copyright: 2020-2023 Input Output Global Inc (IOG).


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Release cardano-cli-10.15.1.0
  type:
   - release
```

# Context

Release cardano-cli-10.15.1.0 with the following changes:
- Integrate cardano-cli with cardano-node 10.7 dependencies ([PR 1319](https://github.com/IntersectMBO/cardano-cli/pull/1319))
- Print friendly stderr message when query future-pparams returns null ([PR 1344](https://github.com/IntersectMBO/cardano-cli/pull/1344))
- Removed requirement of "current treasury value" in transactions ([PR 1322](https://github.com/IntersectMBO/cardano-cli/pull/1322))

# How to trust this PR

Changelog-only change generated via `cardano-dev` scripts.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Self-reviewed the diff