### PR TITLE
Remove --update-proposal-file CLI flag and dead TxUpdateProposal threading

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
@@ -89,7 +89,6 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   -- ^ Auxiliary scripts
   , metadataFiles :: ![MetadataFile]
   , mProtocolParamsFile :: !(Maybe ProtocolParamsFile)
-  , mUpdateProprosalFile :: !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
   , voteFiles :: ![(VoteFile In, Maybe AnyNonAssetScript)]
   , proposalFiles :: ![(ProposalFile In, Maybe AnyNonAssetScript)]
   , mCurrentTreasuryValue :: !(Maybe TxCurrentTreasuryValue)
@@ -162,7 +161,6 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   , scriptFiles :: ![ScriptFile]
   -- ^ Auxiliary scripts
   , metadataFiles :: ![MetadataFile]
-  , mUpdateProposalFile :: !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
   , voteFiles :: ![(VoteFile In, Maybe AnyNonAssetScript)]
   , proposalFiles :: ![(ProposalFile In, Maybe AnyNonAssetScript)]
   , includeCurrentTreasuryValue :: !IncludeCurrentTreasuryValue

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
@@ -219,7 +219,6 @@ pTransactionBuildCmd envCli = do
               "Filepath of auxiliary script(s)"
           )
         <*> many pMetadataFile
-        <*> pFeatured era' (optional pUpdateProposalFile)
         <*> pVoteFiles AutoBalance
         <*> pProposalFiles AutoBalance
         <*> pIncludeCurrentTreasuryValue
@@ -323,7 +322,6 @@ pTransactionBuildRaw =
       <*> many (pScriptFor "auxiliary-script-file" Nothing "Filepath of auxiliary script(s)")
       <*> many pMetadataFile
       <*> optional pProtocolParamsFile
-      <*> pFeatured Exp.useEra (optional pUpdateProposalFile)
       <*> pVoteFiles ManualBalance
       <*> pProposalFiles ManualBalance
       <*> pCurrentTreasuryValue

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
@@ -151,7 +151,6 @@ runTransactionBuildCmd
     , metadataSchema
     , scriptFiles
     , metadataFiles
-    , mUpdateProposalFile
     , voteFiles
     , proposalFiles
     , includeCurrentTreasuryValue
@@ -195,11 +194,6 @@ runTransactionBuildCmd
       mapM (readFileScriptInAnyLang . unFile) scriptFiles
     txAuxScripts <-
       fromEitherCli $ validateTxAuxScripts scripts
-
-    mProp <- case mUpdateProposalFile of
-      Just (Featured w (Just updateProposalFile)) ->
-        readTxUpdateProposal w updateProposalFile & fromExceptTCli
-      _ -> pure TxUpdateProposalNone
 
     requiredSigners <-
       mapM (fromEitherIOCli . readRequiredSigner) reqSigners
@@ -315,7 +309,6 @@ runTransactionBuildCmd
           requiredSigners
           txAuxScripts
           txMetadata
-          mProp
           mOverrideWitnesses
           votingProceduresAndMaybeScriptWits
           proposals
@@ -621,7 +614,6 @@ runTransactionBuildRawCmd
     , scriptFiles
     , metadataFiles
     , mProtocolParamsFile
-    , mUpdateProprosalFile
     , voteFiles
     , proposalFiles
     , mCurrentTreasuryValue
@@ -655,12 +647,6 @@ runTransactionBuildRawCmd
       fromExceptTCli (readProtocolParameters ppf)
 
     let mLedgerPParams = LedgerProtocolParameters <$> pparams
-
-    -- TODO: Remove me as update proposals are deprecated since Conway (replaced with proposals)
-    _txUpdateProposal <- case mUpdateProprosalFile of
-      Just (Featured w (Just updateProposalFile)) ->
-        fromExceptTCli $ readTxUpdateProposal w updateProposalFile
-      _ -> pure TxUpdateProposalNone
 
     requiredSigners <-
       mapM (fromEitherIOCli . readRequiredSigner) reqSigners
@@ -1003,7 +989,6 @@ runTxBuild
   -- ^ Required signers
   -> TxAuxScripts era
   -> TxMetadataInEra era
-  -> TxUpdateProposal era
   -> Maybe Word
   -> [(VotingProcedures era, Exp.AnyWitness (Exp.LedgerEra era))]
   -> [(Proposal era, Exp.AnyWitness (Exp.LedgerEra era))]
@@ -1032,7 +1017,6 @@ runTxBuild
   reqSigners
   txAuxScripts
   txMetadata
-  _txUpdateProposal -- TODO: Remove this parameter
   mOverrideWits
   votingProcedures
   proposals


### PR DESCRIPTION
## Summary

Removes the deprecated `--update-proposal-file` flag from the era-based `transaction build` and `transaction build-raw` commands, plus the dead internal `TxUpdateProposal` plumbing it was wired into. Update proposals are deprecated since Conway (replaced by governance proposals); the read value was already being discarded inside `runTxBuild`, so the flag was effectively a no-op.

**Two commits, intended to be reviewable in order:**

1. **Remove unused `TxUpdateProposal` threading from build/build-raw** — pure dead-code removal: drops the `_txUpdateProposal` bind, the unused `runTxBuild` parameter, and the matching field destructures. No CLI change.
2. **Drop `--update-proposal-file` from era-based transaction build / build-raw** — removes the parser hookups and the `mUpdateProposalFile` / `mUpdateProprosalFile` record fields from `TransactionBuildCmdArgs` / `TransactionBuildRawCmdArgs`. **CLI breaking** for any script that was passing the flag, though the flag was a no-op for Conway+ already (the `Featured ShelleyToBabbageEra` constraint excluded it from `--help` for those eras).

**Out of scope:** `compatible <era> transaction signed-transaction` keeps `--update-proposal-file`, since pre-Conway eras still genuinely use it. Byron's separate `--byron-update-proposal` and `create-/submit-update-proposal` commands are also untouched.

## How to trust this PR

- `cabal build cardano-cli -j4` is clean
- `cabal test cardano-cli-golden -j4` passes (695/695, including all `--help` goldens)
- `cabal test cardano-cli-test -j4` passes (69/69)
- Manually verified: `cardano-cli latest transaction build-raw --help` no longer mentions `update-proposal`; `cardano-cli compatible babbage transaction signed-transaction --help` still does

# Changelog

```yaml
- description: |
    Remove the deprecated `--update-proposal-file` flag from era-based
    `transaction build` and `transaction build-raw`. Update proposals are
    deprecated since Conway and the flag was already a no-op for Conway+.
    The flag is kept for `compatible <era> transaction signed-transaction`
    where pre-Conway eras still need it.
  type:
    - breaking
```