### PR TITLE
Remove x86_64-darwin from release-upload workflow

### DIFF
--- a/.github/workflows/release-upload.yml
+++ b/.github/workflows/release-upload.yml
@@ -8,7 +8,7 @@ name: Release Upload
 #    the tag for which we want to release. If the status is success, the pipeline
 #    continues. If the status cannot be determined or is a failure, the pipeline stops.
 # 2. The "pull" job downloads the binaries from the Hydra build and uploads them as artifacts.
-#    This job uses a matrix to handle all 3 platforms. Uploading as an artifact allows to
+#    This job uses a matrix to handle all supported platforms. Uploading as an artifact allows to
 #    do the last job without a matrix.
 #
 #    This job uses `--builders "" --max-jobs 0` to ensure the assets are downloaded
@@ -135,7 +135,7 @@ jobs:
     strategy:
       matrix:
         # TODO generalize
-        arch: [x86_64-linux, x86_64-darwin, aarch64-darwin, aarch64-linux, win64]
+        arch: [x86_64-linux, aarch64-darwin, aarch64-linux, win64]
     name: "Download Asset"
     runs-on: ubuntu-latest
     steps:
@@ -155,7 +155,7 @@ jobs:
         run: |
           derivation="hydraJobs."
           case ${{ matrix.arch }} in
-            "x86_64-darwin" | "aarch64-darwin")
+            "aarch64-darwin")
               derivation+="${{ matrix.arch }}"
               ;;
             "x86_64-linux")
@@ -204,7 +204,7 @@ jobs:
           # (2)
           # TARGET_TAG is of the form cardano-cli-8.22.0, so we don't need to prefix the tar.gz's name
           # with cardano-cli
-          for arch in x86_64-linux x86_64-darwin aarch64-darwin aarch64-linux; do
+          for arch in x86_64-linux aarch64-darwin aarch64-linux; do
             tar -czf ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-$arch.tar.gz cardano-cli-$arch
           done
           # TODO generalize
@@ -212,7 +212,7 @@ jobs:
       - name: Checksums
         run: |
           # (3)
-          for arch in x86_64-linux x86_64-darwin aarch64-darwin aarch64-linux; do
+          for arch in x86_64-linux aarch64-darwin aarch64-linux; do
             sha256sum ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-$arch.tar.gz >> ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-sha256sums.txt
           done
           sha256sum ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-win64.zip >> ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-sha256sums.txt
@@ -237,7 +237,6 @@ jobs:
           # All entries in 'files' below should match (2) and (3)
           files: |
             ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-x86_64-linux.tar.gz
-            ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-x86_64-darwin.tar.gz
             ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-aarch64-darwin.tar.gz
             ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-aarch64-linux.tar.gz
             ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-win64.zip


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove x86_64-darwin from the release-upload workflow; support for it was dropped from the flake in 26b9be512
  type:
    # - feature        # introduces a new feature
    # - breaking     # the API has changed in a breaking way
    # - compatible   # the API has changed but is non-breaking
    # - optimisation # measurable performance improvements
    # - refactoring  # QoL changes
    # - bugfix       # fixes a defect
    # - test         # fixes/modifies tests
    - maintenance  # not directly related to the code
    # - release      # related to a new release preparation
    # - documentation # change in code docs, haddocks...
```

# Context

Commit 26b9be512 ("drop support for x86_64-darwin", April 2026) removed `x86_64-darwin` from the flake's `supportedSystems`, but the `Release Upload` workflow still listed it in its download matrix. Every run since then fails in `Download Asset (x86_64-darwin)` with:

```
error: flake '...' does not provide attribute 'hydraJobs.x86_64-darwin.packages.cardano-cli:exe:cardano-cli'
```

which cancels the remaining downloads and skips `Create Release`. This is why there is no GitHub release for 11.1.0.0 (run 26503541162 and the re-run 31538755892 both failed this way), and it would break the upcoming 11.2.0.0 upload as well.

This removes `x86_64-darwin` from the matrix, the tar/checksum loops, and the release file list.

# How to trust this PR

Compare with `supportedSystems` in `flake.nix` (x86_64-linux, aarch64-linux, aarch64-darwin) plus the win64 cross-build. After merging, `gh workflow run "Release Upload" -f target_tag=cardano-cli-11.1.0.0` (and the same for 11.2.0.0) should succeed and publish the GitHub releases.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Self-reviewed the diff