### PR TITLE
Bump CHaP index-state to use latest cardano-api revision and ouroboros-consensus 4.1.0.0

### DIFF
--- a/.changes/20260812_011204_cardano-cli_kolam_prepare_11_1_fixup.yml
+++ b/.changes/20260812_011204_cardano-cli_kolam_prepare_11_1_fixup.yml
@@ -1,0 +1,6 @@
+description: Bump CHaP index-state to use cardano-api 11.4 revision and ouroboros-consensus
+  4.1.0.0
+kind:
+- maintenance
+pr: 1412
+project: cardano-cli

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2026-07-30T07:30:12Z
-  , cardano-haskell-packages 2026-08-06T18:32:54Z
+  , cardano-haskell-packages 2026-08-11T14:53:43Z
 
 packages:
   cardano-cli

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1786065508,
-        "narHash": "sha256-pRediX5ChK+Y8Rtv9eLFke9X+amQjw72vMjvFYybKLo=",
+        "lastModified": 1786489982,
+        "narHash": "sha256-T0r6CvdSEDxszlb7uK7mxEVZcCtFNbk8tlr8B1bRKqM=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "062846be4a5a0c88b87d7b94b7e23bd79bbf7e7d",
+        "rev": "13d0f23cf6af9ea55194b91f6947c0a2aeb522d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION

<!--
Every PR needs a changelog fragment in `.changes/`.
Create one from the template at .changes/_TEMPLATE.yml, or use `herald` for interactive creation.
Run herald with nix: nix run github:input-output-hk/cardano-dev#herald

Interactive:
  herald new

Non-interactive:
  herald new -p cardano-cli -k bugfix -d "Fix something" --pr 1234

See .herald.yml for full configuration.
-->

# Context

Bump CHaP index-state to use latest cardano-api revision and ouroboros-consensus 4.1.0.0