### PR TITLE
Fix issue with haddock generation in CI

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -25,6 +25,8 @@ jobs:
             substituters = https://cache.iog.io/ https://cache.nixos.org/
 
       - uses: rrbutani/use-nix-shell-action@v1
+        with:
+          devShell: .#ghc914
 
       - name: Update cabal indices
         run: |

--- a/cabal.project
+++ b/cabal.project
@@ -74,6 +74,15 @@ if impl (ghc >= 9.12)
     -- https://github.com/kapralVV/Unique/issues/11
     , Unique:hashable
 
+if impl (ghc >= 9.14)
+  allow-newer:
+    , *:base
+    , *:containers
+    , *:template-haskell
+    , *:ghc-prim
+    , *:text
+    , *:bytestring
+
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -24,7 +24,7 @@ common project-config
     ImportQualifiedPost
     OverloadedStrings
 
-  build-depends: base >=4.14 && <4.22
+  build-depends: base >=4.14 && <4.23
   ghc-options:
     -Wall
     -Wcompat

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,8 @@
     # latter if you change this value.
     crossCompilerVersionUcrt64 = "ghc9122";
     crossCompilerVersionMusl = "ghc967";
+    # Used for haddock generation (avoids GHC 9.12 tyConStupidTheta panic)
+    haddockCompiler = "ghc914";
   in
     {inherit (inputs) incl;}
     // inputs.flake-utils.lib.eachSystem supportedSystems (
@@ -315,7 +317,7 @@
         flake = cabalProject.flake (
           lib.optionalAttrs (system == "x86_64-linux") {
             # on linux, build/test other supported compilers
-            variants = lib.genAttrs [crossCompilerVersionMusl crossCompilerVersionUcrt64] (compiler-nix-name: {
+            variants = lib.genAttrs [crossCompilerVersionMusl crossCompilerVersionUcrt64 haddockCompiler] (compiler-nix-name: {
               inherit compiler-nix-name;
             });
           }


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fixed issue with haddock build in CI. Added ghc 9.14 dev shell to flake for x86_64-linux.
  type:
  - maintenance
```

# Context

The GitHub Pages haddock generation workflow is broken due to a GHC 9.12.2 panic:

```
panic! (the 'impossible' happened)
  GHC version 9.12.2:
        tyConStupidTheta
AllLedgerPeers
```

This PR works around it by switching haddock generation to GHC 9.14. This is the same fix applied to `cardano-api` in https://github.com/IntersectMBO/cardano-api/pull/1169.

# How to trust this PR

- The `flake.nix` change adds a `haddockCompiler = "ghc914"` variable and includes it in the flake variants so a `.#ghc914` dev shell is available on `x86_64-linux`
- The workflow change uses `devShell: .#ghc914` in the GitHub Pages haddock step so it builds with GHC 9.14 instead of the default 9.12.2
- You can see the result of running the `gh-pages` action in: https://github.com/IntersectMBO/cardano-cli/actions/runs/24047959755/job/70136064292

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff