### PR TITLE
Raise test watchdog timeout on Windows and fix test HTTP server thread leak

### DIFF
--- a/.changes/20260818_204414_cardano-cli_mateusz.galazyn_windows_test_stability.yml
+++ b/.changes/20260818_204414_cardano-cli_mateusz.galazyn_windows_test_stability.yml
@@ -1,0 +1,6 @@
+description: |
+  Fix `serveFilesWhile` in cardano-cli-test-lib leaking its warp server thread on test completion (it was spamming garbled `Network.Socket.accept: failed (Unknown WinSock error: 995)` noise into Hydra's Windows/Wine cross-compile test logs), raise the test watchdog timeout from 20s to 35s on Windows to account for slower Wine emulation on Hydra (the root cause of recent flaky release-blocking CI failures), and wrap `hprop_check_node_configuration_failure` with the previously missing `watchdogProp`.
+kind:
+- test
+pr: 1421
+project: cardano-cli

--- a/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Hash.hs
+++ b/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Hash.hs
@@ -16,9 +16,8 @@ where
 
 import Cardano.Api (MonadIO)
 
-import Control.Concurrent (forkOS)
+import Control.Concurrent (forkOS, killThread)
 import Control.Exception.Lifted (bracket)
-import Control.Monad (void)
 import Control.Monad.Trans.Control (MonadBaseControl)
 import Data.ByteString.UTF8 qualified as BSU8
 import Data.Char (toLower)
@@ -38,7 +37,12 @@ import Network.Wai
   , responseFile
   , responseLBS
   )
-import Network.Wai.Handler.Warp (defaultSettings, openFreePort, runSettingsSocket)
+import Network.Wai.Handler.Warp
+  ( defaultSettings
+  , openFreePort
+  , runSettingsSocket
+  , setOnException
+  )
 
 import Hedgehog as H
 import Hedgehog.Internal.Source (HasCallStack)
@@ -104,13 +108,18 @@ serveFilesWhile relativeUrls action =
                       fromString ("404 - Url \"" ++ urlFromRequest req ++ "\" - Not Found")
 
         -- Run server asynchronously in a separate thread
-        void $ H.evalIO $ forkOS $ runSettingsSocket defaultSettings socket app
-        return (port, socket)
+        -- Silence exceptions: we don't care about warp errors in these tests
+        let settings = setOnException (\_ _ -> pure ()) defaultSettings
+        tid <- H.evalIO $ forkOS $ runSettingsSocket settings socket app
+        return (port, socket, tid)
     )
     -- Server teardown (resource release)
-    (\(_, socket) -> H.evalIO $ close socket)
+    ( \(_, socket, tid) -> H.evalIO $ do
+        close socket
+        killThread tid
+    )
     -- Test action
-    (\(port, _) -> action port)
+    (\(port, _, _) -> action port)
  where
   urlFromRequest :: Request -> String
   urlFromRequest req =

--- a/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
+++ b/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
@@ -54,6 +54,7 @@ import System.Process qualified as IO
 import Hedgehog qualified as H
 import Hedgehog.Extras (ExecConfig)
 import Hedgehog.Extras qualified as H
+import Hedgehog.Extras.Stock.OS (isWin32)
 import Hedgehog.Extras.Test (ExecConfig (..))
 import Hedgehog.Internal.Property (Diff, MonadTest, Property (..), liftTest, mkTest)
 import Hedgehog.Internal.Property qualified as H
@@ -362,4 +363,6 @@ redactJsonField fieldName replacement sourceFilePath targetFilePath = GHC.withFr
 watchdogProp :: HasCallStack => H.Property -> H.Property
 watchdogProp prop@Property{propertyTest} = prop{propertyTest = H.runWithWatchdog_ cfg propertyTest}
  where
-  cfg = H.WatchdogConfig{H.watchdogTimeout = 20}
+  -- Windows tests run under Wine emulation on Hydra and are much slower,
+  -- so give them a longer timeout
+  cfg = H.WatchdogConfig{H.watchdogTimeout = if isWin32 then 35 else 20}

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/CheckNodeConfiguration.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/CheckNodeConfiguration.hs
@@ -58,7 +58,7 @@ hprop_check_node_configuration_failure = do
         , fiddleKind <- [minBound .. maxBound]
         ]
 
-  propertyOnce $ forM_ supplyValues $ \(nodeConfigPath, fiddleKind) -> H.moduleWorkspace "tmp" $ \tempDir -> do
+  watchdogProp . propertyOnce $ forM_ supplyValues $ \(nodeConfigPath, fiddleKind) -> H.moduleWorkspace "tmp" $ \tempDir -> do
     let finalInputConfig = tempDir </> "node-config-changed.json"
         -- TODO why is that writing to "AlonzoGenesisHash" writes one more 0 than specified here? (and hence the need for this hack)
         wrongHash = Text.pack $ replicate (case fiddleKind of FiddleByron -> 65; FiddleNonByron -> 64) '0'


### PR DESCRIPTION
# Context

The Windows cross-compiled test suites run under Wine on Hydra and are far slower than native runs.
The median test is about 17x slower, and the same test can take over 3x longer from one run to the next depending on machine load.
The test watchdog's hardcoded 20 second timeout sits inside that noise band: it killed tests that were still making progress at up to 29.7 seconds, which blocked the 11.1.0.0 to 11.2.1.0 release uploads and threw #1411 out of the merge queue.

Three changes:

- `watchdogProp` now uses a 35 second timeout on Windows and keeps 20 seconds everywhere else.
  The number is measured, not guessed: the slowest test's mean plus one standard deviation is 27.4s, and the watchdog itself fires up to several seconds late under load (mean plus one sigma: 5.6s), giving 33s, rounded up to 35.
- `serveFilesWhile` no longer leaks its warp server thread.
  Teardown used to close the listening socket and leave the thread alive; the orphaned accept loop then spammed `Network.Socket.accept: failed (Unknown WinSock error: 995)` into the test output for the rest of the run.
  Teardown now closes the socket first to unblock the foreign accept call, then kills the thread.
  Warp's exception printer is silenced for this throwaway fixture.
- `hprop_check_node_configuration_failure` gets the `watchdogProp` wrapper it was missing, so it can no longer hang without bound.

# How to trust this PR

The timeout figure comes from 13 live Hydra execution logs (2434 per-test duration records) covering both test suites and both mingw32 GHC variants.
The slowest legitimate pass observed under Wine is 21.2s, and tests were killed while still progressing at 29.7s, so 20s is provably too tight; 35s clears every observed pass.
Example failing builds: [14173682](https://ci.iog.io/build/14173682) (the 11.2.1.0 tag) and [14199317](https://ci.iog.io/build/14199317) (the #1411 merge queue run).
To see the thread leak, grep either log for `WinSock error` - the messages are character-interleaved into other tests' output because they come from a concurrent orphaned thread.
With this change they are gone.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
- [ ] Changelog fragment added in `.changes/`
