### PR TITLE
Release cardano-cli-11.0.0.0

### DIFF
--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for cardano-cli
 
+## 11.0.0.0
+
+- Bump `cardano-api` to `11.0.0.0`. Adapt to the new `Either MakeUnsignedTxError (UnsignedTx ...)` return of `Exp.makeUnsignedTx` and surface the error via a new `TxCmdMakeUnsignedTxError` constructor on `TxCmdError`.
+  (maintenance)
+  [PR 1370](https://github.com/IntersectMBO/cardano-cli/pull/1370)
+
+- Support ghc-9.14
+  (maintenance)
+  [PR 1365](https://github.com/IntersectMBO/cardano-cli/pull/1365)
+
 ## 10.16.0.0
 
 - Added support for generating proofs of possession for BLS keys.

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.8
 name: cardano-cli
-version: 10.16.0.0
+version: 11.0.0.0
 synopsis: The Cardano command-line interface
 description: The Cardano command-line interface.
 copyright: 2020-2023 Input Output Global Inc (IOG).


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Release cardano-cli-11.0.0.0
  type:
    - release        # related to a new release preparation
```

# Context

This release adopts `cardano-api-11.0.0.0` (a major dependency bump — see [PR #1370](https://github.com/IntersectMBO/cardano-cli/pull/1370)) and adds support for ghc-9.14 ([PR #1365](https://github.com/IntersectMBO/cardano-cli/pull/1365)).

Corresponding CHaP PR: https://github.com/IntersectMBO/cardano-haskell-packages/pull/1359

# How to trust this PR

- Diff is metadata-only: cabal version bump (`10.16.0.0` → `11.0.0.0`) and a new `## 11.0.0.0` section in `cardano-cli/CHANGELOG.md`.
- `cabal build cardano-cli -j4` was run locally on the release branch and built clean against the post-#1370 master.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Self-reviewed the diff