### PR TITLE
Error when build-raw uses Plutus scripts without protocol params

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
@@ -808,6 +808,17 @@ runTxBuildRaw
         mTreasuryDonation
         suppDatums
 
+    let hasPlutusScripts =
+          any (isJust . Exp.getAnyWitnessPlutusLanguage . snd) inputsAndMaybeScriptWits
+            || any (isPlutusScriptWitness . snd) (snd valuesWithScriptWits)
+            || any (isJust . Exp.getAnyWitnessPlutusLanguage . snd) certsAndMaybeSriptWits
+            || any (\(_, _, w) -> isJust $ Exp.getAnyWitnessPlutusLanguage w) withdrawals
+            || any (isJust . Exp.getAnyWitnessPlutusLanguage . snd) votingProcedures
+            || any (isJust . Exp.getAnyWitnessPlutusLanguage . snd) proposals
+
+    when (hasPlutusScripts && isNothing mpparams) $
+      Left TxCmdPlutusScriptsRequireProtocolParams
+
     return $ Exp.makeUnsignedTx Exp.useEra txBodyContent
 
 constructTxBodyContent
@@ -1778,6 +1789,10 @@ runTransactionSignWitnessCmd
         if isCborOutCanonical == TxCborCanonical
           then writeTxFileTextEnvelopeCanonical era outFile tx
           else writeTxFileTextEnvelope era outFile tx
+
+isPlutusScriptWitness :: Exp.AnyScriptWitness era -> Bool
+isPlutusScriptWitness (Exp.AnyScriptWitnessPlutus _) = True
+isPlutusScriptWitness _ = False
 
 getExecutionUnitPrices :: CardanoEra era -> LedgerProtocolParameters era -> Maybe L.Prices
 getExecutionUnitPrices cEra (LedgerProtocolParameters pp) =

--- a/cardano-cli/src/Cardano/CLI/Type/Error/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/TxCmdError.hs
@@ -79,6 +79,7 @@ data TxCmdError
   | TxCmdUtxoJsonError String
   | forall era. TxCmdDeprecatedEra (Exp.DeprecatedEra era)
   | TxCmdGenesisDataError GenesisDataError
+  | TxCmdPlutusScriptsRequireProtocolParams
 
 instance Show TxCmdError where
   show = show . renderTxCmdError
@@ -187,6 +188,12 @@ renderTxCmdError = \case
     "Error while decoding JSON from UTxO set file: " <> pretty e
   TxCmdGenesisDataError genesisDataError ->
     "Error while reading Byron genesis data: " <> pshow (toLazyText $ build genesisDataError)
+  TxCmdPlutusScriptsRequireProtocolParams ->
+    mconcat
+      [ "Transaction uses Plutus scripts but no protocol parameters were provided. "
+      , "Please provide protocol parameters via --protocol-params-file so that the "
+      , "script integrity hash (script_data_hash) can be computed."
+      ]
   LostScriptWitnesses before after ->
     mconcat
       [ "Some Plutus script witnesses were lost during transaction processing. "


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    build-raw now errors when Plutus script witnesses are present but
    --protocol-params-file is not supplied. Previously, it silently omitted
    the script_data_hash (field 11), producing an invalid transaction body.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes #1363.

`build-raw` accepts Plutus reference script flags (`--spending-tx-in-reference`, etc.) but does not compute the `script_data_hash` when `--protocol-params-file` is omitted. The hash computation in `makeUnsignedTx` → `convPParamsToScriptIntegrityHash` short-circuits to `SNothing` when protocol params are `Nothing`, producing a transaction body the ledger rejects.

This PR adds a check in `runTxBuildRaw` that detects Plutus script witnesses across all witness sources (spending, minting, certificates, withdrawals, voting, proposals) and errors with a clear message if protocol parameters are missing.

# How to trust this PR

- The check runs after `constructTxBodyContent` succeeds but before `makeUnsignedTx`, so it doesn't affect the happy path where protocol params are supplied.
- `transaction build` always requires protocol params, so this only affects `build-raw`.
- A cardano-node integration test for `build-raw` with reference scripts is being added separately.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Self-reviewed the diff