### PR TITLE
Use cardano-api with ouroboros-consensus ^>=2.0 for node 10.7.2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -78,6 +78,6 @@ if impl (ghc >= 9.12)
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/cardano-api.git
-  tag: cc09054088b2554ea1e7c0882699ae6b04df0102
+  tag: 736df673bd284962706f985796d41d54d360f3ca
   subdir: cardano-api
 

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2026-02-17T10:15:41Z
-  , cardano-haskell-packages 2026-03-19T11:07:17Z
+  , cardano-haskell-packages 2026-04-01T09:04:56Z
 
 packages:
   cardano-cli
@@ -73,4 +73,11 @@ if impl (ghc >= 9.12)
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+-- Temporary: cardano-api with ouroboros-consensus ^>=2.0 for cardano-node 10.7.2
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/cardano-api.git
+  tag: cc09054088b2554ea1e7c0882699ae6b04df0102
+  subdir: cardano-api
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use cardano-api with ouroboros-consensus ^>=2.0 via SRP for cardano-node 10.7.2
  type:
   - release
   - maintenance
```

# Context

Points cardano-cli at the cardano-api release branch (`release/cardano-api-10.25.0.0`) which bumps the `ouroboros-consensus` dependency bound from `^>=1.0` to `^>=2.0`, required for `cardano-node 10.7.2`.

Uses a temporary `source-repository-package` stanza. This can be removed once the CHaP metadata revision for `cardano-api-10.25.0.0` lands.

Related: https://github.com/IntersectMBO/cardano-api/pull/1171

# How to trust this PR

Two changes in `cabal.project`:
1. CHaP index-state bumped to include `ouroboros-consensus-2.0.0.0`
2. Temporary SRP pointing at the cardano-api release branch (single commit: consensus bound bump)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Self-reviewed the diff
