### PR TITLE
Release cardano-cli-10.16.0.0

### DIFF
--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for cardano-cli
 
+## 10.16.0.0
+
+- Added support for generating proofs of possession for BLS keys.
+  (feature)
+  [PR 1356](https://github.com/IntersectMBO/cardano-cli/pull/1356)
+
+- Added support for generating and hashing BLS keys.
+  (feature)
+  [PR 1355](https://github.com/IntersectMBO/cardano-cli/pull/1355)
+
 ## 10.15.1.0
 
 - Integrate cardano-cli with cardano-node 10.7 dependencies (ledger, consensus, network changes)

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.8
 name: cardano-cli
-version: 10.15.1.0
+version: 10.16.0.0
 synopsis: The Cardano command-line interface
 description: The Cardano command-line interface.
 copyright: 2020-2023 Input Output Global Inc (IOG).


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Release cardano-cli-10.16.0.0
  type:
    - release        # related to a new release preparation
```

# Context

This release updates the dependency `ouroboros-consensus-2.0.0.0` as well as support for generating BLS keys and proof-of-possessions for BLS keys in preparation for Leios

Corresponding CHaP PR: https://github.com/IntersectMBO/cardano-haskell-packages/pull/1341