### PR TITLE
Bump cardano-api to 11.5

### DIFF
--- a/.changes/20260817_090828_cardano-cli_mateusz.galazyn.yml
+++ b/.changes/20260817_090828_cardano-cli_mateusz.galazyn.yml
@@ -1,0 +1,5 @@
+description: Bump cardano-api to 11.5, bump CHaP index-state, fix byronGenesis name-shadowing warning
+kind:
+- compatible
+pr: 1418
+project: cardano-cli

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2026-07-30T07:30:12Z
-  , cardano-haskell-packages 2026-08-11T14:53:43Z
+  , cardano-haskell-packages 2026-08-17T09:19:44Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -243,7 +243,7 @@ library
     binary,
     bytestring,
     canonical-json,
-    cardano-api ^>=11.4,
+    cardano-api ^>=11.5,
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class ^>=2.5,

--- a/cardano-cli/src/Cardano/CLI/Legacy/Genesis/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Genesis/Run.hs
@@ -190,7 +190,7 @@ runLegacyGenesisCreateCardanoCmd
   slotLength
   slotCoeff
   network
-  byronGenesis
+  byronGenesisTemplate
   shelleyGenesis
   alonzoGenesis
   conwayGenesis
@@ -207,7 +207,7 @@ runLegacyGenesisCreateCardanoCmd
         , Cmd.slotLength = slotLength
         , Cmd.slotCoeff = slotCoeff
         , Cmd.network = network
-        , Cmd.byronGenesisTemplate = byronGenesis
+        , Cmd.byronGenesisTemplate = byronGenesisTemplate
         , Cmd.shelleyGenesisTemplate = shelleyGenesis
         , Cmd.alonzoGenesisTemplate = alonzoGenesis
         , Cmd.conwayGenesisTemplate = conwayGenesis

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1786489982,
-        "narHash": "sha256-T0r6CvdSEDxszlb7uK7mxEVZcCtFNbk8tlr8B1bRKqM=",
+        "lastModified": 1786963065,
+        "narHash": "sha256-vrwQwlikGCvKfWaGCle7SQuL79m1FU7rScpTW4m8N2U=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "13d0f23cf6af9ea55194b91f6947c0a2aeb522d9",
+        "rev": "99e136ba50cb95e1f552a9ad7ea06bee0deb3983",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Context

Bump cardano-api dependency to 11.5 for cardano-node 11.1 integration.

# Changes

- Bump `cardano-api` dependency from `^>=11.4` to `^>=11.5`
- Bump CHaP index-state to `2026-08-17T09:19:44Z`
- Fix `-Wname-shadowing` warning: rename `byronGenesis` to `byronGenesisTemplate` in `Cardano.CLI.Legacy.Genesis.Run` to avoid shadowing the `Cardano.Api` import

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
