### PR TITLE
Support Dijkstra simple scripts read from JSON

### DIFF
--- a/.changes/20260827_121029_cardano-cli_palas_dijkstra_simple_scripts.yml
+++ b/.changes/20260827_121029_cardano-cli_palas_dijkstra_simple_scripts.yml
@@ -1,0 +1,6 @@
+description: |
+  Simple scripts read from JSON files now work in the Dijkstra era, instead of aborting with an internal TODO error.
+kind:
+- feature
+pr: 1427
+project: cardano-cli

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Read/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Read/Common.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Cardano.CLI.EraBased.Script.Read.Common
   ( -- * Plutus Script Related
@@ -40,20 +39,16 @@ readFileSimpleScript
 readFileSimpleScript file era = do
   bs <- readFileCli file
   case deserialiseFromJSON bs of
-    Left _ -> case era of
-      Exp.DijkstraEra -> Exp.obtainCommonConstraints era $ do
-        -- In addition to the TextEnvelope format, we also try to
-        -- deserialize the JSON representation of SimpleScripts.
-        script :: SimpleScript <- fromEitherCli $ Aeson.eitherDecodeStrict' bs
-        let s :: L.NativeScript (Exp.LedgerEra era) =
-              Dijkstra.upgradeTimelock (toAllegraTimelock @(Exp.LedgerEra Exp.ConwayEra) script)
-        return $ Exp.SimpleScript s
-      Exp.ConwayEra -> Exp.obtainConwayConstraints era $ do
-        -- In addition to the TextEnvelope format, we also try to
-        -- deserialize the JSON representation of SimpleScripts.
-        script :: SimpleScript <- fromEitherCli $ Aeson.eitherDecodeStrict' bs
-        let s :: L.NativeScript (Exp.LedgerEra era) = obtainCommonConstraints era $ toAllegraTimelock script
-        return $ Exp.SimpleScript s
+    Left _ -> do
+      -- In addition to the TextEnvelope format, we also try to
+      -- deserialize the JSON representation of SimpleScripts.
+      script :: SimpleScript <- fromEitherCli $ Aeson.eitherDecodeStrict' bs
+      let conwayTimelock :: L.NativeScript (Exp.LedgerEra Exp.ConwayEra)
+          conwayTimelock = toAllegraTimelock script
+      Exp.obtainCommonConstraints era $
+        pure . Exp.SimpleScript $ case era of
+          Exp.DijkstraEra -> Dijkstra.upgradeTimelock conwayTimelock
+          Exp.ConwayEra -> conwayTimelock
     Right te -> do
       let scriptBs = teRawCBOR te
       obtainCommonConstraints era $

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Read/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Read/Common.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.CLI.EraBased.Script.Read.Common
   ( -- * Plutus Script Related
@@ -21,6 +22,7 @@ import Cardano.CLI.Read (readFileCli)
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Error.ScriptDataError
 import Cardano.Ledger.Core qualified as L
+import Cardano.Ledger.Dijkstra.Scripts qualified as Dijkstra
 
 import Prelude
 
@@ -39,10 +41,16 @@ readFileSimpleScript file era = do
   bs <- readFileCli file
   case deserialiseFromJSON bs of
     Left _ -> case era of
-      Exp.DijkstraEra -> error "TODO Dijkstra: Simple script not supported"
+      Exp.DijkstraEra -> Exp.obtainCommonConstraints era $ do
+        -- In addition to the TextEnvelope format, we also try to
+        -- deserialize the JSON representation of SimpleScripts.
+        script :: SimpleScript <- fromEitherCli $ Aeson.eitherDecodeStrict' bs
+        let s :: L.NativeScript (Exp.LedgerEra era) =
+              Dijkstra.upgradeTimelock (toAllegraTimelock @(Exp.LedgerEra Exp.ConwayEra) script)
+        return $ Exp.SimpleScript s
       Exp.ConwayEra -> Exp.obtainConwayConstraints era $ do
         -- In addition to the TextEnvelope format, we also try to
-        -- deserialize the JSON representation of SimpleScripts..
+        -- deserialize the JSON representation of SimpleScripts.
         script :: SimpleScript <- fromEitherCli $ Aeson.eitherDecodeStrict' bs
         let s :: L.NativeScript (Exp.LedgerEra era) = obtainCommonConstraints era $ toAllegraTimelock script
         return $ Exp.SimpleScript s


### PR DESCRIPTION
# Context

Reading a simple script from a JSON file in the Dijkstra era aborted with an internal `TODO Dijkstra` error. The reader parses simple scripts in the shared Allegra timelock format and then converts to the era's script type; the Dijkstra arm was a stub.

This PR fills it using `upgradeTimelock`, the same conversion the api uses for this exact purpose.

Today this path is not reachable from the command line: no Dijkstra command takes script files yet. That arrives in a later PR, and this stub has to be gone before it does, otherwise every Dijkstra command reading a simple script would crash.

# How to trust this PR

Pretty much the same mechanism as for Conway, but using `Dijkstra.upgradeTimelock`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
