### PR TITLE
Bump cardano-api to 11.6.0.0

### DIFF
--- a/.changes/20260825_164537_cardano-cli_mateusz.galazyn_bump_cardano_api_11_6_0_0.yml
+++ b/.changes/20260825_164537_cardano-cli_mateusz.galazyn_bump_cardano_api_11_6_0_0.yml
@@ -1,0 +1,6 @@
+project: cardano-cli
+pr: 1424
+kind:
+  - compatible
+description: |
+  Bump cardano-api to 11.6.0.0.

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2026-07-30T07:30:12Z
-  , cardano-haskell-packages 2026-08-17T09:19:44Z
+  , cardano-haskell-packages 2026-08-25T14:04:50Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -246,7 +246,7 @@ library
     binary,
     bytestring,
     canonical-json,
-    cardano-api ^>=11.5,
+    cardano-api ^>=11.6,
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class ^>=2.5,

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/TxOut.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/TxOut.hs
@@ -78,6 +78,17 @@ mkTxOut sbe addr val' mDatumAnyEra refScriptFp = do
                   )
               , suppl
               )
+          ShelleyBasedEraDijkstra -> do
+            (dat, suppl) <- babbageDatumFields mDatumAnyEra
+            refScript <- readRefScript sbe refScriptFp
+            pure
+              ( Exp.TxOut
+                  ( L.mkBasicTxOut ledgerAddr ledgerVal
+                      & L.datumTxOutL .~ dat
+                      & L.referenceScriptTxOutL .~ refScript
+                  )
+              , suppl
+              )
 
 alonzoDatumFields
   :: L.Era ledgerera

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -669,6 +669,7 @@ Usage: cardano-cli legacy genesis create
                                            | --alonzo
                                            | --babbage
                                            | --conway
+                                           | --dijkstra
                                            )
                                            [ --key-output-bech32
                                            | --key-output-text-envelope

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create.cli
@@ -5,6 +5,7 @@ Usage: cardano-cli legacy genesis create
                                            | --alonzo
                                            | --babbage
                                            | --conway
+                                           | --dijkstra
                                            )
                                            [ --key-output-bech32
                                            | --key-output-text-envelope
@@ -28,6 +29,7 @@ Available options:
   --alonzo                 Specify the Alonzo era
   --babbage                Specify the Babbage era
   --conway                 Specify the Conway era
+  --dijkstra               Specify the Dijkstra era
   --key-output-bech32      Format key output to BECH32.
   --key-output-text-envelope
                            Format key output to TEXT_ENVELOPE (default).

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1786963065,
-        "narHash": "sha256-vrwQwlikGCvKfWaGCle7SQuL79m1FU7rScpTW4m8N2U=",
+        "lastModified": 1787668218,
+        "narHash": "sha256-cbK37n9b3BJYvQLkYhA5UBrxkvvI0EIjfYdr104fKwQ=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "99e136ba50cb95e1f552a9ad7ea06bee0deb3983",
+        "rev": "7cbe1ae014c0eafb0da35d9b4294c1cab0af7d1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Context

Bump the `cardano-api` dependency to 11.6.0.0.

See the [cardano-api 11.6.0.0 release notes](https://github.com/IntersectMBO/cardano-api/releases/tag/cardano-api-11.6.0.0) for details.

# How to trust this PR

CI building against cardano-api 11.6.0.0 across the GHC matrix, plus the existing test suites, cover this change.

# Changes

- Bump `cardano-api` dependency from `^>=11.5` to `^>=11.6` in `cardano-cli.cabal`
- Bump the CHaP index-state in `cabal.project` to `2026-08-25T14:04:50Z`
- Bump the CHaP flake input in `flake.lock` accordingly
- Add a `ShelleyBasedEraDijkstra` arm to `mkTxOut` in `cardano-cli/src/Cardano/CLI/Compatible/Transaction/TxOut.hs`, mirroring the existing Conway arm: cardano-api 11.6.0.0 completes the Dijkstra era wiring, which turned this era match into a non-exhaustive pattern under `-Werror`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
