### PR TITLE
Bump cardano-api to 11.0.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2026-04-16T00:15:23Z
-  , cardano-haskell-packages 2026-04-15T11:20:53Z
+  , cardano-haskell-packages 2026-04-30T13:08:25Z
 
 active-repositories:
   , :rest

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -242,7 +242,7 @@ library
     binary,
     bytestring,
     canonical-json,
-    cardano-api ^>=10.26,
+    cardano-api ^>=11.0,
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class ^>=2.3,

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
@@ -542,7 +542,10 @@ runTransactionBuildEstimateCmd -- TODO change type
             (anyAddressInShelleyBasedEra sbe changeAddr)
             (obtainCommonConstraints currentEra $ toLedgerValue (convert currentEra) totalUTxOValue)
 
-    let unsignedTx = Exp.makeUnsignedTx currentEra balancedTxBody
+    unsignedTx <-
+      fromEitherCli $
+        first TxCmdMakeUnsignedTxError $
+          Exp.makeUnsignedTx currentEra balancedTxBody
     fromEitherIOCli
       $ ( if isCborOutCanonical == TxCborCanonical
             then writeTxFileTextEnvelopeCanonical
@@ -808,7 +811,7 @@ runTxBuildRaw
         mTreasuryDonation
         suppDatums
 
-    return $ Exp.makeUnsignedTx Exp.useEra txBodyContent
+    first TxCmdMakeUnsignedTxError $ Exp.makeUnsignedTx Exp.useEra txBodyContent
 
 constructTxBodyContent
   :: forall era

--- a/cardano-cli/src/Cardano/CLI/Type/Error/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/TxCmdError.hs
@@ -71,6 +71,7 @@ data TxCmdError
   | -- Validation errors
     forall era. TxCmdVotingError (TxVotingError era)
   | forall era. TxCmdFeeEstimationError (Exp.TxFeeEstimationError era)
+  | TxCmdMakeUnsignedTxError !Exp.MakeUnsignedTxError
   | TxCmdPoolMetadataHashError Exp.AnchorDataFromCertificateError
   | TxCmdHashCheckError L.Url HashCheckError
   | TxCmdUnregisteredStakeAddress !(Set StakeCredential)
@@ -169,6 +170,8 @@ renderTxCmdError = \case
   TxCmdVotingError e ->
     prettyError e
   TxCmdFeeEstimationError e ->
+    prettyError e
+  TxCmdMakeUnsignedTxError e ->
     prettyError e
   TxCmdPoolMetadataHashError e ->
     "Hash of the pool metadata hash is not valid:" <+> prettyError e

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
@@ -159,6 +159,8 @@ hprop_golden_view_babbage_yaml =
           , inputDir </> "alonzo/scripts/mint.all"
           , "--mint-script-file"
           , inputDir </> "alonzo/scripts/mint.sig"
+          , "--protocol-params-file"
+          , "test/cardano-cli-golden/files/input/transaction/calculate-min-fee/protocol-params-preview.json"
           , "--out-file"
           , transactionBodyFile
           ]

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Transaction/Build.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Transaction/Build.hs
@@ -143,6 +143,8 @@ hprop_conway_calculate_plutus_script_cost_offline =
         , "addr_test1wqvxuvh64q9zdqgrjt76d42eclk5wgdxtnsun4808cwg0dqxy2mj0+1000000"
         , "--fee"
         , "200000"
+        , "--protocol-params-file"
+        , "test/cardano-cli-test/files/input/calculate-min-fee/offline-protocol-params-preview.json"
         , "--out-file"
         , unsignedTx
         ]

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1776254461,
-        "narHash": "sha256-kB2azmnVPcQ4pFBvXCc3iKlMuoLsaPRbVP0LfD5j2Zg=",
+        "lastModified": 1777581742,
+        "narHash": "sha256-tvS+sD3FRG621hvRsmF2QpyIwkk5dtopA6ejnO6bMrk=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "d8156d61840f90f0721c396f0598652f7aaf402a",
+        "rev": "20e9dea177c8a003436eda8c59311c2dcd558ffc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Bump `cardano-api` to `11.0.0.0` and adapt to the new `Either MakeUnsignedTxError (UnsignedTx ...)` return of `Exp.makeUnsignedTx` ([cardano-api#1181](https://github.com/IntersectMBO/cardano-api/pull/1181)).
- Add a `TxCmdMakeUnsignedTxError` constructor to `TxCmdError` so the error surfaces via the existing `fromEitherCli`/`firstExceptT` idioms; update the two call sites in `EraBased.Transaction.Run`.
- Provide `--protocol-params-file` in two `build-raw` tests with Plutus scripts. `makeUnsignedTx` now errors when Plutus scripts are present but protocol parameters are missing instead of silently omitting `script_data_hash`, so the existing tests need to point at the `offline-protocol-params-preview.json` fixture already used by the rest of the module.
- Bump the `cardano-haskell-packages` `index-state` to pick up `cardano-api-11.0.0.0` from CHaP ([cardano-haskell-packages#1358](https://github.com/IntersectMBO/cardano-haskell-packages/pull/1358)).

# Changelog

```yaml
- description: |
    Bump `cardano-api` to 11.0.0.0. Adapt to the new `Either MakeUnsignedTxError (UnsignedTx ...)` return of `Exp.makeUnsignedTx` and surface the error via a new `TxCmdMakeUnsignedTxError` constructor.
  type:
    # - feature        # introduces a new feature
    # - breaking       # the API has changed in a breaking way
    # - compatible     # the API has changed but is non-breaking
    # - optimisation   # measurable performance improvements
    # - refactoring    # QoL changes
    # - bugfix         # fixes a defect
    # - test           # fixes/modifies tests
    - maintenance    # not directly related to the code
    # - release        # related to a new release preparation
    # - documentation  # change in code docs, haddocks...
```