### PR TITLE
Support Dijkstra protocol-parameter updates

### DIFF
--- a/.changes/20260827_131104_cardano-cli_palas_dijkstra_pparam_updates.yml
+++ b/.changes/20260827_131104_cardano-cli_palas_dijkstra_pparam_updates.yml
@@ -1,0 +1,6 @@
+description: |
+  Protocol-parameter update proposals can now be created in the Dijkstra era with `governance action create-protocol-parameters-update`, including cost models and the parameters the era introduces: maximum reference-script size per block and per transaction, and the reference-script cost stride and multiplier.
+kind:
+- feature
+pr: 1429
+project: cardano-cli

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Option.hs
@@ -21,6 +21,7 @@ import Cardano.CLI.EraBased.Governance.Actions.Command qualified as Cmd
 import Cardano.CLI.Option.Flag (setDefault)
 import Cardano.CLI.Parser
 import Cardano.CLI.Type.Common
+import Cardano.Ledger.BaseTypes (NonZero, PositiveInterval, nonZero)
 
 import Data.Foldable
 import Data.Function ((&))
@@ -304,6 +305,56 @@ pIntroducedInConwayPParams =
     <*> convertToLedger id (optional pDRepActivity)
     <*> convertToLedger id (optional pMinFeeRefScriptCostPerByte)
 
+pIntroducedInDijkstraPParams :: Parser (IntroducedInDijkstraPParams ledgerera)
+pIntroducedInDijkstraPParams =
+  IntroducedInDijkstraPParams
+    <$> convertToLedger id (optional pMaxRefScriptSizePerBlock)
+    <*> convertToLedger id (optional pMaxRefScriptSizePerTx)
+    <*> convertToLedger id (optional pRefScriptCostStride)
+    <*> convertToLedger id (optional pRefScriptCostMultiplier)
+
+pMaxRefScriptSizePerBlock :: Parser Word32
+pMaxRefScriptSizePerBlock =
+  Opt.option integralReader $
+    mconcat
+      [ Opt.long "max-ref-script-size-per-block"
+      , Opt.metavar "WORD32"
+      , Opt.help "Maximum total size of reference scripts per block."
+      ]
+
+pMaxRefScriptSizePerTx :: Parser Word32
+pMaxRefScriptSizePerTx =
+  Opt.option integralReader $
+    mconcat
+      [ Opt.long "max-ref-script-size-per-tx"
+      , Opt.metavar "WORD32"
+      , Opt.help "Maximum total size of reference scripts per transaction."
+      ]
+
+pRefScriptCostStride :: Parser (NonZero Word32)
+pRefScriptCostStride =
+  Opt.option
+    (integralReader >>= maybe (fail "ref-script-cost-stride must be non-zero") pure . nonZero)
+    $ mconcat
+      [ Opt.long "ref-script-cost-stride"
+      , Opt.metavar "WORD32"
+      , Opt.help "Reference script cost stride (non-zero) for fee calculation."
+      ]
+
+pRefScriptCostMultiplier :: Parser PositiveInterval
+pRefScriptCostMultiplier =
+  Opt.option (readRational >>= toPositiveInterval) $
+    mconcat
+      [ Opt.long "ref-script-cost-multiplier"
+      , Opt.metavar "RATIONAL"
+      , Opt.help "Reference script cost multiplier for fee calculation."
+      ]
+
+toPositiveInterval :: Rational -> Opt.ReadM PositiveInterval
+toPositiveInterval r =
+  maybe (Opt.readerError $ "expected a positive rational, got: " <> show r) pure $
+    L.boundRational r
+
 -- Not necessary in Conway era onwards
 pProtocolParametersUpdateGenesisKeys :: Parser [VerificationKeyFile In]
 pProtocolParametersUpdateGenesisKeys = some pGenesisVerificationKeyFile
@@ -348,8 +399,12 @@ pGovActionProtocolParametersUpdate = \case
       <*> pIntroducedInBabbagePParams
       <*> pIntroducedInConwayPParams
   ShelleyBasedEraDijkstra ->
-    -- TODO: Dijkstra
-    error "pGovActionProtocolParametersUpdate: Dijkstra era not supported yet"
+    DijkstraEraBasedProtocolParametersUpdate
+      <$> pCommonProtocolParameters
+      <*> pAlonzoOnwardsPParams
+      <*> pIntroducedInBabbagePParams
+      <*> pIntroducedInConwayPParams
+      <*> pIntroducedInDijkstraPParams
 
 pGovernanceActionTreasuryWithdrawalCmd
   :: Exp.IsEra era => Maybe (Parser (Cmd.GovernanceActionCmds era))

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Option.hs
@@ -352,8 +352,12 @@ pRefScriptCostMultiplier =
 
 toPositiveInterval :: Rational -> Opt.ReadM PositiveInterval
 toPositiveInterval r =
-  maybe (Opt.readerError $ "expected a positive rational, got: " <> show r) pure $
-    L.boundRational r
+  maybe
+    ( Opt.readerError $
+        "expected a positive rational with numerator and denominator fitting in 64 bits, got: " <> show r
+    )
+    pure
+    $ L.boundRational r
 
 -- Not necessary in Conway era onwards
 pProtocolParametersUpdateGenesisKeys :: Parser [VerificationKeyFile In]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Run.hs
@@ -373,15 +373,9 @@ addCostModelsToEraBasedProtocolParametersUpdate
     ConwayEraBasedProtocolParametersUpdate common (aOn{alCostModels = SJust cmdls}) inB inC
 addCostModelsToEraBasedProtocolParametersUpdate
   AlonzoEraOnwardsDijkstra
-  _
-  _ =
-    -- TODO: Dijkstra
-    -- Add new protocol parameters from
-    -- https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/dijkstra/src/Cardano/Ledger/Dijkstra/PParams.hs#L75
-    -- to
-    -- https://github.com/IntersectMBO/cardano-api/blob/master/cardano-api/src/Cardano/Api/ProtocolParameters.hs#L190
-    -- and remove this `error`
-    error "addCostModelsToEraBasedProtocolParametersUpdate: Dijkstra not supported yet"
+  cmdls
+  (DijkstraEraBasedProtocolParametersUpdate common aOn inB inC inD) =
+    DijkstraEraBasedProtocolParametersUpdate common (aOn{alCostModels = SJust cmdls}) inB inC inD
 
 runGovernanceActionTreasuryWithdrawalCmd
   :: forall era e


### PR DESCRIPTION
# Context

Creating a protocol-parameter update proposal in the Dijkstra era hit two error stubs: building the update itself, and attaching cost models to it.

This PR fills both, the update is built as `DijkstraEraBasedProtocolParametersUpdate` (from the released cardano-api), with option parsers for the four parameters the era introduces:
- maximum reference-script size per block
- maximum reference-script size per transaction
- the reference-script cost stride
- the reference-script cost multiplier
And it also extends the cost-model attachment to the era.

Like the previous PR, these paths are not reachable from the command line yet: the Dijkstra `governance` commands arrive with the command-set PR later in this series, and these stubs must be gone before that lands.

# How to trust this PR

It is command line parsing and simple conversions. It is worth paying attention to both the conversions and the documentation (the help message descriptions, names, and meta-vars).

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
