### PR TITLE
Bump dependency and require aeson >= 2.3

### DIFF
--- a/.changes/20260702_updates.yml
+++ b/.changes/20260702_updates.yml
@@ -1,0 +1,31 @@
+# Changelog fragment template - copy this file and fill in the fields.
+# Or use 'herald new' for interactive creation.
+#
+# Files starting with _ are ignored by herald.
+#
+# Available projects and kinds are defined in .herald.yml
+
+# Which project this change belongs to (see 'projects' in .herald.yml)
+# Uncomment exactly one:
+project: cardano-cli
+# project: cardano-api-gen
+# project: cardano-rpc
+# project: cardano-wasm
+
+# Pull request number associated with this change
+pr: 1394
+
+# One or more change kinds (see 'kinds' in .herald.yml)
+kind:
+#   - breaking       # the API has changed in a breaking way
+#   - feature        # introduces a new feature
+#   - compatible     # the API has changed but is non-breaking
+#   - bugfix         # fixes a defect
+#   - optimisation   # measurable performance improvements
+#   - documentation  # change in code docs, haddocks
+#   - refactoring    # code quality improvements
+#   - test           # fixes or modifies tests
+   - maintenance    # not directly related to the code
+#   - release        # related to a new release preparation
+description: |
+  Update dependencies, increase lower bound of aeson dependency.

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2026-06-02T21:49:32Z
-  , cardano-haskell-packages 2026-06-02T21:14:32Z
+  , hackage.haskell.org 2026-07-02T00:02:36Z
+  , cardano-haskell-packages 2026-06-29T12:05:19Z
 
 active-repositories:
   , :rest

--- a/cabal.project
+++ b/cabal.project
@@ -83,11 +83,11 @@ if impl(ghc >= 9.14)
     , cborg:containers
     , cborg-json:base
     , compact:base
+    , data-elevator:base
     , dependent-map:containers
     , dictionary-sharing:containers
     , diff-containers:base
     , fs-sim:QuickCheck
-    , lsm-tree:data-elevator
     , ordered-containers:containers
     , partial-order:containers
     , safe-wild-cards:template-haskell

--- a/cabal.project
+++ b/cabal.project
@@ -74,6 +74,17 @@ write-ghc-environment-files: always
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
 
+-- Needed for the aeson >= 2.3 dependency.
+allow-newer:
+  , cborg-json:aeson
+  , deriving-aeson:aeson
+  , grapesy:aeson
+  , grpc-spec:aeson
+  , hedgehog-extras:aeson
+  , microstache:aeson
+  , http-api-data:text-iso8601
+  , vary:aeson
+
 -- cabal-allow-newer begin
 if impl(ghc >= 9.14)
   allow-newer:

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -233,7 +233,7 @@ library
   autogen-modules: Paths_cardano_cli
   build-depends:
     -- TODO: bump consensus back
-    aeson >=1.5.6.0,
+    aeson >=2.3,
     aeson-pretty >=0.8.5,
     ansi-terminal,
     attoparsec,
@@ -433,7 +433,7 @@ test-suite cardano-cli-golden
   main-is: cardano-cli-golden.hs
   type: exitcode-stdio-1.0
   build-depends:
-    aeson >=1.5.6.0,
+    aeson >=2.3,
     base16-bytestring,
     bytestring,
     cardano-api:{cardano-api, gen},

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1780436322,
-        "narHash": "sha256-3YDsDhjAcm5QatdluTKuQ9WeDdwrxZMnKH587pVyv9o=",
+        "lastModified": 1782769557,
+        "narHash": "sha256-tCYMTwH15mNajHybvC3KGVPBPMlLlqIOYE0ZgcqRkJU=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "bc93f1caabfdc4d38c5b44e6eea8f5b8f535775a",
+        "rev": "3ee6b1ecce230d62f0083590f38c4ae3457da226",
         "type": "github"
       },
       "original": {
@@ -209,11 +209,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1780437449,
-        "narHash": "sha256-DhOIrGPtRfqqYjKhO8ETnKLhcuPAnPHx1iUoWoyGw4Y=",
+        "lastModified": 1782962365,
+        "narHash": "sha256-60rASaqJX9GbdbbHappidbeH8kSxWYF9LvxK9u2A/Is=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "c791c3f52a6985d49316d1f76317ed36d7f0a915",
+        "rev": "f4163dbd37cd4000a755bd242df326e7870c1b88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Context

* Update cabal.project index-states
* Update cabal.project allow-newers
* Require `aeson >= 2.3` to prevent potential DoS attack.

# How to trust this PR

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
