### PR TITLE
Derive the accepted era list when reading transaction witnesses

### DIFF
--- a/.changes/20260827_111653_cardano-cli_palas_accept_newer_era_witnesses.yml
+++ b/.changes/20260827_111653_cardano-cli_palas_accept_newer_era_witnesses.yml
@@ -1,0 +1,6 @@
+description: |
+  Fixed `transaction assemble` (also known as `transaction sign-witness`) rejecting witness files from eras after Conway: witness files from every supported era, including Dijkstra, are now accepted.
+kind:
+- bugfix
+pr: 1426
+project: cardano-cli

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -341,7 +341,16 @@ readFileTxKeyWitness
   -> IO (Either (FileError TextEnvelopeError) (InAnyShelleyBasedEra KeyWitness))
 readFileTxKeyWitness fp = do
   file <- fileOrPipe fp
-  readFileInAnyShelleyBasedEra AsKeyWitness file
+  readFileOrPipeTextEnvelopeAnyOf fromSomeShelleyTxWitness file
+
+fromSomeShelleyTxWitness :: [FromSomeType HasTextEnvelope (InAnyShelleyBasedEra KeyWitness)]
+fromSomeShelleyTxWitness =
+  [ shelleyBasedEraConstraints sbe $ FromSomeType (makeWitnessProxy sbe) (InAnyShelleyBasedEra sbe)
+  | AnyShelleyBasedEra sbe <- [minBound .. maxBound]
+  ]
+ where
+  makeWitnessProxy :: HasTypeProxy era => ShelleyBasedEra era -> AsType (KeyWitness era)
+  makeWitnessProxy _ = AsKeyWitness (proxyToAsType (Proxy :: Proxy era))
 
 txWitnessTextEnvelopeTypes :: [Text]
 txWitnessTextEnvelopeTypes =
@@ -613,29 +622,6 @@ readCostModels (File fp) = do
   costModels <- firstExceptT (CostModelsErrorJSONDecode fp) . except $ Aeson.eitherDecode bytes
   when (null $ fromAlonzoCostModels costModels) $ throwE $ CostModelsErrorEmpty fp
   return costModels
-
--- Misc
-
-readFileInAnyShelleyBasedEra
-  :: ( HasTextEnvelope (thing ShelleyEra)
-     , HasTextEnvelope (thing AllegraEra)
-     , HasTextEnvelope (thing MaryEra)
-     , HasTextEnvelope (thing AlonzoEra)
-     , HasTextEnvelope (thing BabbageEra)
-     , HasTextEnvelope (thing ConwayEra)
-     )
-  => (forall era. AsType era -> AsType (thing era))
-  -> FileOrPipe
-  -> IO (Either (FileError TextEnvelopeError) (InAnyShelleyBasedEra thing))
-readFileInAnyShelleyBasedEra asThing =
-  readFileOrPipeTextEnvelopeAnyOf
-    [ FromSomeType (asThing AsShelleyEra) (InAnyShelleyBasedEra ShelleyBasedEraShelley)
-    , FromSomeType (asThing AsAllegraEra) (InAnyShelleyBasedEra ShelleyBasedEraAllegra)
-    , FromSomeType (asThing AsMaryEra) (InAnyShelleyBasedEra ShelleyBasedEraMary)
-    , FromSomeType (asThing AsAlonzoEra) (InAnyShelleyBasedEra ShelleyBasedEraAlonzo)
-    , FromSomeType (asThing AsBabbageEra) (InAnyShelleyBasedEra ShelleyBasedEraBabbage)
-    , FromSomeType (asThing AsConwayEra) (InAnyShelleyBasedEra ShelleyBasedEraConway)
-    ]
 
 -- | We need a type for handling files that may be actually be things like
 -- pipes. Currently the CLI makes no guarantee that a "file" will only


### PR DESCRIPTION
# Context

Context transaction assemble (also known as transaction sign-witness) rejected witness files from any era after Conway with a TextEnvelope type error. The reader kept a hand-written list of accepted witness types, and the list ended at Conway. 

This is #1422, and Leios testnet SPOs hit it in the wild as input-output-hk/ouroboros-leios#1061.

The fix derives the list from the api's era enumeration (the same pattern this file already uses for reading transactions: `fromSomeShelleyTx`) so new eras are accepted the moment the api exposes them, and the list cannot rot again.

Closes #1422.

### Note on tests

The end-to-end golden test (build-raw, witness, assemble in Dijkstra) arrives with the upcoming PR that enables the Dijkstra transaction commands because it cannot run before those commands exist. For every existing era the derived list is exactly the same set as the old hand-written one, and the existing suites cover that unchanged behaviour.

# How to trust this PR

It is almost a refactoring, except Dijkstra is now in the list.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`

