### PR TITLE
Render Dijkstra certificates in the friendly JSON view

### DIFF
--- a/.changes/20260827_155708_cardano-cli_palas_dijkstra_friendly_certs.yml
+++ b/.changes/20260827_155708_cardano-cli_palas_dijkstra_friendly_certs.yml
@@ -1,0 +1,6 @@
+description: |
+  `transaction view` now renders Dijkstra-era certificates instead of failing with an internal TODO error.
+kind:
+- feature
+pr: 1430
+project: cardano-cli

--- a/cardano-cli/src/Cardano/CLI/Compatible/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Json/Friendly.hs
@@ -766,7 +766,7 @@ renderDijkstraCertificate cert =
       "Drep certificate update"
         .= object
           [ "Drep credential" .= drepCredential
-          , "anchor " .= mbAnchor
+          , "anchor" .= mbAnchor
           ]
     _ -> "unsupported certificate" .= String (T.pack $ show cert)
 

--- a/cardano-cli/src/Cardano/CLI/Compatible/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Json/Friendly.hs
@@ -554,7 +554,7 @@ renderCertificate
 renderCertificate era (Exp.Certificate c) =
   case era of
     Exp.ConwayEra -> renderConwayCertificate c
-    Exp.DijkstraEra -> error "renderCertificate: TODO Dijkstra era not supported"
+    Exp.DijkstraEra -> renderDijkstraCertificate c
 
 renderDrepCredential
   :: ()
@@ -637,6 +637,95 @@ renderConwayCertificate cert =
         .= object
           [ "stake credential" .= stakeCredential
           ]
+    L.RegDepositTxCert stakeCredential deposit ->
+      "Stake address registration"
+        .= object
+          [ "stake credential" .= stakeCredential
+          , "deposit" .= deposit
+          ]
+    L.UnRegDepositTxCert stakeCredential refund ->
+      "Stake address deregistration"
+        .= object
+          [ "stake credential" .= stakeCredential
+          , "refund" .= refund
+          ]
+    L.DelegTxCert stakeCredential delegatee ->
+      "Stake address delegation"
+        .= object
+          [ "stake credential" .= stakeCredential
+          , "delegatee" .= delegateeJson delegatee
+          ]
+    L.RegDepositDelegTxCert stakeCredential delegatee deposit ->
+      "Stake address registration and delegation"
+        .= object
+          [ "stake credential" .= stakeCredential
+          , "delegatee" .= delegateeJson delegatee
+          , "deposit" .= deposit
+          ]
+    L.RegPoolTxCert poolParams ->
+      "Pool registration"
+        .= object
+          [ "pool params" .= poolParams
+          ]
+    L.RetirePoolTxCert kh@L.KeyHash{} epoch ->
+      "Pool retirement"
+        .= object
+          [ "stake pool key hash" .= kh
+          , "epoch" .= epoch
+          ]
+    L.UpdateDRepTxCert drepCredential mbAnchor ->
+      "Drep certificate update"
+        .= object
+          [ "Drep credential" .= drepCredential
+          , "anchor " .= mbAnchor
+          ]
+    _ -> "unsupported certificate" .= String (T.pack $ show cert)
+
+renderDijkstraCertificate
+  :: Ledger.DijkstraTxCert (Exp.LedgerEra DijkstraEra) -> (Aeson.Key, Aeson.Value)
+renderDijkstraCertificate cert =
+  case cert of
+    L.RegDRepTxCert credential coin mAnchor ->
+      "Drep registration certificate"
+        .= object
+          [ "deposit" .= coin
+          , "certificate" .= renderDrepCredential credential
+          , "anchor" .= mAnchor
+          ]
+    L.UnRegDRepTxCert credential coin ->
+      "Drep unregistration certificate"
+        .= object
+          [ "refund" .= coin
+          , "certificate" .= renderDrepCredential credential
+          ]
+    L.AuthCommitteeHotKeyTxCert coldCred hotCred
+      | L.ScriptHashObj sh <- coldCred ->
+          "Cold committee authorization"
+            .= object
+              ["script hash" .= sh]
+      | L.ScriptHashObj sh <- hotCred ->
+          "Hot committee authorization"
+            .= object
+              ["script hash" .= sh]
+      | L.KeyHashObj ck@L.KeyHash{} <- coldCred
+      , L.KeyHashObj hk@L.KeyHash{} <- hotCred ->
+          "Constitutional committee member hot key registration"
+            .= object
+              [ "cold key hash" .= ck
+              , "hot key hash" .= hk
+              ]
+    L.ResignCommitteeColdTxCert cred anchor -> case cred of
+      L.ScriptHashObj sh ->
+        "Cold committee resignation"
+          .= object
+            [ "script hash" .= sh
+            , "anchor" .= anchor
+            ]
+      L.KeyHashObj ck@L.KeyHash{} ->
+        "Constitutional committee cold key resignation"
+          .= object
+            [ "cold key hash" .= ck
+            ]
     L.RegDepositTxCert stakeCredential deposit ->
       "Stake address registration"
         .= object


### PR DESCRIPTION
# Context

The friendly JSON renderer (what `transaction view` prints) hit an error stub for every Dijkstra-era certificate.

This PR adds `renderDijkstraCertificate`: it is the Conway renderer minus the certificate forms the era drops (Dijkstra no longer has the Shelley-era certificate shapes), so every certificate the era supports renders, and stake pool registrations include their pool parameters.

# How to trust this PR

It is all straightforward to JSON conversion. The only doubt is whether we are covering all the right certificates (since there is a catch-all that prints `"unsupported certificate"`. But it can be checked that they match the ones at: https://cardano-ledger.cardano.intersectmbo.org/cardano-ledger-dijkstra/Cardano-Ledger-Dijkstra-TxCert.html#t:DijkstraTxCert

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
