### PR TITLE
Enable the full Dijkstra command set

### DIFF
--- a/.changes/20260828_211909_cardano-cli_palas_dijkstra_command_set.yml
+++ b/.changes/20260828_211909_cardano-cli_palas_dijkstra_command_set.yml
@@ -1,0 +1,6 @@
+description: |
+  The `dijkstra` era subcommand now provides the full command set: address, key, genesis, governance, query, stake-address, stake-pool, text-view and transaction commands, matching the other eras; previously only the node commands were available.
+kind:
+- feature
+pr: 1431
+project: cardano-cli

--- a/cardano-cli/src/Cardano/CLI/EraBased/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Option.hs
@@ -54,7 +54,7 @@ pAnyEraCommand envCli =
             Opt.progDesc "Conway era commands"
     , Opt.hsubparser $
         commandWithMetavar "dijkstra" $
-          Opt.info (AnyEraCommandOf DijkstraEra <$> asum [NodeCmds <$> pNodeCmds @DijkstraEra]) $
+          Opt.info (AnyEraCommandOf DijkstraEra <$> pCmds @DijkstraEra envCli) $
             Opt.progDesc "Dijkstra era commands"
     , Opt.hsubparser $
         commandWithMetavar "latest" $

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -3451,9 +3451,804 @@ Usage: cardano-cli conway transaction txid
 
   Print a transaction identifier.
 
-Usage: cardano-cli dijkstra node 
+Usage: cardano-cli dijkstra 
+                              ( address
+                              | key
+                              | genesis
+                              | governance
+                              | node
+                              | query
+                              | stake-address
+                              | stake-pool
+                              | text-view
+                              | transaction
+                              )
+                              
 
   Dijkstra era commands
+
+Usage: cardano-cli dijkstra address (key-gen | key-hash | build | info) 
+
+  Payment address commands.
+
+Usage: cardano-cli dijkstra address key-gen 
+                                              [ --key-output-bech32
+                                              | --key-output-text-envelope
+                                              | --key-output-format STRING
+                                              ]
+                                              [ --normal-key
+                                              | --extended-key
+                                              | --byron-key
+                                              ]
+                                              --verification-key-file FILEPATH
+                                              --signing-key-file FILEPATH
+                                              
+
+  Create an address key pair.
+
+Usage: cardano-cli dijkstra address key-hash 
+                                               ( --payment-verification-key STRING
+                                               | --payment-verification-key-file FILEPATH
+                                               )
+                                               [--out-file FILEPATH]
+                                               
+
+  Print the hash of an address key.
+
+Usage: cardano-cli dijkstra address build 
+                                            ( --payment-verification-key STRING
+                                            | --payment-verification-key-file FILEPATH
+                                            | --payment-script-file FILEPATH
+                                            )
+                                            [ --stake-verification-key STRING
+                                            | --stake-verification-key-file FILEPATH
+                                            | --stake-key-hash HASH
+                                            | --stake-script-file FILEPATH
+                                            | --stake-address ADDRESS
+                                            ]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+                                            [--out-file FILEPATH]
+                                            
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Usage: cardano-cli dijkstra address info --address ADDRESS
+                                           [--out-file FILEPATH]
+                                           
+
+  Print information about an address.
+
+Usage: cardano-cli dijkstra key 
+                                  ( verification-key
+                                  | non-extended-key
+                                  | generate-mnemonic
+                                  | derive-from-mnemonic
+                                  | convert-byron-key
+                                  | convert-byron-genesis-vkey
+                                  | convert-itn-key
+                                  | convert-itn-extended-key
+                                  | convert-itn-bip32-key
+                                  | convert-cardano-address-key
+                                  )
+                                  
+
+  Key utility commands.
+
+Usage: cardano-cli dijkstra key verification-key --signing-key-file FILEPATH
+                                                   --verification-key-file FILEPATH
+                                                   
+
+  Get a verification key from a signing key. This supports all key types.
+
+Usage: cardano-cli dijkstra key non-extended-key --extended-verification-key-file FILEPATH
+                                                   --verification-key-file FILEPATH
+                                                   
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Usage: cardano-cli dijkstra key generate-mnemonic [--out-file FILEPATH]
+                                                    --size WORD32
+                                                    
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Usage: cardano-cli dijkstra key derive-from-mnemonic 
+                                                       [ --key-output-bech32
+                                                       | --key-output-text-envelope
+                                                       | --key-output-format STRING
+                                                       ]
+                                                       ( --payment-key-with-number WORD32
+                                                       | --stake-key-with-number WORD32
+                                                       | --drep-key
+                                                       | --cc-cold-key
+                                                       | --cc-hot-key
+                                                       )
+                                                       --account-number WORD32
+                                                       ( --mnemonic-from-file FILEPATH
+                                                       | --mnemonic-from-interactive-prompt
+                                                       )
+                                                       --signing-key-file FILEPATH
+                                                       
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
+
+Usage: cardano-cli dijkstra key convert-byron-key [--password TEXT]
+                                                    ( --byron-payment-key-type
+                                                    | --legacy-byron-payment-key-type
+                                                    | --byron-genesis-key-type
+                                                    | --legacy-byron-genesis-key-type
+                                                    | --byron-genesis-delegate-key-type
+                                                    | --legacy-byron-genesis-delegate-key-type
+                                                    )
+                                                    ( --byron-signing-key-file FILEPATH
+                                                    | --byron-verification-key-file FILEPATH
+                                                    )
+                                                    --out-file FILEPATH
+                                                    
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Usage: cardano-cli dijkstra key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                             --out-file FILEPATH
+                                                             
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Usage: cardano-cli dijkstra key convert-itn-key 
+                                                  ( --itn-signing-key-file FILEPATH
+                                                  | --itn-verification-key-file FILEPATH
+                                                  )
+                                                  --out-file FILEPATH
+                                                  
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Usage: cardano-cli dijkstra key convert-itn-extended-key --itn-signing-key-file FILEPATH
+                                                           --out-file FILEPATH
+                                                           
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Usage: cardano-cli dijkstra key convert-itn-bip32-key --itn-signing-key-file FILEPATH
+                                                        --out-file FILEPATH
+                                                        
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Usage: cardano-cli dijkstra key convert-cardano-address-key 
+                                                              ( --cc-cold-key
+                                                              | --cc-hot-key
+                                                              | --drep-key
+                                                              | --shelley-payment-key
+                                                              | --shelley-stake-key
+                                                              | --icarus-payment-key
+                                                              | --byron-payment-key
+                                                              )
+                                                              --signing-key-file FILEPATH
+                                                              --out-file FILEPATH
+                                                              
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Usage: cardano-cli dijkstra genesis 
+                                      ( key-gen-genesis
+                                      | key-gen-delegate
+                                      | key-gen-utxo
+                                      | key-hash
+                                      | get-ver-key
+                                      | initial-addr
+                                      | initial-txin
+                                      | create-cardano
+                                      | create
+                                      | create-staked
+                                      | create-testnet-data
+                                      | hash
+                                      )
+                                      
+
+  Genesis block commands.
+
+Usage: cardano-cli dijkstra genesis key-gen-genesis --verification-key-file FILEPATH
+                                                      --signing-key-file FILEPATH
+                                                      
+
+  Create a Shelley genesis key pair
+
+Usage: cardano-cli dijkstra genesis key-gen-delegate --verification-key-file FILEPATH
+                                                       --signing-key-file FILEPATH
+                                                       --operational-certificate-issue-counter-file FILEPATH
+                                                       
+
+  Create a Shelley genesis delegate key pair
+
+Usage: cardano-cli dijkstra genesis key-gen-utxo --verification-key-file FILEPATH
+                                                   --signing-key-file FILEPATH
+                                                   
+
+  Create a Shelley genesis UTxO key pair
+
+Usage: cardano-cli dijkstra genesis key-hash --verification-key-file FILEPATH 
+
+  Print the identifier (hash) of a public key
+
+Usage: cardano-cli dijkstra genesis get-ver-key --verification-key-file FILEPATH
+                                                  --signing-key-file FILEPATH
+                                                  
+
+  Derive the verification key from a signing key
+
+Usage: cardano-cli dijkstra genesis initial-addr --verification-key-file FILEPATH
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [--out-file FILEPATH]
+                                                   
+
+  Get the address for an initial UTxO based on the verification key
+
+Usage: cardano-cli dijkstra genesis initial-txin --verification-key-file FILEPATH
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [--out-file FILEPATH]
+                                                   
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Usage: cardano-cli dijkstra genesis create-cardano --genesis-dir DIR
+                                                     [--gen-genesis-keys INT]
+                                                     [--gen-utxo-keys INT]
+                                                     [--start-time UTC_TIME]
+                                                     [--supply LOVELACE]
+                                                     [--security-param NON_ZERO_WORD64]
+                                                     [--slot-length INT]
+                                                     [--slot-coefficient RATIONAL]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     --byron-template FILEPATH
+                                                     --shelley-template FILEPATH
+                                                     --alonzo-template FILEPATH
+                                                     --conway-template FILEPATH
+                                                     [--node-config-template FILEPATH]
+                                                     
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli dijkstra genesis create 
+                                             [ --key-output-bech32
+                                             | --key-output-text-envelope
+                                             | --key-output-format STRING
+                                             ]
+                                             --genesis-dir DIR
+                                             [--gen-genesis-keys INT]
+                                             [--gen-utxo-keys INT]
+                                             [--start-time UTC_TIME]
+                                             [--supply LOVELACE]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli dijkstra genesis create-staked 
+                                                    [ --key-output-bech32
+                                                    | --key-output-text-envelope
+                                                    | --key-output-format STRING
+                                                    ]
+                                                    --genesis-dir DIR
+                                                    [--gen-genesis-keys INT]
+                                                    [--gen-utxo-keys INT]
+                                                    [--gen-pools INT]
+                                                    [--gen-stake-delegs INT]
+                                                    [--start-time UTC_TIME]
+                                                    [--supply LOVELACE]
+                                                    [--supply-delegated LOVELACE]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    [--bulk-pool-cred-files INT]
+                                                    [--bulk-pools-per-file INT]
+                                                    [--num-stuffed-utxo INT]
+                                                    [--relay-specification-file FILEPATH]
+                                                    
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli dijkstra genesis create-testnet-data 
+                                                          [--spec-shelley FILEPATH]
+                                                          [--spec-alonzo FILEPATH]
+                                                          [--spec-conway FILEPATH]
+                                                          
+                                                          [--genesis-keys INT]
+                                                          [--pools INT]
+                                                          [ --stake-delegators INT
+                                                          | --transient-stake-delegators INT
+                                                          ]
+                                                          [--committee-keys INT]
+                                                          [ --drep-keys INT
+                                                          | --transient-drep-keys INT
+                                                          ]
+                                                          [--stuffed-utxo INT]
+                                                          [--utxo-keys INT]
+                                                          [--total-supply LOVELACE]
+                                                          [--delegated-supply LOVELACE]
+                                                          [--testnet-magic NATURAL]
+                                                          [--relays FILEPATH]
+                                                          [--start-time UTC_TIME]
+                                                          --out-dir DIR
+                                                          
+
+  Create data to use for starting a testnet.
+
+Usage: cardano-cli dijkstra genesis hash --genesis FILEPATH 
+
+  DEPRECATION WARNING! This command is deprecated and will be removed in a
+  future release. Please use hash genesis-file instead. Compute the hash of a
+  genesis file.
+
+Usage: cardano-cli dijkstra governance (action | committee | drep | vote) 
+
+  Governance commands.
+
+Usage: cardano-cli dijkstra governance action 
+                                                ( create-constitution
+                                                | update-committee
+                                                | create-info
+                                                | create-no-confidence
+                                                | create-protocol-parameters-update
+                                                | create-treasury-withdrawal
+                                                | create-hardfork
+                                                | view
+                                                )
+                                                
+
+  Governance action commands.
+
+Usage: cardano-cli dijkstra governance action create-constitution 
+                                                                    ( --mainnet
+                                                                    | --testnet
+                                                                    )
+                                                                    --governance-action-deposit NATURAL
+                                                                    ( --deposit-return-stake-verification-key STRING
+                                                                    | --deposit-return-stake-verification-key-file FILEPATH
+                                                                    | --deposit-return-stake-key-hash HASH
+                                                                    | --deposit-return-stake-script-file FILEPATH
+                                                                    | --deposit-return-stake-address ADDRESS
+                                                                    )
+                                                                    [--prev-governance-action-tx-id TXID
+                                                                      --prev-governance-action-index WORD16]
+                                                                    --anchor-url TEXT
+                                                                    --anchor-data-hash HASH
+                                                                    [--check-anchor-data]
+                                                                    --constitution-url TEXT
+                                                                    --constitution-hash HASH
+                                                                    [--check-constitution-hash]
+                                                                    [--constitution-script-hash HASH]
+                                                                    --out-file FILEPATH
+                                                                    
+
+  Create a constitution.
+
+Usage: cardano-cli dijkstra governance action update-committee 
+                                                                 ( --mainnet
+                                                                 | --testnet
+                                                                 )
+                                                                 --governance-action-deposit NATURAL
+                                                                 ( --deposit-return-stake-verification-key STRING
+                                                                 | --deposit-return-stake-verification-key-file FILEPATH
+                                                                 | --deposit-return-stake-key-hash HASH
+                                                                 | --deposit-return-stake-script-file FILEPATH
+                                                                 | --deposit-return-stake-address ADDRESS
+                                                                 )
+                                                                 --anchor-url TEXT
+                                                                 --anchor-data-hash HASH
+                                                                 [--check-anchor-data]
+                                                                 [ --remove-cc-cold-verification-key STRING
+                                                                 | --remove-cc-cold-verification-key-file FILEPATH
+                                                                 | --remove-cc-cold-verification-key-hash STRING
+                                                                 | --remove-cc-cold-script-hash HASH
+                                                                 ]
+                                                                 [
+                                                                   ( --add-cc-cold-verification-key STRING
+                                                                   | --add-cc-cold-verification-key-file FILEPATH
+                                                                   | --add-cc-cold-verification-key-hash STRING
+                                                                   | --add-cc-cold-script-hash HASH
+                                                                   )
+                                                                   --epoch NATURAL]
+                                                                 --threshold RATIONAL
+                                                                 [--prev-governance-action-tx-id TXID
+                                                                   --prev-governance-action-index WORD16]
+                                                                 --out-file FILEPATH
+                                                                 
+
+  Create or update a new committee proposal.
+
+Usage: cardano-cli dijkstra governance action create-info 
+                                                            ( --mainnet
+                                                            | --testnet
+                                                            )
+                                                            --governance-action-deposit NATURAL
+                                                            ( --deposit-return-stake-verification-key STRING
+                                                            | --deposit-return-stake-verification-key-file FILEPATH
+                                                            | --deposit-return-stake-key-hash HASH
+                                                            | --deposit-return-stake-script-file FILEPATH
+                                                            | --deposit-return-stake-address ADDRESS
+                                                            )
+                                                            --anchor-url TEXT
+                                                            --anchor-data-hash HASH
+                                                            [--check-anchor-data]
+                                                            --out-file FILEPATH
+                                                            
+
+  Create an info action.
+
+Usage: cardano-cli dijkstra governance action create-no-confidence 
+                                                                     ( --mainnet
+                                                                     | --testnet
+                                                                     )
+                                                                     --governance-action-deposit NATURAL
+                                                                     ( --deposit-return-stake-verification-key STRING
+                                                                     | --deposit-return-stake-verification-key-file FILEPATH
+                                                                     | --deposit-return-stake-key-hash HASH
+                                                                     | --deposit-return-stake-script-file FILEPATH
+                                                                     | --deposit-return-stake-address ADDRESS
+                                                                     )
+                                                                     --anchor-url TEXT
+                                                                     --anchor-data-hash HASH
+                                                                     [--check-anchor-data]
+                                                                     [--prev-governance-action-tx-id TXID
+                                                                       --prev-governance-action-index WORD16]
+                                                                     --out-file FILEPATH
+                                                                     
+
+  Create a no confidence proposal.
+
+Usage: cardano-cli dijkstra governance action create-protocol-parameters-update 
+                                                                                  ( --mainnet
+                                                                                  | --testnet
+                                                                                  )
+                                                                                  --governance-action-deposit NATURAL
+                                                                                  ( --deposit-return-stake-verification-key STRING
+                                                                                  | --deposit-return-stake-verification-key-file FILEPATH
+                                                                                  | --deposit-return-stake-key-hash HASH
+                                                                                  | --deposit-return-stake-script-file FILEPATH
+                                                                                  | --deposit-return-stake-address ADDRESS
+                                                                                  )
+                                                                                  --anchor-url TEXT
+                                                                                  --anchor-data-hash HASH
+                                                                                  [--check-anchor-data]
+                                                                                  [--prev-governance-action-tx-id TXID
+                                                                                    --prev-governance-action-index WORD16]
+                                                                                  [--constitution-script-hash HASH]
+                                                                                  [--min-fee-linear LOVELACE]
+                                                                                  [--min-fee-constant LOVELACE]
+                                                                                  [--max-block-body-size WORD32]
+                                                                                  [--max-tx-size WORD32]
+                                                                                  [--max-block-header-size WORD16]
+                                                                                  [--key-reg-deposit-amt NATURAL]
+                                                                                  [--pool-reg-deposit NATURAL]
+                                                                                  [--pool-retirement-epoch-interval WORD32]
+                                                                                  [--number-of-pools WORD16]
+                                                                                  [--pool-influence RATIONAL]
+                                                                                  [--treasury-expansion RATIONAL]
+                                                                                  [--monetary-expansion RATIONAL]
+                                                                                  [--min-pool-cost NATURAL]
+                                                                                  [--price-execution-steps RATIONAL
+                                                                                    --price-execution-memory RATIONAL]
+                                                                                  [--max-tx-execution-units (INT, INT)]
+                                                                                  [--max-block-execution-units (INT, INT)]
+                                                                                  [--max-value-size INT]
+                                                                                  [--collateral-percent INT]
+                                                                                  [--max-collateral-inputs INT]
+                                                                                  [--utxo-cost-per-byte LOVELACE]
+                                                                                  [--pool-voting-threshold-motion-no-confidence RATIONAL
+                                                                                    --pool-voting-threshold-committee-normal RATIONAL
+                                                                                    --pool-voting-threshold-committee-no-confidence RATIONAL
+                                                                                    --pool-voting-threshold-hard-fork-initiation RATIONAL
+                                                                                    --pool-voting-threshold-pp-security-group RATIONAL]
+                                                                                  [--drep-voting-threshold-motion-no-confidence RATIONAL
+                                                                                    --drep-voting-threshold-committee-normal RATIONAL
+                                                                                    --drep-voting-threshold-committee-no-confidence RATIONAL
+                                                                                    --drep-voting-threshold-update-to-constitution RATIONAL
+                                                                                    --drep-voting-threshold-hard-fork-initiation RATIONAL
+                                                                                    --drep-voting-threshold-pp-network-group RATIONAL
+                                                                                    --drep-voting-threshold-pp-economic-group RATIONAL
+                                                                                    --drep-voting-threshold-pp-technical-group RATIONAL
+                                                                                    --drep-voting-threshold-pp-governance-group RATIONAL
+                                                                                    --drep-voting-threshold-treasury-withdrawal RATIONAL]
+                                                                                  [--min-committee-size INT]
+                                                                                  [--committee-term-length WORD32]
+                                                                                  [--governance-action-lifetime WORD32]
+                                                                                  [--new-governance-action-deposit NATURAL]
+                                                                                  [--drep-deposit LOVELACE]
+                                                                                  [--drep-activity WORD32]
+                                                                                  [--ref-script-cost-per-byte RATIONAL]
+                                                                                  [--max-ref-script-size-per-block WORD32]
+                                                                                  [--max-ref-script-size-per-tx WORD32]
+                                                                                  [--ref-script-cost-stride WORD32]
+                                                                                  [--ref-script-cost-multiplier RATIONAL]
+                                                                                  [--cost-model-file FILE]
+                                                                                  --out-file FILEPATH
+                                                                                  
+
+  Create a protocol parameters update.
+
+Usage: cardano-cli dijkstra governance action create-treasury-withdrawal 
+                                                                           ( --mainnet
+                                                                           | --testnet
+                                                                           )
+                                                                           --governance-action-deposit NATURAL
+                                                                           ( --deposit-return-stake-verification-key STRING
+                                                                           | --deposit-return-stake-verification-key-file FILEPATH
+                                                                           | --deposit-return-stake-key-hash HASH
+                                                                           | --deposit-return-stake-script-file FILEPATH
+                                                                           | --deposit-return-stake-address ADDRESS
+                                                                           )
+                                                                           --anchor-url TEXT
+                                                                           --anchor-data-hash HASH
+                                                                           [--check-anchor-data]
+                                                                           (
+                                                                             ( --funds-receiving-stake-verification-key STRING
+                                                                             | --funds-receiving-stake-verification-key-file FILEPATH
+                                                                             | --funds-receiving-stake-key-hash HASH
+                                                                             | --funds-receiving-stake-script-file FILEPATH
+                                                                             | --funds-receiving-stake-address ADDRESS
+                                                                             )
+                                                                             --transfer LOVELACE)
+                                                                           [--constitution-script-hash HASH]
+                                                                           --out-file FILEPATH
+                                                                           
+
+  Create a treasury withdrawal.
+
+Usage: cardano-cli dijkstra governance action create-hardfork 
+                                                                ( --mainnet
+                                                                | --testnet
+                                                                )
+                                                                --governance-action-deposit NATURAL
+                                                                ( --deposit-return-stake-verification-key STRING
+                                                                | --deposit-return-stake-verification-key-file FILEPATH
+                                                                | --deposit-return-stake-key-hash HASH
+                                                                | --deposit-return-stake-script-file FILEPATH
+                                                                | --deposit-return-stake-address ADDRESS
+                                                                )
+                                                                [--prev-governance-action-tx-id TXID
+                                                                  --prev-governance-action-index WORD16]
+                                                                --anchor-url TEXT
+                                                                --anchor-data-hash HASH
+                                                                [--check-anchor-data]
+                                                                --protocol-major-version MAJOR
+                                                                --protocol-minor-version MINOR
+                                                                --out-file FILEPATH
+                                                                
+
+  Create a hardfork initiation proposal.
+
+Usage: cardano-cli dijkstra governance action view --action-file FILEPATH
+                                                     [ --output-json
+                                                     | --output-yaml
+                                                     ]
+                                                     [--out-file FILEPATH]
+                                                     
+
+  View a governance action.
+
+Usage: cardano-cli dijkstra governance committee 
+                                                   ( key-gen-cold
+                                                   | key-gen-hot
+                                                   | key-hash
+                                                   | create-hot-key-authorization-certificate
+                                                   | create-cold-key-resignation-certificate
+                                                   )
+                                                   
+
+  Committee member commands.
+
+Usage: cardano-cli dijkstra governance committee key-gen-cold 
+                                                                [ --key-output-bech32
+                                                                | --key-output-text-envelope
+                                                                | --key-output-format STRING
+                                                                ]
+                                                                --cold-verification-key-file FILEPATH
+                                                                --cold-signing-key-file FILEPATH
+                                                                
+
+  Create a cold key pair for a Constitutional Committee Member
+
+Usage: cardano-cli dijkstra governance committee key-gen-hot 
+                                                               [ --key-output-bech32
+                                                               | --key-output-text-envelope
+                                                               | --key-output-format STRING
+                                                               ]
+                                                               --verification-key-file FILEPATH
+                                                               --signing-key-file FILEPATH
+                                                               
+
+  Create a hot key pair for a Constitutional Committee Member
+
+Usage: cardano-cli dijkstra governance committee key-hash 
+                                                            ( --verification-key STRING
+                                                            | --verification-key-file FILEPATH
+                                                            )
+                                                            
+
+  Print the identifier (hash) of a public key
+
+Usage: cardano-cli dijkstra governance committee create-hot-key-authorization-certificate 
+                                                                                            ( --cold-verification-key STRING
+                                                                                            | --cold-verification-key-file FILEPATH
+                                                                                            | --cold-verification-key-hash STRING
+                                                                                            | --cold-script-hash HASH
+                                                                                            | --cold-script-file FILEPATH
+                                                                                            )
+                                                                                            ( --hot-verification-key STRING
+                                                                                            | --hot-verification-key-file FILEPATH
+                                                                                            | --hot-verification-key-hash STRING
+                                                                                            | --hot-script-hash HASH
+                                                                                            | --hot-script-file FILEPATH
+                                                                                            )
+                                                                                            --out-file FILEPATH
+                                                                                            
+
+  Create hot key authorization certificate for a Constitutional Committee Member
+
+Usage: cardano-cli dijkstra governance committee create-cold-key-resignation-certificate 
+                                                                                           ( --cold-verification-key STRING
+                                                                                           | --cold-verification-key-file FILEPATH
+                                                                                           | --cold-verification-key-hash STRING
+                                                                                           | --cold-script-hash HASH
+                                                                                           | --cold-script-file FILEPATH
+                                                                                           )
+                                                                                           [--resignation-metadata-url TEXT
+                                                                                             --resignation-metadata-hash HASH
+                                                                                             [--check-resignation-metadata-hash]]
+                                                                                           --out-file FILEPATH
+                                                                                           
+
+  Create cold key resignation certificate for a Constitutional Committee Member
+
+Usage: cardano-cli dijkstra governance drep 
+                                              ( key-gen
+                                              | id
+                                              | registration-certificate
+                                              | retirement-certificate
+                                              | update-certificate
+                                              | metadata-hash
+                                              )
+                                              
+
+  DRep member commands.
+
+Usage: cardano-cli dijkstra governance drep key-gen 
+                                                      [ --key-output-bech32
+                                                      | --key-output-text-envelope
+                                                      | --key-output-format STRING
+                                                      ]
+                                                      --verification-key-file FILEPATH
+                                                      --signing-key-file FILEPATH
+                                                      
+
+  Generate Delegated Representative verification and signing keys.
+
+Usage: cardano-cli dijkstra governance drep id 
+                                                 ( --drep-verification-key STRING
+                                                 | --drep-verification-key-file FILEPATH
+                                                 | --drep-key-hash HASH
+                                                 )
+                                                 [ --output-hex
+                                                 | --output-bech32
+                                                 | --output-cip129
+                                                 ]
+                                                 [--out-file FILEPATH]
+                                                 
+
+  Generate a drep id.
+
+Usage: cardano-cli dijkstra governance drep registration-certificate 
+                                                                       ( --drep-script-hash HASH
+                                                                       | --drep-verification-key STRING
+                                                                       | --drep-verification-key-file FILEPATH
+                                                                       | --drep-key-hash HASH
+                                                                       )
+                                                                       --key-reg-deposit-amt NATURAL
+                                                                       [--drep-metadata-url TEXT
+                                                                         --drep-metadata-hash HASH
+                                                                         [--check-drep-metadata-hash]]
+                                                                       --out-file FILEPATH
+                                                                       
+
+  Create a registration certificate.
+
+Usage: cardano-cli dijkstra governance drep retirement-certificate 
+                                                                     ( --drep-script-hash HASH
+                                                                     | --drep-verification-key STRING
+                                                                     | --drep-verification-key-file FILEPATH
+                                                                     | --drep-key-hash HASH
+                                                                     )
+                                                                     --deposit-amt LOVELACE
+                                                                     --out-file FILEPATH
+                                                                     
+
+  Create a DRep retirement certificate.
+
+Usage: cardano-cli dijkstra governance drep update-certificate 
+                                                                 ( --drep-script-hash HASH
+                                                                 | --drep-verification-key STRING
+                                                                 | --drep-verification-key-file FILEPATH
+                                                                 | --drep-key-hash HASH
+                                                                 )
+                                                                 [--drep-metadata-url TEXT
+                                                                   --drep-metadata-hash HASH
+                                                                   [--check-drep-metadata-hash]]
+                                                                 --out-file FILEPATH
+                                                                 
+
+  Create a DRep update certificate.
+
+Usage: cardano-cli dijkstra governance drep metadata-hash 
+                                                            ( --drep-metadata-file FILEPATH
+                                                            | --drep-metadata-url TEXT
+                                                            )
+                                                            [ --expected-hash HASH
+                                                            | --out-file FILEPATH
+                                                            ]
+                                                            
+
+  Calculate the hash of a metadata file, optionally checking the obtained hash
+  against an expected value.
+
+Usage: cardano-cli dijkstra governance vote (create | view) 
+
+  Vote commands.
+
+Usage: cardano-cli dijkstra governance vote create (--yes | --no | --abstain)
+                                                     --governance-action-tx-id TXID
+                                                     --governance-action-index WORD16
+                                                     ( --drep-verification-key STRING
+                                                     | --drep-verification-key-file FILEPATH
+                                                     | --drep-key-hash HASH
+                                                     | --drep-script-hash HASH
+                                                     | --stake-pool-verification-key STRING
+                                                     | --stake-pool-verification-extended-key STRING
+                                                     | --cold-verification-key-file FILEPATH
+                                                     | --stake-pool-id STAKE_POOL_ID
+                                                     | --cc-hot-verification-key STRING
+                                                     | --cc-hot-verification-key-file FILEPATH
+                                                     | --cc-hot-key-hash STRING
+                                                     | --cc-hot-script-hash HASH
+                                                     )
+                                                     [--anchor-url TEXT
+                                                       --anchor-data-hash HASH
+                                                       [--check-anchor-data-hash]]
+                                                     --out-file FILEPATH
+                                                     
+
+  Vote creation.
+
+Usage: cardano-cli dijkstra governance vote view --vote-file FILEPATH
+                                                   [ --output-json
+                                                   | --output-yaml
+                                                   ]
+                                                   [--out-file FILEPATH]
+                                                   
+
+  Vote viewing.
 
 Usage: cardano-cli dijkstra node 
                                    ( key-gen
@@ -3565,6 +4360,1604 @@ Usage: cardano-cli dijkstra node issue-op-cert
                                                  
 
   Issue a node operational certificate
+
+Usage: cardano-cli dijkstra query 
+                                    ( committee-state
+                                    | constitution
+                                    | drep-state
+                                    | drep-stake-distribution
+                                    | era-history
+                                    | future-pparams
+                                    | gov-state
+                                    | kes-period-info
+                                    | leadership-schedule
+                                    | ledger-peer-snapshot
+                                    | ledger-state
+                                    | pool-state
+                                    | proposals
+                                    | protocol-parameters
+                                    | protocol-state
+                                    | ratify-state
+                                    | ref-script-size
+                                    | slot-number
+                                    | spo-stake-distribution
+                                    | stake-address-info
+                                    | stake-distribution
+                                    | stake-pools
+                                    | stake-pool-default-vote
+                                    | stake-snapshot
+                                    | tip
+                                    | treasury
+                                    | tx-mempool
+                                    | utxo
+                                    )
+                                    
+
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
+
+Usage: cardano-cli dijkstra query committee-state 
+                                                    [--cardano-mode
+                                                      [--epoch-slots SLOTS]]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    --socket-path SOCKET_PATH
+                                                    [ --volatile-tip
+                                                    | --immutable-tip
+                                                    ]
+                                                    [ --cold-verification-key STRING
+                                                    | --cold-verification-key-file FILEPATH
+                                                    | --cold-verification-key-hash STRING
+                                                    | --cold-script-hash HASH
+                                                    ]
+                                                    [ --hot-key STRING
+                                                    | --hot-key-file FILEPATH
+                                                    | --hot-key-hash STRING
+                                                    | --hot-script-hash HASH
+                                                    ]
+                                                    [ --active
+                                                    | --expired
+                                                    | --unrecognized
+                                                    ]
+                                                    [ --output-json
+                                                    | --output-yaml
+                                                    ]
+                                                    [--out-file FILEPATH]
+                                                    
+
+  Get the committee state
+
+Usage: cardano-cli dijkstra query constitution 
+                                                 [--cardano-mode
+                                                   [--epoch-slots SLOTS]]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 --socket-path SOCKET_PATH
+                                                 [ --volatile-tip
+                                                 | --immutable-tip
+                                                 ]
+                                                 [--output-json | --output-yaml]
+                                                 [--out-file FILEPATH]
+                                                 
+
+  Get the constitution
+
+Usage: cardano-cli dijkstra query drep-state 
+                                               [--cardano-mode
+                                                 [--epoch-slots SLOTS]]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               --socket-path SOCKET_PATH
+                                               [ --volatile-tip
+                                               | --immutable-tip
+                                               ]
+                                               ( --all-dreps
+                                               | 
+                                               ( --drep-script-hash HASH
+                                               | --drep-verification-key STRING
+                                               | --drep-verification-key-file FILEPATH
+                                               | --drep-key-hash HASH
+                                               )
+                                               )
+                                               [--include-stake]
+                                               [--output-json | --output-yaml]
+                                               [--out-file FILEPATH]
+                                               
+
+  Get the DRep state.
+
+Usage: cardano-cli dijkstra query drep-stake-distribution 
+                                                            [--cardano-mode
+                                                              [--epoch-slots SLOTS]]
+                                                            ( --mainnet
+                                                            | --testnet-magic NATURAL
+                                                            )
+                                                            --socket-path SOCKET_PATH
+                                                            [ --volatile-tip
+                                                            | --immutable-tip
+                                                            ]
+                                                            ( --all-dreps
+                                                            | 
+                                                            ( --drep-script-hash HASH
+                                                            | --drep-verification-key STRING
+                                                            | --drep-verification-key-file FILEPATH
+                                                            | --drep-key-hash HASH
+                                                            )
+                                                            )
+                                                            [ --output-json
+                                                            | --output-yaml
+                                                            ]
+                                                            [--out-file FILEPATH]
+                                                            
+
+  Get the DRep stake distribution.
+
+Usage: cardano-cli dijkstra query era-history 
+                                                [--cardano-mode
+                                                  [--epoch-slots SLOTS]]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --socket-path SOCKET_PATH
+                                                [ --volatile-tip
+                                                | --immutable-tip
+                                                ]
+                                                [--out-file FILEPATH]
+                                                
+
+  Obtains the era history data. The era history contains information about when
+  era transitions happened and can be used together with the start time to
+  convert slot numbers to POSIX times offline (without connecting to the node).
+  Converting slot numbers to POSIX times is useful, for example, when
+  calculating the cost of executing a Plutus script. And being able to do it
+  offline means that it can be calculated without access to a live node.
+
+Usage: cardano-cli dijkstra query future-pparams 
+                                                   [--cardano-mode
+                                                     [--epoch-slots SLOTS]]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --socket-path SOCKET_PATH
+                                                   [ --volatile-tip
+                                                   | --immutable-tip
+                                                   ]
+                                                   [ --output-json
+                                                   | --output-yaml
+                                                   ]
+                                                   [--out-file FILEPATH]
+                                                   
+
+  Get the protocol parameters that will apply at the next epoch
+
+Usage: cardano-cli dijkstra query gov-state 
+                                              [--cardano-mode
+                                                [--epoch-slots SLOTS]]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              --socket-path SOCKET_PATH
+                                              [--volatile-tip | --immutable-tip]
+                                              [--output-json | --output-yaml]
+                                              [--out-file FILEPATH]
+                                              
+
+  Get the governance state
+
+Usage: cardano-cli dijkstra query kes-period-info 
+                                                    [--cardano-mode
+                                                      [--epoch-slots SLOTS]]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    --socket-path SOCKET_PATH
+                                                    [ --volatile-tip
+                                                    | --immutable-tip
+                                                    ]
+                                                    --op-cert-file FILEPATH
+                                                    [ --output-json
+                                                    | --output-yaml
+                                                    ]
+                                                    [--out-file FILEPATH]
+                                                    
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Usage: cardano-cli dijkstra query leadership-schedule 
+                                                        [--cardano-mode
+                                                          [--epoch-slots SLOTS]]
+                                                        ( --mainnet
+                                                        | --testnet-magic NATURAL
+                                                        )
+                                                        --socket-path SOCKET_PATH
+                                                        [ --volatile-tip
+                                                        | --immutable-tip
+                                                        ]
+                                                        --genesis FILEPATH
+                                                        ( --stake-pool-verification-key STRING
+                                                        | --stake-pool-verification-extended-key STRING
+                                                        | --cold-verification-key-file FILEPATH
+                                                        | --stake-pool-id STAKE_POOL_ID
+                                                        )
+                                                        --vrf-signing-key-file FILEPATH
+                                                        (--current | --next)
+                                                        [ --output-json
+                                                        | --output-text
+                                                        | --output-yaml
+                                                        ]
+                                                        [--out-file FILEPATH]
+                                                        
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Usage: cardano-cli dijkstra query ledger-peer-snapshot 
+                                                         [--cardano-mode
+                                                           [--epoch-slots SLOTS]]
+                                                         ( --mainnet
+                                                         | --testnet-magic NATURAL
+                                                         )
+                                                         --socket-path SOCKET_PATH
+                                                         [ --volatile-tip
+                                                         | --immutable-tip
+                                                         ]
+                                                         [--all-ledger-peers]
+                                                         [ --output-json
+                                                         | --output-yaml
+                                                         ]
+                                                         [--out-file FILEPATH]
+                                                         
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
+
+Usage: cardano-cli dijkstra query ledger-state 
+                                                 [--cardano-mode
+                                                   [--epoch-slots SLOTS]]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 --socket-path SOCKET_PATH
+                                                 [ --volatile-tip
+                                                 | --immutable-tip
+                                                 ]
+                                                 [ --output-json
+                                                 | --output-text
+                                                 | --output-yaml
+                                                 ]
+                                                 [--out-file FILEPATH]
+                                                 
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Usage: cardano-cli dijkstra query pool-params 
+                                                [--cardano-mode
+                                                  [--epoch-slots SLOTS]]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --socket-path SOCKET_PATH
+                                                [ --volatile-tip
+                                                | --immutable-tip
+                                                ]
+                                                ( --all-stake-pools
+                                                | (--stake-pool-id STAKE_POOL_ID)
+                                                )
+                                                [--output-json | --output-yaml]
+                                                [--out-file FILEPATH]
+                                                
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Usage: cardano-cli dijkstra query pool-state 
+                                               [--cardano-mode
+                                                 [--epoch-slots SLOTS]]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               --socket-path SOCKET_PATH
+                                               [ --volatile-tip
+                                               | --immutable-tip
+                                               ]
+                                               ( --all-stake-pools
+                                               | (--stake-pool-id STAKE_POOL_ID)
+                                               )
+                                               [--output-json | --output-yaml]
+                                               [--out-file FILEPATH]
+                                               
+
+  Dump the pool state
+
+Usage: cardano-cli dijkstra query proposals 
+                                              [--cardano-mode
+                                                [--epoch-slots SLOTS]]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              --socket-path SOCKET_PATH
+                                              [--volatile-tip | --immutable-tip]
+                                              ( --all-proposals
+                                              | (--governance-action-tx-id TXID
+                                                --governance-action-index WORD16)
+                                              )
+                                              [--output-json | --output-yaml]
+                                              [--out-file FILEPATH]
+                                              
+
+  Get the governance proposals that are eligible for ratification. Proposals
+  submitted during the current epoch are excluded, as they cannot be ratified
+  until the next epoch.
+
+Usage: cardano-cli dijkstra query protocol-parameters 
+                                                        [--cardano-mode
+                                                          [--epoch-slots SLOTS]]
+                                                        ( --mainnet
+                                                        | --testnet-magic NATURAL
+                                                        )
+                                                        --socket-path SOCKET_PATH
+                                                        [ --output-json
+                                                        | --output-yaml
+                                                        ]
+                                                        [--out-file FILEPATH]
+                                                        
+
+  Get the node's current protocol parameters
+
+Usage: cardano-cli dijkstra query protocol-state 
+                                                   [--cardano-mode
+                                                     [--epoch-slots SLOTS]]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --socket-path SOCKET_PATH
+                                                   [ --volatile-tip
+                                                   | --immutable-tip
+                                                   ]
+                                                   [ --output-cbor-bin
+                                                   | --output-cbor-hex
+                                                   | --output-json
+                                                   | --output-yaml
+                                                   ]
+                                                   [--out-file FILEPATH]
+                                                   
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Usage: cardano-cli dijkstra query ratify-state 
+                                                 [--cardano-mode
+                                                   [--epoch-slots SLOTS]]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 --socket-path SOCKET_PATH
+                                                 [ --volatile-tip
+                                                 | --immutable-tip
+                                                 ]
+                                                 [--output-json | --output-yaml]
+                                                 [--out-file FILEPATH]
+                                                 
+
+  Get the ratification state
+
+Usage: cardano-cli dijkstra query ref-script-size 
+                                                    [--cardano-mode
+                                                      [--epoch-slots SLOTS]]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    --socket-path SOCKET_PATH
+                                                    [ --volatile-tip
+                                                    | --immutable-tip
+                                                    ]
+                                                    (--tx-in TX_IN)
+                                                    [ --output-json
+                                                    | --output-text
+                                                    | --output-yaml
+                                                    ]
+                                                    [--out-file FILEPATH]
+                                                    
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
+
+Usage: cardano-cli dijkstra query slot-number 
+                                                [--cardano-mode
+                                                  [--epoch-slots SLOTS]]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --socket-path SOCKET_PATH
+                                                [ --volatile-tip
+                                                | --immutable-tip
+                                                ]
+                                                TIMESTAMP
+                                                
+
+  Query slot number for UTC timestamp
+
+Usage: cardano-cli dijkstra query spo-stake-distribution 
+                                                           [--cardano-mode
+                                                             [--epoch-slots SLOTS]]
+                                                           ( --mainnet
+                                                           | --testnet-magic NATURAL
+                                                           )
+                                                           --socket-path SOCKET_PATH
+                                                           [ --volatile-tip
+                                                           | --immutable-tip
+                                                           ]
+                                                           ( --all-spos
+                                                           | 
+                                                           ( --spo-verification-key STRING
+                                                           | --spo-verification-key-file FILEPATH
+                                                           | --spo-key-hash HASH
+                                                           )
+                                                           )
+                                                           [ --output-json
+                                                           | --output-yaml
+                                                           ]
+                                                           [--out-file FILEPATH]
+                                                           
+
+  Get the SPO stake distribution.
+
+Usage: cardano-cli dijkstra query stake-address-info 
+                                                       [--cardano-mode
+                                                         [--epoch-slots SLOTS]]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       --socket-path SOCKET_PATH
+                                                       [ --volatile-tip
+                                                       | --immutable-tip
+                                                       ]
+                                                       --address ADDRESS
+                                                       [ --output-json
+                                                       | --output-yaml
+                                                       ]
+                                                       [--out-file FILEPATH]
+                                                       
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Usage: cardano-cli dijkstra query stake-distribution 
+                                                       [--cardano-mode
+                                                         [--epoch-slots SLOTS]]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       --socket-path SOCKET_PATH
+                                                       [ --volatile-tip
+                                                       | --immutable-tip
+                                                       ]
+                                                       [ --output-json
+                                                       | --output-text
+                                                       | --output-yaml
+                                                       ]
+                                                       [--out-file FILEPATH]
+                                                       
+
+  Get the node's current aggregated stake distribution
+
+Usage: cardano-cli dijkstra query stake-pools 
+                                                [--cardano-mode
+                                                  [--epoch-slots SLOTS]]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --socket-path SOCKET_PATH
+                                                [ --volatile-tip
+                                                | --immutable-tip
+                                                ]
+                                                [ --output-json
+                                                | --output-text
+                                                | --output-yaml
+                                                ]
+                                                [--out-file FILEPATH]
+                                                
+
+  Get the node's current set of stake pool ids
+
+Usage: cardano-cli dijkstra query stake-pool-default-vote 
+                                                            [--cardano-mode
+                                                              [--epoch-slots SLOTS]]
+                                                            ( --mainnet
+                                                            | --testnet-magic NATURAL
+                                                            )
+                                                            --socket-path SOCKET_PATH
+                                                            [ --volatile-tip
+                                                            | --immutable-tip
+                                                            ]
+                                                            ( --spo-verification-key STRING
+                                                            | --spo-verification-key-file FILEPATH
+                                                            | --spo-key-hash HASH
+                                                            )
+                                                            [ --output-json
+                                                            | --output-yaml
+                                                            ]
+                                                            [--out-file FILEPATH]
+                                                            
+
+  Get the stake pool default vote.
+
+Usage: cardano-cli dijkstra query stake-snapshot 
+                                                   [--cardano-mode
+                                                     [--epoch-slots SLOTS]]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --socket-path SOCKET_PATH
+                                                   [ --volatile-tip
+                                                   | --immutable-tip
+                                                   ]
+                                                   ( --all-stake-pools
+                                                   | (--stake-pool-id STAKE_POOL_ID)
+                                                   )
+                                                   [ --output-json
+                                                   | --output-yaml
+                                                   ]
+                                                   [--out-file FILEPATH]
+                                                   
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Usage: cardano-cli dijkstra query tip [--cardano-mode [--epoch-slots SLOTS]]
+                                        (--mainnet | --testnet-magic NATURAL)
+                                        --socket-path SOCKET_PATH
+                                        [--volatile-tip | --immutable-tip]
+                                        [--output-json | --output-yaml]
+                                        [--out-file FILEPATH]
+                                        
+
+  Get the node's current tip (slot no, hash, block no)
+
+Usage: cardano-cli dijkstra query treasury 
+                                             [--cardano-mode
+                                               [--epoch-slots SLOTS]]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             --socket-path SOCKET_PATH
+                                             [--volatile-tip | --immutable-tip]
+                                             [--out-file FILEPATH]
+                                             
+
+  Get the treasury value
+
+Usage: cardano-cli dijkstra query tx-mempool 
+                                               [--cardano-mode
+                                                 [--epoch-slots SLOTS]]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               --socket-path SOCKET_PATH
+                                               (info | next-tx | tx-exists)
+                                               [--output-json | --output-yaml]
+                                               [--out-file FILEPATH]
+                                               
+
+  Local Mempool info
+
+Usage: cardano-cli dijkstra query tx-mempool info 
+
+  Ask the node about the current mempool's capacity and sizes
+
+Usage: cardano-cli dijkstra query tx-mempool next-tx 
+
+  Requests the next transaction from the mempool's current list
+
+Usage: cardano-cli dijkstra query tx-mempool tx-exists TX_ID 
+
+  Query if a particular transaction exists in the mempool
+
+Usage: cardano-cli dijkstra query utxo [--cardano-mode [--epoch-slots SLOTS]]
+                                         (--mainnet | --testnet-magic NATURAL)
+                                         --socket-path SOCKET_PATH
+                                         [--volatile-tip | --immutable-tip]
+                                         ( --whole-utxo
+                                         | (--address ADDRESS)
+                                         | (--tx-in TX_IN)
+                                         )
+                                         [ --output-cbor-bin
+                                         | --output-cbor-hex
+                                         | --output-json
+                                         | --output-text
+                                         | --output-yaml
+                                         ]
+                                         [--out-file FILEPATH]
+                                         
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Usage: cardano-cli dijkstra stake-address 
+                                            ( key-gen
+                                            | key-hash
+                                            | build
+                                            | registration-certificate
+                                            | deregistration-certificate
+                                            | stake-delegation-certificate
+                                            | stake-and-vote-delegation-certificate
+                                            | vote-delegation-certificate
+                                            | registration-and-delegation-certificate
+                                            | registration-and-vote-delegation-certificate
+                                            | registration-stake-and-vote-delegation-certificate
+                                            )
+                                            
+
+  Stake address commands.
+
+Usage: cardano-cli dijkstra stake-address key-gen 
+                                                    [ --key-output-bech32
+                                                    | --key-output-text-envelope
+                                                    | --key-output-format STRING
+                                                    ]
+                                                    --verification-key-file FILEPATH
+                                                    --signing-key-file FILEPATH
+                                                    
+
+  Create a stake address key pair
+
+Usage: cardano-cli dijkstra stake-address key-hash 
+                                                     ( --stake-verification-key STRING
+                                                     | --stake-verification-key-file FILEPATH
+                                                     )
+                                                     [--out-file FILEPATH]
+                                                     
+
+  Print the hash of a stake address key
+
+Usage: cardano-cli dijkstra stake-address build 
+                                                  ( --stake-verification-key STRING
+                                                  | --stake-verification-key-file FILEPATH
+                                                  | --stake-key-hash HASH
+                                                  | --stake-script-file FILEPATH
+                                                  )
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILEPATH]
+                                                  
+
+  Build a stake address
+
+Usage: cardano-cli dijkstra stake-address registration-certificate 
+                                                                     ( --stake-verification-key STRING
+                                                                     | --stake-verification-key-file FILEPATH
+                                                                     | --stake-key-hash HASH
+                                                                     | --stake-script-file FILEPATH
+                                                                     | --stake-address ADDRESS
+                                                                     )
+                                                                     --key-reg-deposit-amt NATURAL
+                                                                     --out-file FILEPATH
+                                                                     
+
+  Create a stake address registration certificate
+
+Usage: cardano-cli dijkstra stake-address deregistration-certificate 
+                                                                       ( --stake-verification-key STRING
+                                                                       | --stake-verification-key-file FILEPATH
+                                                                       | --stake-key-hash HASH
+                                                                       | --stake-script-file FILEPATH
+                                                                       | --stake-address ADDRESS
+                                                                       )
+                                                                       --key-reg-deposit-amt NATURAL
+                                                                       --out-file FILEPATH
+                                                                       
+
+  Create a stake address deregistration certificate
+
+Usage: cardano-cli dijkstra stake-address stake-delegation-certificate 
+                                                                         ( --stake-verification-key STRING
+                                                                         | --stake-verification-key-file FILEPATH
+                                                                         | --stake-key-hash HASH
+                                                                         | --stake-script-file FILEPATH
+                                                                         | --stake-address ADDRESS
+                                                                         )
+                                                                         ( --stake-pool-verification-key STRING
+                                                                         | --stake-pool-verification-extended-key STRING
+                                                                         | --cold-verification-key-file FILEPATH
+                                                                         | --stake-pool-id STAKE_POOL_ID
+                                                                         )
+                                                                         --out-file FILEPATH
+                                                                         
+
+  Create a stake address stake delegation certificate, which when submitted in a
+  transaction delegates stake to a stake pool.
+
+Usage: cardano-cli dijkstra stake-address stake-and-vote-delegation-certificate 
+                                                                                  ( --stake-verification-key STRING
+                                                                                  | --stake-verification-key-file FILEPATH
+                                                                                  | --stake-key-hash HASH
+                                                                                  | --stake-script-file FILEPATH
+                                                                                  | --stake-address ADDRESS
+                                                                                  )
+                                                                                  ( --stake-pool-verification-key STRING
+                                                                                  | --stake-pool-verification-extended-key STRING
+                                                                                  | --cold-verification-key-file FILEPATH
+                                                                                  | --stake-pool-id STAKE_POOL_ID
+                                                                                  )
+                                                                                  ( --drep-script-hash HASH
+                                                                                  | --drep-verification-key STRING
+                                                                                  | --drep-verification-key-file FILEPATH
+                                                                                  | --drep-key-hash HASH
+                                                                                  | --always-abstain
+                                                                                  | --always-no-confidence
+                                                                                  )
+                                                                                  --out-file FILEPATH
+                                                                                  
+
+  Create a stake address stake and vote delegation certificate, which when
+  submitted in a transaction delegates stake to a stake pool and a DRep.
+
+Usage: cardano-cli dijkstra stake-address vote-delegation-certificate 
+                                                                        ( --stake-verification-key STRING
+                                                                        | --stake-verification-key-file FILEPATH
+                                                                        | --stake-key-hash HASH
+                                                                        | --stake-script-file FILEPATH
+                                                                        | --stake-address ADDRESS
+                                                                        )
+                                                                        ( --drep-script-hash HASH
+                                                                        | --drep-verification-key STRING
+                                                                        | --drep-verification-key-file FILEPATH
+                                                                        | --drep-key-hash HASH
+                                                                        | --always-abstain
+                                                                        | --always-no-confidence
+                                                                        )
+                                                                        --out-file FILEPATH
+                                                                        
+
+  Create a stake address vote delegation certificate, which when submitted in a
+  transaction delegates stake to a DRep.
+
+Usage: cardano-cli dijkstra stake-address registration-and-delegation-certificate 
+                                                                                    ( --stake-verification-key STRING
+                                                                                    | --stake-verification-key-file FILEPATH
+                                                                                    | --stake-key-hash HASH
+                                                                                    | --stake-script-file FILEPATH
+                                                                                    | --stake-address ADDRESS
+                                                                                    )
+                                                                                    ( --stake-pool-verification-key STRING
+                                                                                    | --stake-pool-verification-extended-key STRING
+                                                                                    | --cold-verification-key-file FILEPATH
+                                                                                    | --stake-pool-id STAKE_POOL_ID
+                                                                                    )
+                                                                                    --key-reg-deposit-amt NATURAL
+                                                                                    --out-file FILEPATH
+                                                                                    
+
+  Create a stake address registration and delegation certificate, which when
+  submitted in a transaction registers a stake address and delegates stake to a
+  stake pool.
+
+Usage: cardano-cli dijkstra stake-address registration-and-vote-delegation-certificate 
+                                                                                         ( --stake-verification-key STRING
+                                                                                         | --stake-verification-key-file FILEPATH
+                                                                                         | --stake-key-hash HASH
+                                                                                         | --stake-script-file FILEPATH
+                                                                                         | --stake-address ADDRESS
+                                                                                         )
+                                                                                         ( --drep-script-hash HASH
+                                                                                         | --drep-verification-key STRING
+                                                                                         | --drep-verification-key-file FILEPATH
+                                                                                         | --drep-key-hash HASH
+                                                                                         | --always-abstain
+                                                                                         | --always-no-confidence
+                                                                                         )
+                                                                                         --key-reg-deposit-amt NATURAL
+                                                                                         --out-file FILEPATH
+                                                                                         
+
+  Create a stake address registration and vote delegation certificate, which
+  when submitted in a transaction registers a stake address and delegates votes
+  to a DRep or pre-defined voting option.
+
+Usage: cardano-cli dijkstra stake-address registration-stake-and-vote-delegation-certificate 
+                                                                                               ( --stake-verification-key STRING
+                                                                                               | --stake-verification-key-file FILEPATH
+                                                                                               | --stake-key-hash HASH
+                                                                                               | --stake-script-file FILEPATH
+                                                                                               | --stake-address ADDRESS
+                                                                                               )
+                                                                                               ( --stake-pool-verification-key STRING
+                                                                                               | --stake-pool-verification-extended-key STRING
+                                                                                               | --cold-verification-key-file FILEPATH
+                                                                                               | --stake-pool-id STAKE_POOL_ID
+                                                                                               )
+                                                                                               ( --drep-script-hash HASH
+                                                                                               | --drep-verification-key STRING
+                                                                                               | --drep-verification-key-file FILEPATH
+                                                                                               | --drep-key-hash HASH
+                                                                                               | --always-abstain
+                                                                                               | --always-no-confidence
+                                                                                               )
+                                                                                               --key-reg-deposit-amt NATURAL
+                                                                                               --out-file FILEPATH
+                                                                                               
+
+  Create a stake address registration, stake delegation and vote delegation
+  certificate, which when submitted in a transaction registers a stake address,
+  delgates stake to a pool, and delegates votes to a DRep or pre-defined voting
+  option.
+
+Usage: cardano-cli dijkstra stake-pool 
+                                         ( registration-certificate
+                                         | deregistration-certificate
+                                         | id
+                                         | metadata-hash
+                                         )
+                                         
+
+  Stake pool commands.
+
+Usage: cardano-cli dijkstra stake-pool registration-certificate 
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --stake-pool-verification-extended-key STRING
+                                                                  | --cold-verification-key-file FILEPATH
+                                                                  )
+                                                                  ( --vrf-verification-key STRING
+                                                                  | --vrf-verification-key-file FILEPATH
+                                                                  )
+                                                                  --pool-pledge LOVELACE
+                                                                  --pool-cost LOVELACE
+                                                                  --pool-margin RATIONAL
+                                                                  ( --pool-reward-account-verification-key STRING
+                                                                  | --pool-reward-account-verification-key-file FILEPATH
+                                                                  )
+                                                                  ( --pool-owner-verification-key STRING
+                                                                  | --pool-owner-stake-verification-key-file FILEPATH
+                                                                  )
+                                                                  [ [--pool-relay-ipv4 STRING]
+                                                                    [--pool-relay-ipv6 STRING]
+                                                                    --pool-relay-port INT
+                                                                  | --single-host-pool-relay STRING
+                                                                    --pool-relay-port INT
+                                                                  | --multi-host-pool-relay STRING
+                                                                  ]
+                                                                  [--validate-relays]
+                                                                  [--metadata-url URL
+                                                                    --metadata-hash HASH
+                                                                    [--check-metadata-hash]]
+                                                                  ( --mainnet
+                                                                  | --testnet-magic NATURAL
+                                                                  )
+                                                                  --out-file FILEPATH
+                                                                  
+
+  Create a stake pool registration certificate
+
+Usage: cardano-cli dijkstra stake-pool deregistration-certificate 
+                                                                    ( --stake-pool-verification-key STRING
+                                                                    | --stake-pool-verification-extended-key STRING
+                                                                    | --cold-verification-key-file FILEPATH
+                                                                    )
+                                                                    --epoch NATURAL
+                                                                    --out-file FILEPATH
+                                                                    
+
+  Create a stake pool deregistration certificate
+
+Usage: cardano-cli dijkstra stake-pool id 
+                                            ( --stake-pool-verification-key STRING
+                                            | --stake-pool-verification-extended-key STRING
+                                            | --cold-verification-key-file FILEPATH
+                                            )
+                                            [--output-bech32 | --output-hex]
+                                            [--out-file FILEPATH]
+                                            
+
+  Build pool id from the offline key
+
+Usage: cardano-cli dijkstra stake-pool metadata-hash 
+                                                       ( --pool-metadata-file FILEPATH
+                                                       | --pool-metadata-url TEXT
+                                                       )
+                                                       [ --expected-hash HASH
+                                                       | --out-file FILEPATH
+                                                       ]
+                                                       
+
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
+
+Usage: cardano-cli dijkstra text-view decode-cbor 
+
+  Commands for dealing with Shelley TextView files. Transactions, addresses etc
+  are stored on disk as TextView files.
+
+Usage: cardano-cli dijkstra text-view decode-cbor --in-file FILEPATH
+                                                    [ --output-cbor-hex
+                                                    | --output-json
+                                                    | --output-text
+                                                    | --output-yaml
+                                                    ]
+                                                    [--out-file FILEPATH]
+                                                    
+
+  Print a TextView file as decoded CBOR.
+
+Usage: cardano-cli dijkstra transaction 
+                                          ( build-raw
+                                          | build
+                                          | build-estimate
+                                          | sign
+                                          | witness
+                                          | assemble
+                                          | submit
+                                          | policyid
+                                          | calculate-min-fee
+                                          | calculate-min-required-utxo
+                                          | calculate-plutus-script-cost
+                                          | hash-script-data
+                                          | txid
+                                          )
+                                          
+
+  Transaction commands.
+
+Usage: cardano-cli dijkstra transaction build-raw 
+                                                    [ --script-valid
+                                                    | --script-invalid
+                                                    ]
+                                                    (--tx-in TX_IN
+                                                      [ --spending-tx-in-reference TX_IN
+                                                        ( --spending-plutus-script-v2
+                                                        | --spending-plutus-script-v3
+                                                        )
+                                                        [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                        | --spending-reference-tx-in-datum-file JSON_FILE
+                                                        | --spending-reference-tx-in-datum-value JSON_VALUE
+                                                        | --spending-reference-tx-in-inline-datum-present
+                                                        ]
+                                                        ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                        | --spending-reference-tx-in-redeemer-value JSON_VALUE
+                                                        )
+                                                        --spending-reference-tx-in-execution-units (INT, INT)
+                                                      | --simple-script-tx-in-reference TX_IN
+                                                      | --tx-in-script-file FILEPATH
+                                                        [
+                                                          [ --tx-in-datum-cbor-file CBOR_FILE
+                                                          | --tx-in-datum-file JSON_FILE
+                                                          | --tx-in-datum-value JSON_VALUE
+                                                          | --tx-in-inline-datum-present
+                                                          ]
+                                                          ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                          | --tx-in-redeemer-file JSON_FILE
+                                                          | --tx-in-redeemer-value JSON_VALUE
+                                                          )
+                                                          --tx-in-execution-units (INT, INT)]
+                                                      ])
+                                                    [--read-only-tx-in-reference TX_IN]
+                                                    [--tx-in-collateral TX_IN]
+                                                    [--tx-out-return-collateral ADDRESS VALUE]
+                                                    [--tx-total-collateral INTEGER]
+                                                    [ --required-signer FILEPATH
+                                                    | --required-signer-hash HASH
+                                                    ]
+                                                    [--tx-out ADDRESS VALUE
+                                                      [ --tx-out-datum-hash HASH
+                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                      | --tx-out-datum-hash-file JSON_FILE
+                                                      | --tx-out-datum-hash-value JSON_VALUE
+                                                      | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                      | --tx-out-datum-embed-file JSON_FILE
+                                                      | --tx-out-datum-embed-value JSON_VALUE
+                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                      | --tx-out-inline-datum-file JSON_FILE
+                                                      | --tx-out-inline-datum-value JSON_VALUE
+                                                      ]
+                                                      [--tx-out-reference-script-file FILEPATH]]
+                                                    [--mint VALUE
+                                                      ( --mint-script-file FILEPATH
+                                                        [
+                                                          ( --mint-redeemer-cbor-file CBOR_FILE
+                                                          | --mint-redeemer-file JSON_FILE
+                                                          | --mint-redeemer-value JSON_VALUE
+                                                          )
+                                                          --mint-execution-units (INT, INT)]
+                                                      | --simple-minting-script-tx-in-reference TX_IN
+                                                        --policy-id HASH
+                                                      | --mint-tx-in-reference TX_IN
+                                                        ( --mint-plutus-script-v2
+                                                        | --mint-plutus-script-v3
+                                                        )
+                                                        ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                        | --mint-reference-tx-in-redeemer-value JSON_VALUE
+                                                        )
+                                                        --mint-reference-tx-in-execution-units (INT, INT)
+                                                        --policy-id HASH
+                                                      )]
+                                                    [--invalid-before SLOT]
+                                                    [--invalid-hereafter SLOT]
+                                                    --fee LOVELACE
+                                                    [--certificate-file FILEPATH
+                                                      [ --certificate-script-file FILEPATH
+                                                        [
+                                                          ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                          | --certificate-redeemer-file JSON_FILE
+                                                          | --certificate-redeemer-value JSON_VALUE
+                                                          )
+                                                          --certificate-execution-units (INT, INT)]
+                                                      | --certificate-tx-in-reference TX_IN
+                                                        ( --certificate-plutus-script-v2
+                                                        | --certificate-plutus-script-v3
+                                                        )
+                                                        ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                        | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                        )
+                                                        --certificate-reference-tx-in-execution-units (INT, INT)
+                                                      ]]
+                                                    [--withdrawal WITHDRAWAL
+                                                      [ --withdrawal-script-file FILEPATH
+                                                        [
+                                                          ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                          | --withdrawal-redeemer-file JSON_FILE
+                                                          | --withdrawal-redeemer-value JSON_VALUE
+                                                          )
+                                                          --withdrawal-execution-units (INT, INT)]
+                                                      | --withdrawal-tx-in-reference TX_IN
+                                                        ( --withdrawal-plutus-script-v2
+                                                        | --withdrawal-plutus-script-v3
+                                                        )
+                                                        ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                        | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                                                        )
+                                                        --withdrawal-reference-tx-in-execution-units (INT, INT)
+                                                      ]]
+                                                    [ --json-metadata-no-schema
+                                                    | --json-metadata-detailed-schema
+                                                    ]
+                                                    [--auxiliary-script-file FILEPATH]
+                                                    [ --metadata-json-file FILEPATH
+                                                    | --metadata-cbor-file FILEPATH
+                                                    ]
+                                                    [--protocol-params-file FILEPATH]
+                                                    [--vote-file FILEPATH
+                                                      [ --vote-script-file FILEPATH
+                                                        [
+                                                          ( --vote-redeemer-cbor-file CBOR_FILE
+                                                          | --vote-redeemer-file JSON_FILE
+                                                          | --vote-redeemer-value JSON_VALUE
+                                                          )
+                                                          --vote-execution-units (INT, INT)]
+                                                      | --vote-tx-in-reference TX_IN
+                                                        --vote-plutus-script-v3
+                                                        ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                        | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                        )
+                                                        --vote-reference-tx-in-execution-units (INT, INT)
+                                                      ]]
+                                                    [--proposal-file FILEPATH
+                                                      [ --proposal-script-file FILEPATH
+                                                        [
+                                                          ( --proposal-redeemer-cbor-file CBOR_FILE
+                                                          | --proposal-redeemer-file JSON_FILE
+                                                          | --proposal-redeemer-value JSON_VALUE
+                                                          )
+                                                          --proposal-execution-units (INT, INT)]
+                                                      | --proposal-tx-in-reference TX_IN
+                                                        --proposal-plutus-script-v3
+                                                        ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                        | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                        )
+                                                        --proposal-reference-tx-in-execution-units (INT, INT)
+                                                      ]]
+                                                    [--current-treasury-value LOVELACE]
+                                                    [--treasury-donation LOVELACE]
+                                                    [--out-canonical-cbor]
+                                                    --out-file FILEPATH
+                                                    
+
+  Build a transaction (low-level, inconvenient)
+
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+
+Usage: cardano-cli dijkstra transaction build 
+                                                [--cardano-mode
+                                                  [--epoch-slots SLOTS]]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --socket-path SOCKET_PATH
+                                                [ --script-valid
+                                                | --script-invalid
+                                                ]
+                                                [--witness-override WORD]
+                                                (--tx-in TX_IN
+                                                  [ --spending-tx-in-reference TX_IN
+                                                    ( --spending-plutus-script-v2
+                                                    | --spending-plutus-script-v3
+                                                    )
+                                                    [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                    | --spending-reference-tx-in-datum-file JSON_FILE
+                                                    | --spending-reference-tx-in-datum-value JSON_VALUE
+                                                    | --spending-reference-tx-in-inline-datum-present
+                                                    ]
+                                                    ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --spending-reference-tx-in-redeemer-value JSON_VALUE
+                                                    )
+                                                  | --simple-script-tx-in-reference TX_IN
+                                                  | --tx-in-script-file FILEPATH
+                                                    [
+                                                      [ --tx-in-datum-cbor-file CBOR_FILE
+                                                      | --tx-in-datum-file JSON_FILE
+                                                      | --tx-in-datum-value JSON_VALUE
+                                                      | --tx-in-inline-datum-present
+                                                      ]
+                                                      ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --tx-in-redeemer-file JSON_FILE
+                                                      | --tx-in-redeemer-value JSON_VALUE
+                                                      )]
+                                                  ])
+                                                [--read-only-tx-in-reference TX_IN]
+                                                [ --required-signer FILEPATH
+                                                | --required-signer-hash HASH
+                                                ]
+                                                [--tx-in-collateral TX_IN]
+                                                [--tx-out-return-collateral ADDRESS VALUE]
+                                                [--tx-total-collateral INTEGER]
+                                                [--tx-out ADDRESS VALUE
+                                                  [ --tx-out-datum-hash HASH
+                                                  | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                  | --tx-out-datum-hash-file JSON_FILE
+                                                  | --tx-out-datum-hash-value JSON_VALUE
+                                                  | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                  | --tx-out-datum-embed-file JSON_FILE
+                                                  | --tx-out-datum-embed-value JSON_VALUE
+                                                  | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                  | --tx-out-inline-datum-file JSON_FILE
+                                                  | --tx-out-inline-datum-value JSON_VALUE
+                                                  ]
+                                                  [--tx-out-reference-script-file FILEPATH]]
+                                                --change-address ADDRESS
+                                                [--mint VALUE
+                                                  ( --mint-script-file FILEPATH
+                                                    [ --mint-redeemer-cbor-file CBOR_FILE
+                                                    | --mint-redeemer-file JSON_FILE
+                                                    | --mint-redeemer-value JSON_VALUE
+                                                    ]
+                                                  | --simple-minting-script-tx-in-reference TX_IN
+                                                    --policy-id HASH
+                                                  | --mint-tx-in-reference TX_IN
+                                                    ( --mint-plutus-script-v2
+                                                    | --mint-plutus-script-v3
+                                                    )
+                                                    ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --mint-reference-tx-in-redeemer-value JSON_VALUE
+                                                    )
+                                                    --policy-id HASH
+                                                  )]
+                                                [--invalid-before SLOT]
+                                                [--invalid-hereafter SLOT]
+                                                [--certificate-file FILEPATH
+                                                  [ --certificate-script-file FILEPATH
+                                                    [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                    | --certificate-redeemer-file JSON_FILE
+                                                    | --certificate-redeemer-value JSON_VALUE
+                                                    ]
+                                                  | --certificate-tx-in-reference TX_IN
+                                                    ( --certificate-plutus-script-v2
+                                                    | --certificate-plutus-script-v3
+                                                    )
+                                                    ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                    )
+                                                  ]]
+                                                [--withdrawal WITHDRAWAL
+                                                  [ --withdrawal-script-file FILEPATH
+                                                    [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                    | --withdrawal-redeemer-file JSON_FILE
+                                                    | --withdrawal-redeemer-value JSON_VALUE
+                                                    ]
+                                                  | --withdrawal-tx-in-reference TX_IN
+                                                    ( --withdrawal-plutus-script-v2
+                                                    | --withdrawal-plutus-script-v3
+                                                    )
+                                                    ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                                                    )
+                                                  ]]
+                                                [ --json-metadata-no-schema
+                                                | --json-metadata-detailed-schema
+                                                ]
+                                                [--auxiliary-script-file FILEPATH]
+                                                [ --metadata-json-file FILEPATH
+                                                | --metadata-cbor-file FILEPATH
+                                                ]
+                                                [--vote-file FILEPATH
+                                                  [ --vote-script-file FILEPATH
+                                                    [ --vote-redeemer-cbor-file CBOR_FILE
+                                                    | --vote-redeemer-file JSON_FILE
+                                                    | --vote-redeemer-value JSON_VALUE
+                                                    ]
+                                                  | --vote-tx-in-reference TX_IN
+                                                    --vote-plutus-script-v3
+                                                    ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                    )
+                                                  ]]
+                                                [--proposal-file FILEPATH
+                                                  [ --proposal-script-file FILEPATH
+                                                    [ --proposal-redeemer-cbor-file CBOR_FILE
+                                                    | --proposal-redeemer-file JSON_FILE
+                                                    | --proposal-redeemer-value JSON_VALUE
+                                                    ]
+                                                  | --proposal-tx-in-reference TX_IN
+                                                    --proposal-plutus-script-v3
+                                                    ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                    )
+                                                  ]]
+                                                [--current-treasury-value]
+                                                [--treasury-donation LOVELACE]
+                                                [--out-canonical-cbor]
+                                                ( --out-file FILEPATH
+                                                | --calculate-plutus-script-cost FILEPATH
+                                                )
+                                                
+
+  Build a balanced transaction (automatically calculates fees)
+
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+
+Usage: cardano-cli dijkstra transaction build-estimate 
+                                                         [ --script-valid
+                                                         | --script-invalid
+                                                         ]
+                                                         --shelley-key-witnesses INT
+                                                         [--byron-key-witnesses Int]
+                                                         --protocol-params-file FILEPATH
+                                                         --total-utxo-value VALUE
+                                                         (--tx-in TX_IN
+                                                           [ --spending-tx-in-reference TX_IN
+                                                             ( --spending-plutus-script-v2
+                                                             | --spending-plutus-script-v3
+                                                             )
+                                                             [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                             | --spending-reference-tx-in-datum-file JSON_FILE
+                                                             | --spending-reference-tx-in-datum-value JSON_VALUE
+                                                             | --spending-reference-tx-in-inline-datum-present
+                                                             ]
+                                                             ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                             | --spending-reference-tx-in-redeemer-value JSON_VALUE
+                                                             )
+                                                             --spending-reference-tx-in-execution-units (INT, INT)
+                                                           | --simple-script-tx-in-reference TX_IN
+                                                           | --tx-in-script-file FILEPATH
+                                                             [
+                                                               [ --tx-in-datum-cbor-file CBOR_FILE
+                                                               | --tx-in-datum-file JSON_FILE
+                                                               | --tx-in-datum-value JSON_VALUE
+                                                               | --tx-in-inline-datum-present
+                                                               ]
+                                                               ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                               | --tx-in-redeemer-file JSON_FILE
+                                                               | --tx-in-redeemer-value JSON_VALUE
+                                                               )
+                                                               --tx-in-execution-units (INT, INT)]
+                                                           ])
+                                                         [--read-only-tx-in-reference TX_IN]
+                                                         [ --required-signer FILEPATH
+                                                         | --required-signer-hash HASH
+                                                         ]
+                                                         [--tx-in-collateral TX_IN]
+                                                         [--tx-out-return-collateral ADDRESS VALUE]
+                                                         [--tx-out ADDRESS VALUE
+                                                           [ --tx-out-datum-hash HASH
+                                                           | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                           | --tx-out-datum-hash-file JSON_FILE
+                                                           | --tx-out-datum-hash-value JSON_VALUE
+                                                           | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                           | --tx-out-datum-embed-file JSON_FILE
+                                                           | --tx-out-datum-embed-value JSON_VALUE
+                                                           | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                           | --tx-out-inline-datum-file JSON_FILE
+                                                           | --tx-out-inline-datum-value JSON_VALUE
+                                                           ]
+                                                           [--tx-out-reference-script-file FILEPATH]]
+                                                         --change-address ADDRESS
+                                                         [--mint VALUE
+                                                           ( --mint-script-file FILEPATH
+                                                             [
+                                                               ( --mint-redeemer-cbor-file CBOR_FILE
+                                                               | --mint-redeemer-file JSON_FILE
+                                                               | --mint-redeemer-value JSON_VALUE
+                                                               )
+                                                               --mint-execution-units (INT, INT)]
+                                                           | --simple-minting-script-tx-in-reference TX_IN
+                                                             --policy-id HASH
+                                                           | --mint-tx-in-reference TX_IN
+                                                             ( --mint-plutus-script-v2
+                                                             | --mint-plutus-script-v3
+                                                             )
+                                                             ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                             | --mint-reference-tx-in-redeemer-value JSON_VALUE
+                                                             )
+                                                             --mint-reference-tx-in-execution-units (INT, INT)
+                                                             --policy-id HASH
+                                                           )]
+                                                         [--invalid-before SLOT]
+                                                         [--invalid-hereafter SLOT]
+                                                         [
+                                                           --certificate-file FILEPATH
+                                                           [ --certificate-script-file FILEPATH
+                                                             [
+                                                               ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                               | --certificate-redeemer-file JSON_FILE
+                                                               | --certificate-redeemer-value JSON_VALUE
+                                                               )
+                                                               --certificate-execution-units (INT, INT)]
+                                                           | --certificate-tx-in-reference TX_IN
+                                                             ( --certificate-plutus-script-v2
+                                                             | --certificate-plutus-script-v3
+                                                             )
+                                                             ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                             | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                             )
+                                                             --certificate-reference-tx-in-execution-units (INT, INT)
+                                                           ]]
+                                                         [--withdrawal WITHDRAWAL
+                                                           [ --withdrawal-script-file FILEPATH
+                                                             [
+                                                               ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                               | --withdrawal-redeemer-file JSON_FILE
+                                                               | --withdrawal-redeemer-value JSON_VALUE
+                                                               )
+                                                               --withdrawal-execution-units (INT, INT)]
+                                                           | --withdrawal-tx-in-reference TX_IN
+                                                             ( --withdrawal-plutus-script-v2
+                                                             | --withdrawal-plutus-script-v3
+                                                             )
+                                                             ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                             | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                                                             )
+                                                             --withdrawal-reference-tx-in-execution-units (INT, INT)
+                                                           ]]
+                                                         [--tx-total-collateral INTEGER]
+                                                         [--reference-script-size NATURAL]
+                                                         [ --json-metadata-no-schema
+                                                         | --json-metadata-detailed-schema
+                                                         ]
+                                                         [--auxiliary-script-file FILEPATH]
+                                                         [ --metadata-json-file FILEPATH
+                                                         | --metadata-cbor-file FILEPATH
+                                                         ]
+                                                         [--vote-file FILEPATH
+                                                           [ --vote-script-file FILEPATH
+                                                             [
+                                                               ( --vote-redeemer-cbor-file CBOR_FILE
+                                                               | --vote-redeemer-file JSON_FILE
+                                                               | --vote-redeemer-value JSON_VALUE
+                                                               )
+                                                               --vote-execution-units (INT, INT)]
+                                                           | --vote-tx-in-reference TX_IN
+                                                             --vote-plutus-script-v3
+                                                             ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                             | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                             )
+                                                             --vote-reference-tx-in-execution-units (INT, INT)
+                                                           ]]
+                                                         [--proposal-file FILEPATH
+                                                           [ --proposal-script-file FILEPATH
+                                                             [
+                                                               ( --proposal-redeemer-cbor-file CBOR_FILE
+                                                               | --proposal-redeemer-file JSON_FILE
+                                                               | --proposal-redeemer-value JSON_VALUE
+                                                               )
+                                                               --proposal-execution-units (INT, INT)]
+                                                           | --proposal-tx-in-reference TX_IN
+                                                             --proposal-plutus-script-v3
+                                                             ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                             | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                             )
+                                                             --proposal-reference-tx-in-execution-units (INT, INT)
+                                                           ]]
+                                                         [--current-treasury-value LOVELACE]
+                                                         [--treasury-donation LOVELACE]
+                                                         [--out-canonical-cbor]
+                                                         --out-file FILEPATH
+                                                         
+
+  Build a balanced transaction without access to a live node (automatically estimates fees)
+
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+
+Usage: cardano-cli dijkstra transaction sign 
+                                               ( --tx-body-file FILEPATH
+                                               | --tx-file FILEPATH
+                                               )
+                                               [--signing-key-file FILEPATH
+                                                 [--address STRING]]
+                                               [ --mainnet
+                                               | --testnet-magic NATURAL
+                                               ]
+                                               [--out-canonical-cbor]
+                                               --out-file FILEPATH
+                                               
+
+  Sign a transaction
+
+Usage: cardano-cli dijkstra transaction witness --tx-body-file FILEPATH
+                                                  --signing-key-file FILEPATH
+                                                  [--address STRING]
+                                                  [ --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  ]
+                                                  --out-file FILEPATH
+                                                  
+
+  Create a transaction witness
+
+Usage: cardano-cli dijkstra transaction assemble --tx-body-file FILEPATH
+                                                   [--witness-file FILEPATH]
+                                                   [--out-canonical-cbor]
+                                                   --out-file FILEPATH
+                                                   
+
+  Assemble a tx body and witness(es) to form a transaction
+
+Usage: cardano-cli dijkstra transaction sign-witness --tx-body-file FILEPATH
+                                                       [--witness-file FILEPATH]
+                                                       [--out-canonical-cbor]
+                                                       --out-file FILEPATH
+                                                       
+
+  Assemble a tx body and witness(es) to form a transaction
+
+Usage: cardano-cli dijkstra transaction submit 
+                                                 [--cardano-mode
+                                                   [--epoch-slots SLOTS]]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 --socket-path SOCKET_PATH
+                                                 --tx-file FILEPATH
+                                                 
+
+  Submit a transaction to the local node whose Unix domain socket is obtained
+  from the CARDANO_NODE_SOCKET_PATH environment variable.
+
+Usage: cardano-cli dijkstra transaction policyid --script-file FILEPATH 
+
+  Calculate the PolicyId from the monetary policy script.
+
+Usage: cardano-cli dijkstra transaction calculate-min-fee --tx-body-file FILEPATH
+                                                            --protocol-params-file FILEPATH
+                                                            --witness-count NATURAL
+                                                            [--byron-witness-count NATURAL]
+                                                            [--reference-script-size NATURAL]
+                                                            [ --output-json
+                                                            | --output-text
+                                                            | --output-yaml
+                                                            ]
+                                                            [--out-file FILEPATH]
+                                                            [ --mainnet
+                                                            | --testnet-magic NATURAL
+                                                            ]
+                                                            [--tx-in-count NATURAL]
+                                                            [--tx-out-count NATURAL]
+                                                            
+
+  Calculate the minimum fee for a transaction.
+
+Usage: cardano-cli dijkstra transaction calculate-min-required-utxo --protocol-params-file FILEPATH
+                                                                      --tx-out ADDRESS VALUE
+                                                                      [ --tx-out-datum-hash HASH
+                                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                      | --tx-out-datum-hash-file JSON_FILE
+                                                                      | --tx-out-datum-hash-value JSON_VALUE
+                                                                      | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                      | --tx-out-datum-embed-file JSON_FILE
+                                                                      | --tx-out-datum-embed-value JSON_VALUE
+                                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                      | --tx-out-inline-datum-file JSON_FILE
+                                                                      | --tx-out-inline-datum-value JSON_VALUE
+                                                                      ]
+                                                                      [--tx-out-reference-script-file FILEPATH]
+                                                                      
+
+  Calculate the minimum required UTxO for a transaction output.
+
+Usage: cardano-cli dijkstra transaction calculate-plutus-script-cost 
+                                                                       ( online
+                                                                       | offline
+                                                                       )
+                                                                       
+
+  Calculate the costs of the Plutus scripts of a given transaction.
+
+Usage: cardano-cli dijkstra transaction calculate-plutus-script-cost online 
+                                                                              [--cardano-mode
+                                                                                [--epoch-slots SLOTS]]
+                                                                              ( --mainnet
+                                                                              | --testnet-magic NATURAL
+                                                                              )
+                                                                              --socket-path SOCKET_PATH
+                                                                              --tx-file FILEPATH
+                                                                              [--out-file FILEPATH]
+                                                                              
+
+  Connect to a running node to get context info and calculate the costs of the
+  Plutus scripts of a given transaction.
+
+Usage: cardano-cli dijkstra transaction calculate-plutus-script-cost offline 
+                                                                               ( --start-time-utc UTC_TIME
+                                                                               | --start-time-posix POSIX_TIME
+                                                                               | --genesis-file FILEPATH
+                                                                               )
+                                                                               [--unsafe-extend-safe-zone]
+                                                                               --era-history-file FILEPATH
+                                                                               --utxo-file FILEPATH
+                                                                               --protocol-params-file FILEPATH
+                                                                               --tx-file FILEPATH
+                                                                               [--out-file FILEPATH]
+                                                                               
+
+  Manually provide get context info and calculate the costs of the Plutus
+  scripts of a given transaction.
+
+Usage: cardano-cli dijkstra transaction calculate-min-value --protocol-params-file FILEPATH
+                                                              --tx-out ADDRESS VALUE
+                                                              [ --tx-out-datum-hash HASH
+                                                              | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                              | --tx-out-datum-hash-file JSON_FILE
+                                                              | --tx-out-datum-hash-value JSON_VALUE
+                                                              | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                              | --tx-out-datum-embed-file JSON_FILE
+                                                              | --tx-out-datum-embed-value JSON_VALUE
+                                                              | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                              | --tx-out-inline-datum-file JSON_FILE
+                                                              | --tx-out-inline-datum-value JSON_VALUE
+                                                              ]
+                                                              [--tx-out-reference-script-file FILEPATH]
+                                                              
+
+  DEPRECATED: Use 'calculate-min-required-utxo' instead.
+
+Usage: cardano-cli dijkstra transaction hash-script-data 
+                                                           ( --script-data-cbor-file CBOR_FILE
+                                                           | --script-data-file JSON_FILE
+                                                           | --script-data-value JSON_VALUE
+                                                           )
+                                                           
+
+  Calculate the hash of script data.
+
+Usage: cardano-cli dijkstra transaction txid 
+                                               ( --tx-body-file FILEPATH
+                                               | --tx-file FILEPATH
+                                               )
+                                               [ --output-json
+                                               | --output-text
+                                               | --output-yaml
+                                               ]
+                                               
+
+  Print a transaction identifier.
 
 Usage: cardano-cli latest 
                             ( address

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli dijkstra 
+                              ( address
+                              | key
+                              | genesis
+                              | governance
+                              | node
+                              | query
+                              | stake-address
+                              | stake-pool
+                              | text-view
+                              | transaction
+                              )
+                              
+
+  Dijkstra era commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  address                  Payment address commands.
+  key                      Key utility commands.
+  genesis                  Genesis block commands.
+  governance               Governance commands.
+  node                     Node operation commands.
+  query                    Node query commands. Will query the local node whose
+                           Unix domain socket is obtained from the
+                           CARDANO_NODE_SOCKET_PATH environment variable.
+  stake-address            Stake address commands.
+  stake-pool               Stake pool commands.
+  text-view                Commands for dealing with Shelley TextView files.
+                           Transactions, addresses etc are stored on disk as
+                           TextView files.
+  transaction              Transaction commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_address.cli
@@ -1,0 +1,13 @@
+Usage: cardano-cli dijkstra address (key-gen | key-hash | build | info) 
+
+  Payment address commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create an address key pair.
+  key-hash                 Print the hash of an address key.
+  build                    Build a Shelley payment address, with optional
+                           delegation to a stake address.
+  info                     Print information about an address.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_address_build.cli
@@ -1,0 +1,40 @@
+Usage: cardano-cli dijkstra address build 
+                                            ( --payment-verification-key STRING
+                                            | --payment-verification-key-file FILEPATH
+                                            | --payment-script-file FILEPATH
+                                            )
+                                            [ --stake-verification-key STRING
+                                            | --stake-verification-key-file FILEPATH
+                                            | --stake-key-hash HASH
+                                            | --stake-script-file FILEPATH
+                                            | --stake-address ADDRESS
+                                            ]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+                                            [--out-file FILEPATH]
+                                            
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILEPATH
+                           Filepath of the payment verification key.
+  --payment-script-file FILEPATH
+                           Filepath of the payment script.
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_address_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_address_info.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli dijkstra address info --address ADDRESS
+                                           [--out-file FILEPATH]
+                                           
+
+  Print information about an address.
+
+Available options:
+  --address ADDRESS        A Cardano address
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_address_key-gen.cli
@@ -1,0 +1,32 @@
+Usage: cardano-cli dijkstra address key-gen 
+                                              [ --key-output-bech32
+                                              | --key-output-text-envelope
+                                              | --key-output-format STRING
+                                              ]
+                                              [ --normal-key
+                                              | --extended-key
+                                              | --byron-key
+                                              ]
+                                              --verification-key-file FILEPATH
+                                              --signing-key-file FILEPATH
+                                              
+
+  Create an address key pair.
+
+Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
+  --normal-key             Use a normal Shelley-era key (default).
+  --extended-key           Use an extended ed25519 Shelley-era key.
+  --byron-key              Use a Byron-era key.
+  --verification-key-file FILEPATH
+                           Output filepath of the verification key.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_address_key-hash.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli dijkstra address key-hash 
+                                               ( --payment-verification-key STRING
+                                               | --payment-verification-key-file FILEPATH
+                                               )
+                                               [--out-file FILEPATH]
+                                               
+
+  Print the hash of an address key.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILEPATH
+                           Filepath of the payment verification key.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis.cli
@@ -1,0 +1,43 @@
+Usage: cardano-cli dijkstra genesis 
+                                      ( key-gen-genesis
+                                      | key-gen-delegate
+                                      | key-gen-utxo
+                                      | key-hash
+                                      | get-ver-key
+                                      | initial-addr
+                                      | initial-txin
+                                      | create-cardano
+                                      | create
+                                      | create-staked
+                                      | create-testnet-data
+                                      | hash
+                                      )
+                                      
+
+  Genesis block commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen-genesis          Create a Shelley genesis key pair
+  key-gen-delegate         Create a Shelley genesis delegate key pair
+  key-gen-utxo             Create a Shelley genesis UTxO key pair
+  key-hash                 Print the identifier (hash) of a public key
+  get-ver-key              Derive the verification key from a signing key
+  initial-addr             Get the address for an initial UTxO based on the
+                           verification key
+  initial-txin             Get the TxIn for an initial UTxO based on the
+                           verification key
+  create-cardano           Create a Byron and Shelley genesis file from a
+                           genesis template and genesis/delegation/spending
+                           keys.
+  create                   Create a Shelley genesis file from a genesis template
+                           and genesis/delegation/spending keys.
+  create-staked            Create a staked Shelley genesis file from a genesis
+                           template and genesis/delegation/spending keys.
+  create-testnet-data      Create data to use for starting a testnet.
+  hash                     DEPRECATION WARNING! This command is deprecated and
+                           will be removed in a future release. Please use hash
+                           genesis-file instead. Compute the hash of a genesis
+                           file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_create-cardano.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_create-cardano.cli
@@ -1,0 +1,53 @@
+Usage: cardano-cli dijkstra genesis create-cardano --genesis-dir DIR
+                                                     [--gen-genesis-keys INT]
+                                                     [--gen-utxo-keys INT]
+                                                     [--start-time UTC_TIME]
+                                                     [--supply LOVELACE]
+                                                     [--security-param NON_ZERO_WORD64]
+                                                     [--slot-length INT]
+                                                     [--slot-coefficient RATIONAL]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     --byron-template FILEPATH
+                                                     --shelley-template FILEPATH
+                                                     --alonzo-template FILEPATH
+                                                     --conway-template FILEPATH
+                                                     [--node-config-template FILEPATH]
+                                                     
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --security-param NON_ZERO_WORD64
+                           Security parameter for genesis file [default is 108].
+  --slot-length INT        slot length (ms) parameter for genesis file [default
+                           is 1000].
+  --slot-coefficient RATIONAL
+                           Slot Coefficient for genesis file [default is .05].
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --byron-template FILEPATH
+                           JSON file with genesis defaults for each byron.
+  --shelley-template FILEPATH
+                           JSON file with genesis defaults for each shelley.
+  --alonzo-template FILEPATH
+                           JSON file with genesis defaults for alonzo.
+  --conway-template FILEPATH
+                           JSON file with genesis defaults for conway.
+  --node-config-template FILEPATH
+                           the node config template
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_create-staked.cli
@@ -1,0 +1,67 @@
+Usage: cardano-cli dijkstra genesis create-staked 
+                                                    [ --key-output-bech32
+                                                    | --key-output-text-envelope
+                                                    | --key-output-format STRING
+                                                    ]
+                                                    --genesis-dir DIR
+                                                    [--gen-genesis-keys INT]
+                                                    [--gen-utxo-keys INT]
+                                                    [--gen-pools INT]
+                                                    [--gen-stake-delegs INT]
+                                                    [--start-time UTC_TIME]
+                                                    [--supply LOVELACE]
+                                                    [--supply-delegated LOVELACE]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    [--bulk-pool-cred-files INT]
+                                                    [--bulk-pools-per-file INT]
+                                                    [--num-stuffed-utxo INT]
+                                                    [--relay-specification-file FILEPATH]
+                                                    
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --gen-pools INT          The number of stake pool credential sets to make
+                           [default is 0].
+  --gen-stake-delegs INT   The number of stake delegator credential sets to make
+                           [default is 0].
+  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --supply-delegated LOVELACE
+                           The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, delegating stake
+                           holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --bulk-pool-cred-files INT
+                           Generate bulk pool credential files [default is 0].
+  --bulk-pools-per-file INT
+                           Each bulk pool to contain this many pool credential
+                           sets [default is 0].
+  --num-stuffed-utxo INT   The number of fake UTxO entries to generate [default
+                           is 0].
+  --relay-specification-file FILEPATH
+                           JSON file that specifies the relays of each stake
+                           pool.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_create-testnet-data.cli
@@ -1,0 +1,72 @@
+Usage: cardano-cli dijkstra genesis create-testnet-data 
+                                                          [--spec-shelley FILEPATH]
+                                                          [--spec-alonzo FILEPATH]
+                                                          [--spec-conway FILEPATH]
+                                                          
+                                                          [--genesis-keys INT]
+                                                          [--pools INT]
+                                                          [ --stake-delegators INT
+                                                          | --transient-stake-delegators INT
+                                                          ]
+                                                          [--committee-keys INT]
+                                                          [ --drep-keys INT
+                                                          | --transient-drep-keys INT
+                                                          ]
+                                                          [--stuffed-utxo INT]
+                                                          [--utxo-keys INT]
+                                                          [--total-supply LOVELACE]
+                                                          [--delegated-supply LOVELACE]
+                                                          [--testnet-magic NATURAL]
+                                                          [--relays FILEPATH]
+                                                          [--start-time UTC_TIME]
+                                                          --out-dir DIR
+                                                          
+
+  Create data to use for starting a testnet.
+
+Available options:
+  --spec-shelley FILEPATH  The shelley specification file to use as input. A
+                           default one is generated if omitted.
+  --spec-alonzo FILEPATH   The alonzo specification file to use as input. A
+                           default one is generated if omitted.
+  --spec-conway FILEPATH   The conway specification file to use as input. A
+                           default one is generated if omitted.
+  --genesis-keys INT       The number of genesis keys to make (default is 3).
+  --pools INT              The number of stake pool credential sets to make
+                           (default is 0).
+  --stake-delegators INT   The number of stake delegator credential sets to make
+                           (default is 0). Credentials are written to disk.
+  --transient-stake-delegators INT
+                           The number of stake delegator credential sets to make
+                           (default is 0). The credentials are NOT written to
+                           disk.
+  --committee-keys INT     The number of constitutional committee credentials to
+                           make (default is 0).
+  --drep-keys INT          The number of DRep credentials to make (default is
+                           0). Credentials are written to disk.
+  --transient-drep-keys INT
+                           The number of DRep credentials to make (default is
+                           0). The credentials are NOT written to disk.
+  --stuffed-utxo INT       The number of fake UTxO entries to generate (default
+                           is 0).
+  --utxo-keys INT          The number of UTxO keys to make (default is 0).
+  --total-supply LOVELACE  The maximum possible amount of Lovelace, which is
+                           evenly distributed across stake holders. Overrides
+                           the value from the shelley genesis. If
+                           --delegated-supply is specified, a part of this
+                           amount will be delegated.
+  --delegated-supply LOVELACE
+                           The amount of the total supply which is evenly
+                           delegated. Defaulted to half of the total supply.
+                           Cannot be more than the amount specified with
+                           --total-supply.
+  --testnet-magic NATURAL  Specify a testnet magic id for the cluster. This
+                           overrides both the network magic from the spec file
+                           and CARDANO_NODE_NETWORK_ID environment variable.
+  --relays FILEPATH        JSON file specifying the relays of each stake pool.
+  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --out-dir DIR            The directory where to generate the data. Created if
+                           not existing.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_create.cli
@@ -1,0 +1,42 @@
+Usage: cardano-cli dijkstra genesis create 
+                                             [ --key-output-bech32
+                                             | --key-output-text-envelope
+                                             | --key-output-format STRING
+                                             ]
+                                             --genesis-dir DIR
+                                             [--gen-genesis-keys INT]
+                                             [--gen-utxo-keys INT]
+                                             [--start-time UTC_TIME]
+                                             [--supply LOVELACE]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_get-ver-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_get-ver-key.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli dijkstra genesis get-ver-key --verification-key-file FILEPATH
+                                                  --signing-key-file FILEPATH
+                                                  
+
+  Derive the verification key from a signing key
+
+Available options:
+  --verification-key-file FILEPATH
+                           Output filepath of the verification key.
+  --signing-key-file FILEPATH
+                           Input filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_hash.cli
@@ -1,0 +1,9 @@
+Usage: cardano-cli dijkstra genesis hash --genesis FILEPATH 
+
+  DEPRECATION WARNING! This command is deprecated and will be removed in a
+  future release. Please use hash genesis-file instead. Compute the hash of a
+  genesis file.
+
+Available options:
+  --genesis FILEPATH       The genesis file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_initial-addr.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_initial-addr.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli dijkstra genesis initial-addr --verification-key-file FILEPATH
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [--out-file FILEPATH]
+                                                   
+
+  Get the address for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILEPATH
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_initial-txin.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_initial-txin.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli dijkstra genesis initial-txin --verification-key-file FILEPATH
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [--out-file FILEPATH]
+                                                   
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILEPATH
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_key-gen-delegate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_key-gen-delegate.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli dijkstra genesis key-gen-delegate --verification-key-file FILEPATH
+                                                       --signing-key-file FILEPATH
+                                                       --operational-certificate-issue-counter-file FILEPATH
+                                                       
+
+  Create a Shelley genesis delegate key pair
+
+Available options:
+  --verification-key-file FILEPATH
+                           Output filepath of the verification key.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  --operational-certificate-issue-counter-file FILEPATH
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_key-gen-genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_key-gen-genesis.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli dijkstra genesis key-gen-genesis --verification-key-file FILEPATH
+                                                      --signing-key-file FILEPATH
+                                                      
+
+  Create a Shelley genesis key pair
+
+Available options:
+  --verification-key-file FILEPATH
+                           Output filepath of the verification key.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_key-gen-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_key-gen-utxo.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli dijkstra genesis key-gen-utxo --verification-key-file FILEPATH
+                                                   --signing-key-file FILEPATH
+                                                   
+
+  Create a Shelley genesis UTxO key pair
+
+Available options:
+  --verification-key-file FILEPATH
+                           Output filepath of the verification key.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_genesis_key-hash.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli dijkstra genesis key-hash --verification-key-file FILEPATH 
+
+  Print the identifier (hash) of a public key
+
+Available options:
+  --verification-key-file FILEPATH
+                           Input filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli dijkstra governance (action | committee | drep | vote) 
+
+  Governance commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  action                   Governance action commands.
+  committee                Committee member commands.
+  drep                     DRep member commands.
+  vote                     Vote commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action.cli
@@ -1,0 +1,28 @@
+Usage: cardano-cli dijkstra governance action 
+                                                ( create-constitution
+                                                | update-committee
+                                                | create-info
+                                                | create-no-confidence
+                                                | create-protocol-parameters-update
+                                                | create-treasury-withdrawal
+                                                | create-hardfork
+                                                | view
+                                                )
+                                                
+
+  Governance action commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-constitution      Create a constitution.
+  update-committee         Create or update a new committee proposal.
+  create-info              Create an info action.
+  create-no-confidence     Create a no confidence proposal.
+  create-protocol-parameters-update
+                           Create a protocol parameters update.
+  create-treasury-withdrawal
+                           Create a treasury withdrawal.
+  create-hardfork          Create a hardfork initiation proposal.
+  view                     View a governance action.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_create-constitution.cli
@@ -1,0 +1,65 @@
+Usage: cardano-cli dijkstra governance action create-constitution 
+                                                                    ( --mainnet
+                                                                    | --testnet
+                                                                    )
+                                                                    --governance-action-deposit NATURAL
+                                                                    ( --deposit-return-stake-verification-key STRING
+                                                                    | --deposit-return-stake-verification-key-file FILEPATH
+                                                                    | --deposit-return-stake-key-hash HASH
+                                                                    | --deposit-return-stake-script-file FILEPATH
+                                                                    | --deposit-return-stake-address ADDRESS
+                                                                    )
+                                                                    [--prev-governance-action-tx-id TXID
+                                                                      --prev-governance-action-index WORD16]
+                                                                    --anchor-url TEXT
+                                                                    --anchor-data-hash HASH
+                                                                    [--check-anchor-data]
+                                                                    --constitution-url TEXT
+                                                                    --constitution-hash HASH
+                                                                    [--check-constitution-hash]
+                                                                    [--constitution-script-hash HASH]
+                                                                    --out-file FILEPATH
+                                                                    
+
+  Create a constitution.
+
+Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --deposit-return-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --deposit-return-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --deposit-return-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --deposit-return-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --prev-governance-action-tx-id TXID
+                           Txid of the previous governance action.
+  --prev-governance-action-index WORD16
+                           Action index of the previous governance action.
+  --anchor-url TEXT        Anchor URL
+  --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
+                           "cardano-cli hash anchor-data ...")
+  --check-anchor-data      Verify that the expected proposal hash provided in
+                           --anchor-data-hash matches the hash of the file
+                           downloaded from the URL provided in --anchor-url
+                           (this parameter will download the file from the URL)
+  --constitution-url TEXT  Constitution URL.
+  --constitution-hash HASH Hash of the constitution data (obtain it with
+                           "cardano-cli hash anchor-data ...").
+  --check-constitution-hash
+                           Verify that the expected constitution hash provided
+                           in --constitution-hash matches the hash of the file
+                           downloaded from the URL provided in
+                           --constitution-url (this parameter will download the
+                           file from the URL)
+  --constitution-script-hash HASH
+                           Constitution script hash (hex-encoded). Obtain it
+                           with "cardano-cli hash script ...".
+  --out-file FILEPATH      Output filepath of the constitution.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_create-hardfork.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_create-hardfork.cli
@@ -1,0 +1,61 @@
+Usage: cardano-cli dijkstra governance action create-hardfork 
+                                                                ( --mainnet
+                                                                | --testnet
+                                                                )
+                                                                --governance-action-deposit NATURAL
+                                                                ( --deposit-return-stake-verification-key STRING
+                                                                | --deposit-return-stake-verification-key-file FILEPATH
+                                                                | --deposit-return-stake-key-hash HASH
+                                                                | --deposit-return-stake-script-file FILEPATH
+                                                                | --deposit-return-stake-address ADDRESS
+                                                                )
+                                                                [--prev-governance-action-tx-id TXID
+                                                                  --prev-governance-action-index WORD16]
+                                                                --anchor-url TEXT
+                                                                --anchor-data-hash HASH
+                                                                [--check-anchor-data]
+                                                                --protocol-major-version MAJOR
+                                                                --protocol-minor-version MINOR
+                                                                --out-file FILEPATH
+                                                                
+
+  Create a hardfork initiation proposal.
+
+Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --deposit-return-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --deposit-return-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --deposit-return-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --deposit-return-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --prev-governance-action-tx-id TXID
+                           Txid of the previous governance action.
+  --prev-governance-action-index WORD16
+                           Action index of the previous governance action.
+  --anchor-url TEXT        Anchor URL
+  --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
+                           "cardano-cli hash anchor-data ...")
+  --check-anchor-data      Verify that the expected proposal hash provided in
+                           --anchor-data-hash matches the hash of the file
+                           downloaded from the URL provided in --anchor-url
+                           (this parameter will download the file from the URL)
+  --protocol-major-version MAJOR
+                           Specify the major protocol version to fork into. An
+                           increase indicates a hard fork. It must be the next
+                           natural number after the current version and must be
+                           supported by the node.
+  --protocol-minor-version MINOR
+                           Minor protocol version. An increase indicates a soft
+                           fork (old software can validate but not produce new
+                           blocks). Must be zero when the major protocol version
+                           is increased.
+  --out-file FILEPATH      Output filepath of the hardfork proposal.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_create-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_create-info.cli
@@ -1,0 +1,44 @@
+Usage: cardano-cli dijkstra governance action create-info 
+                                                            ( --mainnet
+                                                            | --testnet
+                                                            )
+                                                            --governance-action-deposit NATURAL
+                                                            ( --deposit-return-stake-verification-key STRING
+                                                            | --deposit-return-stake-verification-key-file FILEPATH
+                                                            | --deposit-return-stake-key-hash HASH
+                                                            | --deposit-return-stake-script-file FILEPATH
+                                                            | --deposit-return-stake-address ADDRESS
+                                                            )
+                                                            --anchor-url TEXT
+                                                            --anchor-data-hash HASH
+                                                            [--check-anchor-data]
+                                                            --out-file FILEPATH
+                                                            
+
+  Create an info action.
+
+Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --deposit-return-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --deposit-return-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --deposit-return-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --deposit-return-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --anchor-url TEXT        Anchor URL
+  --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
+                           "cardano-cli hash anchor-data ...")
+  --check-anchor-data      Verify that the expected proposal hash provided in
+                           --anchor-data-hash matches the hash of the file
+                           downloaded from the URL provided in --anchor-url
+                           (this parameter will download the file from the URL)
+  --out-file FILEPATH      Path to action file to be used later on with build or
+                           build-raw
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_create-no-confidence.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_create-no-confidence.cli
@@ -1,0 +1,49 @@
+Usage: cardano-cli dijkstra governance action create-no-confidence 
+                                                                     ( --mainnet
+                                                                     | --testnet
+                                                                     )
+                                                                     --governance-action-deposit NATURAL
+                                                                     ( --deposit-return-stake-verification-key STRING
+                                                                     | --deposit-return-stake-verification-key-file FILEPATH
+                                                                     | --deposit-return-stake-key-hash HASH
+                                                                     | --deposit-return-stake-script-file FILEPATH
+                                                                     | --deposit-return-stake-address ADDRESS
+                                                                     )
+                                                                     --anchor-url TEXT
+                                                                     --anchor-data-hash HASH
+                                                                     [--check-anchor-data]
+                                                                     [--prev-governance-action-tx-id TXID
+                                                                       --prev-governance-action-index WORD16]
+                                                                     --out-file FILEPATH
+                                                                     
+
+  Create a no confidence proposal.
+
+Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --deposit-return-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --deposit-return-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --deposit-return-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --deposit-return-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --anchor-url TEXT        Anchor URL
+  --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
+                           "cardano-cli hash anchor-data ...")
+  --check-anchor-data      Verify that the expected proposal hash provided in
+                           --anchor-data-hash matches the hash of the file
+                           downloaded from the URL provided in --anchor-url
+                           (this parameter will download the file from the URL)
+  --prev-governance-action-tx-id TXID
+                           Txid of the previous governance action.
+  --prev-governance-action-index WORD16
+                           Action index of the previous governance action.
+  --out-file FILEPATH      Output filepath of the no confidence proposal.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_create-protocol-parameters-update.cli
@@ -1,0 +1,224 @@
+Usage: cardano-cli dijkstra governance action create-protocol-parameters-update 
+                                                                                  ( --mainnet
+                                                                                  | --testnet
+                                                                                  )
+                                                                                  --governance-action-deposit NATURAL
+                                                                                  ( --deposit-return-stake-verification-key STRING
+                                                                                  | --deposit-return-stake-verification-key-file FILEPATH
+                                                                                  | --deposit-return-stake-key-hash HASH
+                                                                                  | --deposit-return-stake-script-file FILEPATH
+                                                                                  | --deposit-return-stake-address ADDRESS
+                                                                                  )
+                                                                                  --anchor-url TEXT
+                                                                                  --anchor-data-hash HASH
+                                                                                  [--check-anchor-data]
+                                                                                  [--prev-governance-action-tx-id TXID
+                                                                                    --prev-governance-action-index WORD16]
+                                                                                  [--constitution-script-hash HASH]
+                                                                                  [--min-fee-linear LOVELACE]
+                                                                                  [--min-fee-constant LOVELACE]
+                                                                                  [--max-block-body-size WORD32]
+                                                                                  [--max-tx-size WORD32]
+                                                                                  [--max-block-header-size WORD16]
+                                                                                  [--key-reg-deposit-amt NATURAL]
+                                                                                  [--pool-reg-deposit NATURAL]
+                                                                                  [--pool-retirement-epoch-interval WORD32]
+                                                                                  [--number-of-pools WORD16]
+                                                                                  [--pool-influence RATIONAL]
+                                                                                  [--treasury-expansion RATIONAL]
+                                                                                  [--monetary-expansion RATIONAL]
+                                                                                  [--min-pool-cost NATURAL]
+                                                                                  [--price-execution-steps RATIONAL
+                                                                                    --price-execution-memory RATIONAL]
+                                                                                  [--max-tx-execution-units (INT, INT)]
+                                                                                  [--max-block-execution-units (INT, INT)]
+                                                                                  [--max-value-size INT]
+                                                                                  [--collateral-percent INT]
+                                                                                  [--max-collateral-inputs INT]
+                                                                                  [--utxo-cost-per-byte LOVELACE]
+                                                                                  [--pool-voting-threshold-motion-no-confidence RATIONAL
+                                                                                    --pool-voting-threshold-committee-normal RATIONAL
+                                                                                    --pool-voting-threshold-committee-no-confidence RATIONAL
+                                                                                    --pool-voting-threshold-hard-fork-initiation RATIONAL
+                                                                                    --pool-voting-threshold-pp-security-group RATIONAL]
+                                                                                  [--drep-voting-threshold-motion-no-confidence RATIONAL
+                                                                                    --drep-voting-threshold-committee-normal RATIONAL
+                                                                                    --drep-voting-threshold-committee-no-confidence RATIONAL
+                                                                                    --drep-voting-threshold-update-to-constitution RATIONAL
+                                                                                    --drep-voting-threshold-hard-fork-initiation RATIONAL
+                                                                                    --drep-voting-threshold-pp-network-group RATIONAL
+                                                                                    --drep-voting-threshold-pp-economic-group RATIONAL
+                                                                                    --drep-voting-threshold-pp-technical-group RATIONAL
+                                                                                    --drep-voting-threshold-pp-governance-group RATIONAL
+                                                                                    --drep-voting-threshold-treasury-withdrawal RATIONAL]
+                                                                                  [--min-committee-size INT]
+                                                                                  [--committee-term-length WORD32]
+                                                                                  [--governance-action-lifetime WORD32]
+                                                                                  [--new-governance-action-deposit NATURAL]
+                                                                                  [--drep-deposit LOVELACE]
+                                                                                  [--drep-activity WORD32]
+                                                                                  [--ref-script-cost-per-byte RATIONAL]
+                                                                                  [--max-ref-script-size-per-block WORD32]
+                                                                                  [--max-ref-script-size-per-tx WORD32]
+                                                                                  [--ref-script-cost-stride WORD32]
+                                                                                  [--ref-script-cost-multiplier RATIONAL]
+                                                                                  [--cost-model-file FILE]
+                                                                                  --out-file FILEPATH
+                                                                                  
+
+  Create a protocol parameters update.
+
+Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --deposit-return-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --deposit-return-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --deposit-return-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --deposit-return-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --anchor-url TEXT        Anchor URL
+  --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
+                           "cardano-cli hash anchor-data ...")
+  --check-anchor-data      Verify that the expected proposal hash provided in
+                           --anchor-data-hash matches the hash of the file
+                           downloaded from the URL provided in --anchor-url
+                           (this parameter will download the file from the URL)
+  --prev-governance-action-tx-id TXID
+                           Txid of the previous governance action.
+  --prev-governance-action-index WORD16
+                           Action index of the previous governance action.
+  --constitution-script-hash HASH
+                           Constitution script hash (hex-encoded). Obtain it
+                           with "cardano-cli hash script ...".
+  --min-fee-linear LOVELACE
+                           The linear factor per byte for the minimum fee
+                           calculation.
+  --min-fee-constant LOVELACE
+                           The constant factor for the minimum fee calculation.
+  --max-block-body-size WORD32
+                           Maximal block body size.
+  --max-tx-size WORD32     Maximum transaction size.
+  --max-block-header-size WORD16
+                           Maximum block header size.
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --pool-reg-deposit NATURAL
+                           The amount of a pool registration deposit.
+  --pool-retirement-epoch-interval WORD32
+                           Epoch interval of pool retirement.
+  --number-of-pools WORD16 Desired number of pools.
+  --pool-influence RATIONAL
+                           Pool influence.
+  --treasury-expansion RATIONAL
+                           Treasury expansion.
+  --monetary-expansion RATIONAL
+                           Monetary expansion.
+  --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
+  --price-execution-steps RATIONAL
+                           Step price of execution units for script languages
+                           that use them (from Alonzo era). (Examples: '1.1',
+                           '11/10')
+  --price-execution-memory RATIONAL
+                           Memory price of execution units for script languages
+                           that use them (from Alonzo era). (Examples: '1.1',
+                           '11/10')
+  --max-tx-execution-units (INT, INT)
+                           Max total script execution resources units allowed
+                           per tx (from Alonzo era). They are denominated as
+                           follows (steps, memory).
+  --max-block-execution-units (INT, INT)
+                           Max total script execution resources units allowed
+                           per block (from Alonzo era). They are denominated as
+                           follows (steps, memory).
+  --max-value-size INT     Max size of a multi-asset value in a tx output (from
+                           Alonzo era).
+  --collateral-percent INT The percentage of the script contribution to the
+                           txfee that must be provided as collateral inputs when
+                           including Plutus scripts (from Alonzo era).
+  --max-collateral-inputs INT
+                           The maximum number of collateral inputs allowed in a
+                           transaction (from Alonzo era).
+  --utxo-cost-per-byte LOVELACE
+                           Cost in lovelace per unit of UTxO storage (from
+                           Babbage era).
+  --pool-voting-threshold-motion-no-confidence RATIONAL
+                           Acceptance threshold for stake pool votes on motions
+                           no confidence.
+  --pool-voting-threshold-committee-normal RATIONAL
+                           Acceptance threshold for stake pool votes on normal
+                           committee updates.
+  --pool-voting-threshold-committee-no-confidence RATIONAL
+                           Acceptance threshold for stake pool votes on
+                           committee updates when the committee is in a state of
+                           no confidence.
+  --pool-voting-threshold-hard-fork-initiation RATIONAL
+                           Acceptance threshold for stake pool votes on hard
+                           fork initiations.
+  --pool-voting-threshold-pp-security-group RATIONAL
+                           Acceptance threshold for stake pool votes on protocol
+                           parameters for parameters in the 'security' group.
+  --drep-voting-threshold-motion-no-confidence RATIONAL
+                           Acceptance threshold for DRep votes on motions of no
+                           confidence.
+  --drep-voting-threshold-committee-normal RATIONAL
+                           Acceptance threshold for DRep votes on normal
+                           committee updates.
+  --drep-voting-threshold-committee-no-confidence RATIONAL
+                           Acceptance threshold for DRep votes on committee
+                           updates when the committee is in a state of no
+                           confidence.
+  --drep-voting-threshold-update-to-constitution RATIONAL
+                           Acceptance threshold for DRep votes on constitution
+                           updates.
+  --drep-voting-threshold-hard-fork-initiation RATIONAL
+                           Acceptance threshold for DRep votes on hard fork
+                           initiations.
+  --drep-voting-threshold-pp-network-group RATIONAL
+                           Acceptance threshold for DRep votes on protocol
+                           parameters for parameters in the 'network' group.
+  --drep-voting-threshold-pp-economic-group RATIONAL
+                           Acceptance threshold for DRep votes on protocol
+                           parameters for parameters in the 'economic' group.
+  --drep-voting-threshold-pp-technical-group RATIONAL
+                           Acceptance threshold for DRep votes on protocol
+                           parameters for parameters in the 'technical' group.
+  --drep-voting-threshold-pp-governance-group RATIONAL
+                           Acceptance threshold for DRep votes on protocol
+                           parameters for parameters in the 'governance' group.
+  --drep-voting-threshold-treasury-withdrawal RATIONAL
+                           Acceptance threshold for DRep votes on treasury
+                           withdrawals.
+  --min-committee-size INT Minimal size of the constitutional committee.
+  --committee-term-length WORD32
+                           Maximal term length for members of the constitutional
+                           committee, in epochs.
+  --governance-action-lifetime WORD32
+                           Maximal lifetime of governance actions, in epochs.
+  --new-governance-action-deposit NATURAL
+                           Proposed new value of the deposit required to submit
+                           a governance action.
+  --drep-deposit LOVELACE  DRep deposit amount.
+  --drep-activity WORD32   DRep activity period, in epochs.
+  --ref-script-cost-per-byte RATIONAL
+                           Reference script cost per byte for the minimum fee
+                           calculation.
+  --max-ref-script-size-per-block WORD32
+                           Maximum total size of reference scripts per block.
+  --max-ref-script-size-per-tx WORD32
+                           Maximum total size of reference scripts per
+                           transaction.
+  --ref-script-cost-stride WORD32
+                           Reference script cost stride (non-zero) for fee
+                           calculation.
+  --ref-script-cost-multiplier RATIONAL
+                           Reference script cost multiplier for fee calculation.
+  --cost-model-file FILE   Filepath of the JSON formatted cost model
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_create-treasury-withdrawal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_create-treasury-withdrawal.cli
@@ -1,0 +1,70 @@
+Usage: cardano-cli dijkstra governance action create-treasury-withdrawal 
+                                                                           ( --mainnet
+                                                                           | --testnet
+                                                                           )
+                                                                           --governance-action-deposit NATURAL
+                                                                           ( --deposit-return-stake-verification-key STRING
+                                                                           | --deposit-return-stake-verification-key-file FILEPATH
+                                                                           | --deposit-return-stake-key-hash HASH
+                                                                           | --deposit-return-stake-script-file FILEPATH
+                                                                           | --deposit-return-stake-address ADDRESS
+                                                                           )
+                                                                           --anchor-url TEXT
+                                                                           --anchor-data-hash HASH
+                                                                           [--check-anchor-data]
+                                                                           (
+                                                                             ( --funds-receiving-stake-verification-key STRING
+                                                                             | --funds-receiving-stake-verification-key-file FILEPATH
+                                                                             | --funds-receiving-stake-key-hash HASH
+                                                                             | --funds-receiving-stake-script-file FILEPATH
+                                                                             | --funds-receiving-stake-address ADDRESS
+                                                                             )
+                                                                             --transfer LOVELACE)
+                                                                           [--constitution-script-hash HASH]
+                                                                           --out-file FILEPATH
+                                                                           
+
+  Create a treasury withdrawal.
+
+Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --deposit-return-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --deposit-return-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --deposit-return-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --deposit-return-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --anchor-url TEXT        Anchor URL
+  --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
+                           "cardano-cli hash anchor-data ...")
+  --check-anchor-data      Verify that the expected proposal hash provided in
+                           --anchor-data-hash matches the hash of the file
+                           downloaded from the URL provided in --anchor-url
+                           (this parameter will download the file from the URL)
+  --funds-receiving-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --funds-receiving-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --funds-receiving-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --funds-receiving-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --funds-receiving-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --transfer LOVELACE      The amount of lovelace the proposal intends to
+                           withdraw from the Treasury. Multiple withdrawals can
+                           be proposed in a single governance action by
+                           repeating the --funds-receiving-stake and --transfer
+                           options as many times as needed.
+  --constitution-script-hash HASH
+                           Constitution script hash (hex-encoded). Obtain it
+                           with "cardano-cli hash script ...".
+  --out-file FILEPATH      Output filepath of the treasury withdrawal.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_update-committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_update-committee.cli
@@ -1,0 +1,83 @@
+Usage: cardano-cli dijkstra governance action update-committee 
+                                                                 ( --mainnet
+                                                                 | --testnet
+                                                                 )
+                                                                 --governance-action-deposit NATURAL
+                                                                 ( --deposit-return-stake-verification-key STRING
+                                                                 | --deposit-return-stake-verification-key-file FILEPATH
+                                                                 | --deposit-return-stake-key-hash HASH
+                                                                 | --deposit-return-stake-script-file FILEPATH
+                                                                 | --deposit-return-stake-address ADDRESS
+                                                                 )
+                                                                 --anchor-url TEXT
+                                                                 --anchor-data-hash HASH
+                                                                 [--check-anchor-data]
+                                                                 [ --remove-cc-cold-verification-key STRING
+                                                                 | --remove-cc-cold-verification-key-file FILEPATH
+                                                                 | --remove-cc-cold-verification-key-hash STRING
+                                                                 | --remove-cc-cold-script-hash HASH
+                                                                 ]
+                                                                 [
+                                                                   ( --add-cc-cold-verification-key STRING
+                                                                   | --add-cc-cold-verification-key-file FILEPATH
+                                                                   | --add-cc-cold-verification-key-hash STRING
+                                                                   | --add-cc-cold-script-hash HASH
+                                                                   )
+                                                                   --epoch NATURAL]
+                                                                 --threshold RATIONAL
+                                                                 [--prev-governance-action-tx-id TXID
+                                                                   --prev-governance-action-index WORD16]
+                                                                 --out-file FILEPATH
+                                                                 
+
+  Create or update a new committee proposal.
+
+Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --deposit-return-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --deposit-return-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --deposit-return-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --deposit-return-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --anchor-url TEXT        Anchor URL
+  --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
+                           "cardano-cli hash anchor-data ...")
+  --check-anchor-data      Verify that the expected proposal hash provided in
+                           --anchor-data-hash matches the hash of the file
+                           downloaded from the URL provided in --anchor-url
+                           (this parameter will download the file from the URL)
+  --remove-cc-cold-verification-key STRING
+                           Constitutional Committee cold key (hex-encoded).
+  --remove-cc-cold-verification-key-file FILEPATH
+                           Filepath of the Constitutional Committee cold key.
+  --remove-cc-cold-verification-key-hash STRING
+                           Constitutional Committee key hash (hex-encoded).
+  --remove-cc-cold-script-hash HASH
+                           Cold Native or Plutus script file hash (hex-encoded).
+                           Obtain it with "cardano-cli hash script ...".
+  --add-cc-cold-verification-key STRING
+                           Constitutional Committee cold key (hex-encoded).
+  --add-cc-cold-verification-key-file FILEPATH
+                           Filepath of the Constitutional Committee cold key.
+  --add-cc-cold-verification-key-hash STRING
+                           Constitutional Committee key hash (hex-encoded).
+  --add-cc-cold-script-hash HASH
+                           Cold Native or Plutus script file hash (hex-encoded).
+                           Obtain it with "cardano-cli hash script ...".
+  --epoch NATURAL          Committee member expiry epoch
+  --threshold RATIONAL     Threshold of YES votes that are necessary for
+                           approving a governance action.
+  --prev-governance-action-tx-id TXID
+                           Txid of the previous governance action.
+  --prev-governance-action-index WORD16
+                           Action index of the previous governance action.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_action_view.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli dijkstra governance action view --action-file FILEPATH
+                                                     [ --output-json
+                                                     | --output-yaml
+                                                     ]
+                                                     [--out-file FILEPATH]
+                                                     
+
+  View a governance action.
+
+Available options:
+  --action-file FILEPATH   Path to action file.
+  --output-json            Format governance action view output to JSON
+                           (default).
+  --output-yaml            Format governance action view output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_committee.cli
@@ -1,0 +1,26 @@
+Usage: cardano-cli dijkstra governance committee 
+                                                   ( key-gen-cold
+                                                   | key-gen-hot
+                                                   | key-hash
+                                                   | create-hot-key-authorization-certificate
+                                                   | create-cold-key-resignation-certificate
+                                                   )
+                                                   
+
+  Committee member commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen-cold             Create a cold key pair for a Constitutional Committee
+                           Member
+  key-gen-hot              Create a hot key pair for a Constitutional Committee
+                           Member
+  key-hash                 Print the identifier (hash) of a public key
+  create-hot-key-authorization-certificate
+                           Create hot key authorization certificate for a
+                           Constitutional Committee Member
+  create-cold-key-resignation-certificate
+                           Create cold key resignation certificate for a
+                           Constitutional Committee Member

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_committee_create-cold-key-resignation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_committee_create-cold-key-resignation-certificate.cli
@@ -1,0 +1,42 @@
+Usage: cardano-cli dijkstra governance committee create-cold-key-resignation-certificate 
+                                                                                           ( --cold-verification-key STRING
+                                                                                           | --cold-verification-key-file FILEPATH
+                                                                                           | --cold-verification-key-hash STRING
+                                                                                           | --cold-script-hash HASH
+                                                                                           | --cold-script-file FILEPATH
+                                                                                           )
+                                                                                           [--resignation-metadata-url TEXT
+                                                                                             --resignation-metadata-hash HASH
+                                                                                             [--check-resignation-metadata-hash]]
+                                                                                           --out-file FILEPATH
+                                                                                           
+
+  Create cold key resignation certificate for a Constitutional Committee Member
+
+Available options:
+  --cold-verification-key STRING
+                           Constitutional Committee cold key (hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the Constitutional Committee cold key.
+  --cold-verification-key-hash STRING
+                           Constitutional Committee key hash (hex-encoded).
+  --cold-script-hash HASH  Committee cold Native or Plutus script file hash
+                           (hex-encoded). Obtain it with "cardano-cli hash
+                           script ...".
+  --cold-script-file FILEPATH
+                           Cold Native or Plutus script file
+  --resignation-metadata-url TEXT
+                           Constitutional Committee cold key resignation
+                           certificate URL
+  --resignation-metadata-hash HASH
+                           Constitutional Committee cold key resignation
+                           certificate metadata hash
+  --check-resignation-metadata-hash
+                           Verify that the expected Constitutional Committee
+                           cold key resignation certificate metadata hash
+                           provided in --resignation-metadata-hash matches the
+                           hash of the file downloaded from the URL provided in
+                           --resignation-metadata-url (this parameter will
+                           download the file from the URL)
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_committee_create-hot-key-authorization-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_committee_create-hot-key-authorization-certificate.cli
@@ -1,0 +1,43 @@
+Usage: cardano-cli dijkstra governance committee create-hot-key-authorization-certificate 
+                                                                                            ( --cold-verification-key STRING
+                                                                                            | --cold-verification-key-file FILEPATH
+                                                                                            | --cold-verification-key-hash STRING
+                                                                                            | --cold-script-hash HASH
+                                                                                            | --cold-script-file FILEPATH
+                                                                                            )
+                                                                                            ( --hot-verification-key STRING
+                                                                                            | --hot-verification-key-file FILEPATH
+                                                                                            | --hot-verification-key-hash STRING
+                                                                                            | --hot-script-hash HASH
+                                                                                            | --hot-script-file FILEPATH
+                                                                                            )
+                                                                                            --out-file FILEPATH
+                                                                                            
+
+  Create hot key authorization certificate for a Constitutional Committee Member
+
+Available options:
+  --cold-verification-key STRING
+                           Constitutional Committee cold key (hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the Constitutional Committee cold key.
+  --cold-verification-key-hash STRING
+                           Constitutional Committee key hash (hex-encoded).
+  --cold-script-hash HASH  Committee cold Native or Plutus script file hash
+                           (hex-encoded). Obtain it with "cardano-cli hash
+                           script ...".
+  --cold-script-file FILEPATH
+                           Cold Native or Plutus script file
+  --hot-verification-key STRING
+                           Constitutional Committee hot key (hex-encoded).
+  --hot-verification-key-file FILEPATH
+                           Filepath of the Constitutional Committee hot key.
+  --hot-verification-key-hash STRING
+                           Constitutional Committee key hash (hex-encoded).
+  --hot-script-hash HASH   Committee hot Native or Plutus script file hash
+                           (hex-encoded). Obtain it with "cardano-cli hash
+                           script ...".
+  --hot-script-file FILEPATH
+                           Hot Native or Plutus script file
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_committee_key-gen-cold.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_committee_key-gen-cold.cli
@@ -1,0 +1,25 @@
+Usage: cardano-cli dijkstra governance committee key-gen-cold 
+                                                                [ --key-output-bech32
+                                                                | --key-output-text-envelope
+                                                                | --key-output-format STRING
+                                                                ]
+                                                                --cold-verification-key-file FILEPATH
+                                                                --cold-signing-key-file FILEPATH
+                                                                
+
+  Create a cold key pair for a Constitutional Committee Member
+
+Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
+  --cold-verification-key-file FILEPATH
+                           Filepath of the cold verification key.
+  --cold-signing-key-file FILEPATH
+                           Filepath of the cold signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_committee_key-gen-hot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_committee_key-gen-hot.cli
@@ -1,0 +1,25 @@
+Usage: cardano-cli dijkstra governance committee key-gen-hot 
+                                                               [ --key-output-bech32
+                                                               | --key-output-text-envelope
+                                                               | --key-output-format STRING
+                                                               ]
+                                                               --verification-key-file FILEPATH
+                                                               --signing-key-file FILEPATH
+                                                               
+
+  Create a hot key pair for a Constitutional Committee Member
+
+Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
+  --verification-key-file FILEPATH
+                           Output filepath of the verification key.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_committee_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_committee_key-hash.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli dijkstra governance committee key-hash 
+                                                            ( --verification-key STRING
+                                                            | --verification-key-file FILEPATH
+                                                            )
+                                                            
+
+  Print the identifier (hash) of a public key
+
+Available options:
+  --verification-key STRING
+                           Constitutional Committee Member key (hot or cold)
+                           (Bech32-encoded)
+  --verification-key-file FILEPATH
+                           Input filepath of the Constitutional Committee Member
+                           key (hot or cold).
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_drep.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_drep.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli dijkstra governance drep 
+                                              ( key-gen
+                                              | id
+                                              | registration-certificate
+                                              | retirement-certificate
+                                              | update-certificate
+                                              | metadata-hash
+                                              )
+                                              
+
+  DRep member commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Generate Delegated Representative verification and
+                           signing keys.
+  id                       Generate a drep id.
+  registration-certificate Create a registration certificate.
+  retirement-certificate   Create a DRep retirement certificate.
+  update-certificate       Create a DRep update certificate.
+  metadata-hash            Calculate the hash of a metadata file, optionally
+                           checking the obtained hash against an expected value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_drep_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_drep_id.cli
@@ -1,0 +1,26 @@
+Usage: cardano-cli dijkstra governance drep id 
+                                                 ( --drep-verification-key STRING
+                                                 | --drep-verification-key-file FILEPATH
+                                                 | --drep-key-hash HASH
+                                                 )
+                                                 [ --output-hex
+                                                 | --output-bech32
+                                                 | --output-cip129
+                                                 ]
+                                                 [--out-file FILEPATH]
+                                                 
+
+  Generate a drep id.
+
+Available options:
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --output-hex             Format drep id output to BASE16.
+  --output-bech32          Format drep id output to BECH32 (default).
+  --output-cip129          Format drep id output to CIP-129.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_drep_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_drep_key-gen.cli
@@ -1,0 +1,25 @@
+Usage: cardano-cli dijkstra governance drep key-gen 
+                                                      [ --key-output-bech32
+                                                      | --key-output-text-envelope
+                                                      | --key-output-format STRING
+                                                      ]
+                                                      --verification-key-file FILEPATH
+                                                      --signing-key-file FILEPATH
+                                                      
+
+  Generate Delegated Representative verification and signing keys.
+
+Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
+  --verification-key-file FILEPATH
+                           Output filepath of the verification key.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_drep_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_drep_metadata-hash.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli dijkstra governance drep metadata-hash 
+                                                            ( --drep-metadata-file FILEPATH
+                                                            | --drep-metadata-url TEXT
+                                                            )
+                                                            [ --expected-hash HASH
+                                                            | --out-file FILEPATH
+                                                            ]
+                                                            
+
+  Calculate the hash of a metadata file, optionally checking the obtained hash
+  against an expected value.
+
+Available options:
+  --drep-metadata-file FILEPATH
+                           JSON Metadata file to hash.
+  --drep-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
+                           Supported schemes are: file, http, https, ipfs.
+  --expected-hash HASH     Expected hash for the DRep metadata, for verification
+                           purposes. If provided, the hash of the DRep metadata
+                           will be compared to this value.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_drep_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_drep_registration-certificate.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli dijkstra governance drep registration-certificate 
+                                                                       ( --drep-script-hash HASH
+                                                                       | --drep-verification-key STRING
+                                                                       | --drep-verification-key-file FILEPATH
+                                                                       | --drep-key-hash HASH
+                                                                       )
+                                                                       --key-reg-deposit-amt NATURAL
+                                                                       [--drep-metadata-url TEXT
+                                                                         --drep-metadata-hash HASH
+                                                                         [--check-drep-metadata-hash]]
+                                                                       --out-file FILEPATH
+                                                                       
+
+  Create a registration certificate.
+
+Available options:
+  --drep-script-hash HASH  DRep script hash (hex-encoded). Obtain it with
+                           "cardano-cli hash script ...".
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --drep-metadata-url TEXT DRep anchor URL
+  --drep-metadata-hash HASH
+                           DRep anchor data hash.
+  --check-drep-metadata-hash
+                           Verify that the expected DRep metadata hash provided
+                           in --drep-metadata-hash matches the hash of the file
+                           downloaded from the URL provided in
+                           --drep-metadata-url (this parameter will download the
+                           file from the URL)
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_drep_retirement-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_drep_retirement-certificate.cli
@@ -1,0 +1,25 @@
+Usage: cardano-cli dijkstra governance drep retirement-certificate 
+                                                                     ( --drep-script-hash HASH
+                                                                     | --drep-verification-key STRING
+                                                                     | --drep-verification-key-file FILEPATH
+                                                                     | --drep-key-hash HASH
+                                                                     )
+                                                                     --deposit-amt LOVELACE
+                                                                     --out-file FILEPATH
+                                                                     
+
+  Create a DRep retirement certificate.
+
+Available options:
+  --drep-script-hash HASH  DRep script hash (hex-encoded). Obtain it with
+                           "cardano-cli hash script ...".
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --deposit-amt LOVELACE   DRep deposit amount (same at registration and
+                           retirement).
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_drep_update-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_drep_update-certificate.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli dijkstra governance drep update-certificate 
+                                                                 ( --drep-script-hash HASH
+                                                                 | --drep-verification-key STRING
+                                                                 | --drep-verification-key-file FILEPATH
+                                                                 | --drep-key-hash HASH
+                                                                 )
+                                                                 [--drep-metadata-url TEXT
+                                                                   --drep-metadata-hash HASH
+                                                                   [--check-drep-metadata-hash]]
+                                                                 --out-file FILEPATH
+                                                                 
+
+  Create a DRep update certificate.
+
+Available options:
+  --drep-script-hash HASH  DRep script hash (hex-encoded). Obtain it with
+                           "cardano-cli hash script ...".
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --drep-metadata-url TEXT DRep anchor URL
+  --drep-metadata-hash HASH
+                           DRep anchor data hash.
+  --check-drep-metadata-hash
+                           Verify that the expected DRep metadata hash provided
+                           in --drep-metadata-hash matches the hash of the file
+                           downloaded from the URL provided in
+                           --drep-metadata-url (this parameter will download the
+                           file from the URL)
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_vote.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli dijkstra governance vote (create | view) 
+
+  Vote commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create                   Vote creation.
+  view                     Vote viewing.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_vote_create.cli
@@ -1,0 +1,65 @@
+Usage: cardano-cli dijkstra governance vote create (--yes | --no | --abstain)
+                                                     --governance-action-tx-id TXID
+                                                     --governance-action-index WORD16
+                                                     ( --drep-verification-key STRING
+                                                     | --drep-verification-key-file FILEPATH
+                                                     | --drep-key-hash HASH
+                                                     | --drep-script-hash HASH
+                                                     | --stake-pool-verification-key STRING
+                                                     | --stake-pool-verification-extended-key STRING
+                                                     | --cold-verification-key-file FILEPATH
+                                                     | --stake-pool-id STAKE_POOL_ID
+                                                     | --cc-hot-verification-key STRING
+                                                     | --cc-hot-verification-key-file FILEPATH
+                                                     | --cc-hot-key-hash STRING
+                                                     | --cc-hot-script-hash HASH
+                                                     )
+                                                     [--anchor-url TEXT
+                                                       --anchor-data-hash HASH
+                                                       [--check-anchor-data-hash]]
+                                                     --out-file FILEPATH
+                                                     
+
+  Vote creation.
+
+Available options:
+  --governance-action-tx-id TXID
+                           Txid of the governance action.
+  --governance-action-index WORD16
+                           Tx's governance action index.
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --drep-script-hash HASH  Cold Native or Plutus script file hash (hex-encoded).
+                           Obtain it with "cardano-cli hash script ...".
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded).
+  --cc-hot-verification-key STRING
+                           Constitutional Committee hot key (hex-encoded).
+  --cc-hot-verification-key-file FILEPATH
+                           Filepath of the Constitutional Committee hot key.
+  --cc-hot-key-hash STRING Constitutional Committee key hash (hex-encoded).
+  --cc-hot-script-hash HASH
+                           Cold Native or Plutus script file hash (hex-encoded).
+                           Obtain it with "cardano-cli hash script ...".
+  --anchor-url TEXT        Vote anchor URL
+  --anchor-data-hash HASH  Hash of the vote anchor data (obtain it with
+                           "cardano-cli hash anchor-data ...").
+  --check-anchor-data-hash Verify that the expected vote anchor data hash
+                           provided in --anchor-data-hash matches the hash of
+                           the file downloaded from the URL provided in
+                           --anchor-url (this parameter will download the file
+                           from the URL)
+  --out-file FILEPATH      Output filepath of the vote.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_vote_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_governance_vote_view.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli dijkstra governance vote view --vote-file FILEPATH
+                                                   [ --output-json
+                                                   | --output-yaml
+                                                   ]
+                                                   [--out-file FILEPATH]
+                                                   
+
+  Vote viewing.
+
+Available options:
+  --vote-file FILEPATH     Input filepath of the vote.
+  --output-json            Format governance vote view output to JSON (default).
+  --output-yaml            Format governance vote view output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key.cli
@@ -1,0 +1,49 @@
+Usage: cardano-cli dijkstra key 
+                                  ( verification-key
+                                  | non-extended-key
+                                  | generate-mnemonic
+                                  | derive-from-mnemonic
+                                  | convert-byron-key
+                                  | convert-byron-genesis-vkey
+                                  | convert-itn-key
+                                  | convert-itn-extended-key
+                                  | convert-itn-bip32-key
+                                  | convert-cardano-address-key
+                                  )
+                                  
+
+  Key utility commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  verification-key         Get a verification key from a signing key. This
+                           supports all key types.
+  non-extended-key         Get a non-extended verification key from an extended
+                           verification key. This supports all extended key
+                           types.
+  generate-mnemonic        Generate a mnemonic sentence that can be used for key
+                           derivation.
+  derive-from-mnemonic     Derive an extended signing key from a mnemonic
+                           sentence. To ensure the safety of the mnemonic
+                           phrase, we recommend that key derivation is performed
+                           in an air-gapped environment.
+  convert-byron-key        Convert a Byron payment, genesis or genesis delegate
+                           key (signing or verification) to a corresponding
+                           Shelley-format key.
+  convert-byron-genesis-vkey
+                           Convert a Base64-encoded Byron genesis verification
+                           key to a Shelley genesis verification key
+  convert-itn-key          Convert an Incentivized Testnet (ITN) non-extended
+                           (Ed25519) signing or verification key to a
+                           corresponding Shelley stake key
+  convert-itn-extended-key Convert an Incentivized Testnet (ITN) extended
+                           (Ed25519Extended) signing key to a corresponding
+                           Shelley stake signing key
+  convert-itn-bip32-key    Convert an Incentivized Testnet (ITN) BIP32
+                           (Ed25519Bip32) signing key to a corresponding Shelley
+                           stake signing key
+  convert-cardano-address-key
+                           Convert a cardano-address extended signing key to a
+                           corresponding Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_convert-byron-genesis-vkey.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_convert-byron-genesis-vkey.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli dijkstra key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                             --out-file FILEPATH
+                                                             
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Available options:
+  --byron-genesis-verification-key BASE64
+                           Base64 string for the Byron genesis verification key.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_convert-byron-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_convert-byron-key.cli
@@ -1,0 +1,36 @@
+Usage: cardano-cli dijkstra key convert-byron-key [--password TEXT]
+                                                    ( --byron-payment-key-type
+                                                    | --legacy-byron-payment-key-type
+                                                    | --byron-genesis-key-type
+                                                    | --legacy-byron-genesis-key-type
+                                                    | --byron-genesis-delegate-key-type
+                                                    | --legacy-byron-genesis-delegate-key-type
+                                                    )
+                                                    ( --byron-signing-key-file FILEPATH
+                                                    | --byron-verification-key-file FILEPATH
+                                                    )
+                                                    --out-file FILEPATH
+                                                    
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Available options:
+  --password TEXT          Password for signing key (if applicable).
+  --byron-payment-key-type Use a Byron-era payment key.
+  --legacy-byron-payment-key-type
+                           Use a Byron-era payment key, in legacy SL format.
+  --byron-genesis-key-type Use a Byron-era genesis key.
+  --legacy-byron-genesis-key-type
+                           Use a Byron-era genesis key, in legacy SL format.
+  --byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key.
+  --legacy-byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key, in legacy SL
+                           format.
+  --byron-signing-key-file FILEPATH
+                           Input filepath of the Byron-format signing key.
+  --byron-verification-key-file FILEPATH
+                           Input filepath of the Byron-format verification key.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_convert-cardano-address-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_convert-cardano-address-key.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli dijkstra key convert-cardano-address-key 
+                                                              ( --cc-cold-key
+                                                              | --cc-hot-key
+                                                              | --drep-key
+                                                              | --shelley-payment-key
+                                                              | --shelley-stake-key
+                                                              | --icarus-payment-key
+                                                              | --byron-payment-key
+                                                              )
+                                                              --signing-key-file FILEPATH
+                                                              --out-file FILEPATH
+                                                              
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Available options:
+  --cc-cold-key            Use a committee cold key.
+  --cc-hot-key             Use a committee hot key.
+  --drep-key               Use a DRep key.
+  --shelley-payment-key    Use a Shelley-era extended payment key.
+  --shelley-stake-key      Use a Shelley-era extended stake key.
+  --icarus-payment-key     Use a Byron-era extended payment key formatted in the
+                           Icarus style.
+  --byron-payment-key      Use a Byron-era extended payment key formatted in the
+                           deprecated Byron style.
+  --signing-key-file FILEPATH
+                           Input filepath of the signing key.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_convert-itn-bip32-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_convert-itn-bip32-key.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli dijkstra key convert-itn-bip32-key --itn-signing-key-file FILEPATH
+                                                        --out-file FILEPATH
+                                                        
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILEPATH
+                           Filepath of the ITN signing key.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_convert-itn-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_convert-itn-extended-key.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli dijkstra key convert-itn-extended-key --itn-signing-key-file FILEPATH
+                                                           --out-file FILEPATH
+                                                           
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILEPATH
+                           Filepath of the ITN signing key.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_convert-itn-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_convert-itn-key.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli dijkstra key convert-itn-key 
+                                                  ( --itn-signing-key-file FILEPATH
+                                                  | --itn-verification-key-file FILEPATH
+                                                  )
+                                                  --out-file FILEPATH
+                                                  
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Available options:
+  --itn-signing-key-file FILEPATH
+                           Filepath of the ITN signing key.
+  --itn-verification-key-file FILEPATH
+                           Filepath of the ITN verification key.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_derive-from-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_derive-from-mnemonic.cli
@@ -1,0 +1,51 @@
+Usage: cardano-cli dijkstra key derive-from-mnemonic 
+                                                       [ --key-output-bech32
+                                                       | --key-output-text-envelope
+                                                       | --key-output-format STRING
+                                                       ]
+                                                       ( --payment-key-with-number WORD32
+                                                       | --stake-key-with-number WORD32
+                                                       | --drep-key
+                                                       | --cc-cold-key
+                                                       | --cc-hot-key
+                                                       )
+                                                       --account-number WORD32
+                                                       ( --mnemonic-from-file FILEPATH
+                                                       | --mnemonic-from-interactive-prompt
+                                                       )
+                                                       --signing-key-file FILEPATH
+                                                       
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
+
+Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
+  --payment-key-with-number WORD32
+                           Derive an extended payment key with the given payment
+                           address number from the derivation path.
+  --stake-key-with-number WORD32
+                           Derive an extended stake key with the given stake
+                           address number from the derivation path.
+  --drep-key               Derive an extended DRep key.
+  --cc-cold-key            Derive an extended committee cold key.
+  --cc-hot-key             Derive an extended committee hot key.
+  --account-number WORD32  Account number in the derivation path.
+  --mnemonic-from-file FILEPATH
+                           Input text file with the mnemonic.
+  --mnemonic-from-interactive-prompt
+                           Input the mnemonic through an interactive prompt.
+                           This mode also accepts receiving the mnemonic through
+                           standard input directly, for example, by using a
+                           pipe.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_generate-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_generate-mnemonic.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli dijkstra key generate-mnemonic [--out-file FILEPATH]
+                                                    --size WORD32
+                                                    
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Available options:
+  --out-file FILEPATH      The output file.
+  --size WORD32            Specify the desired number of words for the
+                           outputmnemonic sentence (valid options are: 12, 15,
+                           18, 21, and 24)
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_non-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_non-extended-key.cli
@@ -1,0 +1,13 @@
+Usage: cardano-cli dijkstra key non-extended-key --extended-verification-key-file FILEPATH
+                                                   --verification-key-file FILEPATH
+                                                   
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Available options:
+  --extended-verification-key-file FILEPATH
+                           Input filepath of the ed25519-bip32 verification key.
+  --verification-key-file FILEPATH
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_verification-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_key_verification-key.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli dijkstra key verification-key --signing-key-file FILEPATH
+                                                   --verification-key-file FILEPATH
+                                                   
+
+  Get a verification key from a signing key. This supports all key types.
+
+Available options:
+  --signing-key-file FILEPATH
+                           Input filepath of the signing key.
+  --verification-key-file FILEPATH
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query.cli
@@ -1,0 +1,93 @@
+Usage: cardano-cli dijkstra query 
+                                    ( committee-state
+                                    | constitution
+                                    | drep-state
+                                    | drep-stake-distribution
+                                    | era-history
+                                    | future-pparams
+                                    | gov-state
+                                    | kes-period-info
+                                    | leadership-schedule
+                                    | ledger-peer-snapshot
+                                    | ledger-state
+                                    | pool-state
+                                    | proposals
+                                    | protocol-parameters
+                                    | protocol-state
+                                    | ratify-state
+                                    | ref-script-size
+                                    | slot-number
+                                    | spo-stake-distribution
+                                    | stake-address-info
+                                    | stake-distribution
+                                    | stake-pools
+                                    | stake-pool-default-vote
+                                    | stake-snapshot
+                                    | tip
+                                    | treasury
+                                    | tx-mempool
+                                    | utxo
+                                    )
+                                    
+
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  committee-state          Get the committee state
+  constitution             Get the constitution
+  drep-state               Get the DRep state.
+  drep-stake-distribution  Get the DRep stake distribution.
+  era-history              Obtains the era history data. The era history
+                           contains information about when era transitions
+                           happened and can be used together with the start time
+                           to convert slot numbers to POSIX times offline
+                           (without connecting to the node). Converting slot
+                           numbers to POSIX times is useful, for example, when
+                           calculating the cost of executing a Plutus script.
+                           And being able to do it offline means that it can be
+                           calculated without access to a live node.
+  future-pparams           Get the protocol parameters that will apply at the
+                           next epoch
+  gov-state                Get the governance state
+  kes-period-info          Get information about the current KES period and your
+                           node's operational certificate.
+  leadership-schedule      Get the slots the node is expected to mint a block in
+                           (advanced command)
+  ledger-peer-snapshot     Dump the current snapshot of ledger peers.These are
+                           the largest pools that cumulatively hold 90% of total
+                           stake.
+  ledger-state             Dump the current ledger state of the node
+                           (Ledger.NewEpochState -- advanced command)
+  pool-params              DEPRECATED. Use query pool-state instead. Dump the
+                           pool parameters
+                           (Ledger.NewEpochState.esLState._delegationState._pState._pParams
+                           -- advanced command)
+  pool-state               Dump the pool state
+  proposals                Get the governance proposals that are eligible for
+                           ratification. Proposals submitted during the current
+                           epoch are excluded, as they cannot be ratified until
+                           the next epoch.
+  protocol-parameters      Get the node's current protocol parameters
+  protocol-state           Dump the current protocol state of the node
+                           (Ledger.ChainDepState -- advanced command)
+  ratify-state             Get the ratification state
+  ref-script-size          Calculate the reference input scripts size in bytes
+                           for provided transaction inputs.
+  slot-number              Query slot number for UTC timestamp
+  spo-stake-distribution   Get the SPO stake distribution.
+  stake-address-info       Get the current delegations and reward accounts
+                           filtered by stake address.
+  stake-distribution       Get the node's current aggregated stake distribution
+  stake-pools              Get the node's current set of stake pool ids
+  stake-pool-default-vote  Get the stake pool default vote.
+  stake-snapshot           Obtain the three stake snapshots for a pool, plus the
+                           total active stake (advanced command)
+  tip                      Get the node's current tip (slot no, hash, block no)
+  treasury                 Get the treasury value
+  tx-mempool               Local Mempool info
+  utxo                     Get a portion of the current UTxO: by tx in, by
+                           address or the whole.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_committee-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_committee-state.cli
@@ -1,0 +1,72 @@
+Usage: cardano-cli dijkstra query committee-state 
+                                                    [--cardano-mode
+                                                      [--epoch-slots SLOTS]]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    --socket-path SOCKET_PATH
+                                                    [ --volatile-tip
+                                                    | --immutable-tip
+                                                    ]
+                                                    [ --cold-verification-key STRING
+                                                    | --cold-verification-key-file FILEPATH
+                                                    | --cold-verification-key-hash STRING
+                                                    | --cold-script-hash HASH
+                                                    ]
+                                                    [ --hot-key STRING
+                                                    | --hot-key-file FILEPATH
+                                                    | --hot-key-hash STRING
+                                                    | --hot-script-hash HASH
+                                                    ]
+                                                    [ --active
+                                                    | --expired
+                                                    | --unrecognized
+                                                    ]
+                                                    [ --output-json
+                                                    | --output-yaml
+                                                    ]
+                                                    [--out-file FILEPATH]
+                                                    
+
+  Get the committee state
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --cold-verification-key STRING
+                           Constitutional Committee cold key (hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the Constitutional Committee cold key.
+  --cold-verification-key-hash STRING
+                           Constitutional Committee key hash (hex-encoded).
+  --cold-script-hash HASH  Cold Native or Plutus script file hash (hex-encoded).
+                           Obtain it with "cardano-cli hash script ...".
+  --hot-key STRING         Constitutional Committee hot key (hex-encoded).
+  --hot-key-file FILEPATH  Filepath of the Constitutional Committee hot key.
+  --hot-key-hash STRING    Constitutional Committee key hash (hex-encoded).
+  --hot-script-hash HASH   Hot Native or Plutus script file hash (hex-encoded).
+                           Obtain it with "cardano-cli hash script ...".
+  --active                 Active committee members (members whose vote will
+                           count during ratification)
+  --expired                Expired committee members
+  --unrecognized           Unrecognized committe members: a hot credential for
+                           an unknown cold credential
+  --output-json            Format committee-state query output to JSON
+                           (default).
+  --output-yaml            Format committee-state query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_constitution.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli dijkstra query constitution 
+                                                 [--cardano-mode
+                                                   [--epoch-slots SLOTS]]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 --socket-path SOCKET_PATH
+                                                 [ --volatile-tip
+                                                 | --immutable-tip
+                                                 ]
+                                                 [--output-json | --output-yaml]
+                                                 [--out-file FILEPATH]
+                                                 
+
+  Get the constitution
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format constitution query output to JSON (default).
+  --output-yaml            Format constitution query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_drep-stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_drep-stake-distribution.cli
@@ -1,0 +1,57 @@
+Usage: cardano-cli dijkstra query drep-stake-distribution 
+                                                            [--cardano-mode
+                                                              [--epoch-slots SLOTS]]
+                                                            ( --mainnet
+                                                            | --testnet-magic NATURAL
+                                                            )
+                                                            --socket-path SOCKET_PATH
+                                                            [ --volatile-tip
+                                                            | --immutable-tip
+                                                            ]
+                                                            ( --all-dreps
+                                                            | 
+                                                            ( --drep-script-hash HASH
+                                                            | --drep-verification-key STRING
+                                                            | --drep-verification-key-file FILEPATH
+                                                            | --drep-key-hash HASH
+                                                            )
+                                                            )
+                                                            [ --output-json
+                                                            | --output-yaml
+                                                            ]
+                                                            [--out-file FILEPATH]
+                                                            
+
+  Get the DRep stake distribution.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --all-dreps              Query for all DReps.
+  --drep-script-hash HASH  DRep script hash (hex-encoded). Obtain it with
+                           "cardano-cli hash script ...".
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --output-json            Format drep-stake-distribution query output to JSON
+                           (default).
+  --output-yaml            Format drep-stake-distribution query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_drep-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_drep-state.cli
@@ -1,0 +1,60 @@
+Usage: cardano-cli dijkstra query drep-state 
+                                               [--cardano-mode
+                                                 [--epoch-slots SLOTS]]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               --socket-path SOCKET_PATH
+                                               [ --volatile-tip
+                                               | --immutable-tip
+                                               ]
+                                               ( --all-dreps
+                                               | 
+                                               ( --drep-script-hash HASH
+                                               | --drep-verification-key STRING
+                                               | --drep-verification-key-file FILEPATH
+                                               | --drep-key-hash HASH
+                                               )
+                                               )
+                                               [--include-stake]
+                                               [--output-json | --output-yaml]
+                                               [--out-file FILEPATH]
+                                               
+
+  Get the DRep state.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --all-dreps              Query for all DReps.
+  --drep-script-hash HASH  DRep script hash (hex-encoded). Obtain it with
+                           "cardano-cli hash script ...".
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --include-stake          Also return the stake associated with each DRep. The
+                           result is the same as with "drep-stake-distribution";
+                           this is a convenience option to obtain all
+                           information concerning a DRep at once. This is a
+                           potentially expensive query, so it's OFF by default.
+  --output-json            Format drep-state query output to JSON (default).
+  --output-yaml            Format drep-state query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_era-history.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_era-history.cli
@@ -1,0 +1,39 @@
+Usage: cardano-cli dijkstra query era-history 
+                                                [--cardano-mode
+                                                  [--epoch-slots SLOTS]]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --socket-path SOCKET_PATH
+                                                [ --volatile-tip
+                                                | --immutable-tip
+                                                ]
+                                                [--out-file FILEPATH]
+                                                
+
+  Obtains the era history data. The era history contains information about when
+  era transitions happened and can be used together with the start time to
+  convert slot numbers to POSIX times offline (without connecting to the node).
+  Converting slot numbers to POSIX times is useful, for example, when
+  calculating the cost of executing a Plutus script. And being able to do it
+  offline means that it can be calculated without access to a live node.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_future-pparams.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_future-pparams.cli
@@ -1,0 +1,39 @@
+Usage: cardano-cli dijkstra query future-pparams 
+                                                   [--cardano-mode
+                                                     [--epoch-slots SLOTS]]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --socket-path SOCKET_PATH
+                                                   [ --volatile-tip
+                                                   | --immutable-tip
+                                                   ]
+                                                   [ --output-json
+                                                   | --output-yaml
+                                                   ]
+                                                   [--out-file FILEPATH]
+                                                   
+
+  Get the protocol parameters that will apply at the next epoch
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format future-pparams query output to JSON (default).
+  --output-yaml            Format future-pparams query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_gov-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_gov-state.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli dijkstra query gov-state 
+                                              [--cardano-mode
+                                                [--epoch-slots SLOTS]]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              --socket-path SOCKET_PATH
+                                              [--volatile-tip | --immutable-tip]
+                                              [--output-json | --output-yaml]
+                                              [--out-file FILEPATH]
+                                              
+
+  Get the governance state
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format gov-state query output to JSON (default).
+  --output-yaml            Format gov-state query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_kes-period-info.cli
@@ -1,0 +1,43 @@
+Usage: cardano-cli dijkstra query kes-period-info 
+                                                    [--cardano-mode
+                                                      [--epoch-slots SLOTS]]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    --socket-path SOCKET_PATH
+                                                    [ --volatile-tip
+                                                    | --immutable-tip
+                                                    ]
+                                                    --op-cert-file FILEPATH
+                                                    [ --output-json
+                                                    | --output-yaml
+                                                    ]
+                                                    [--out-file FILEPATH]
+                                                    
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --op-cert-file FILEPATH  Filepath of the node's operational certificate.
+  --output-json            Format kes-period-info query output to JSON
+                           (default).
+  --output-yaml            Format kes-period-info query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_leadership-schedule.cli
@@ -1,0 +1,65 @@
+Usage: cardano-cli dijkstra query leadership-schedule 
+                                                        [--cardano-mode
+                                                          [--epoch-slots SLOTS]]
+                                                        ( --mainnet
+                                                        | --testnet-magic NATURAL
+                                                        )
+                                                        --socket-path SOCKET_PATH
+                                                        [ --volatile-tip
+                                                        | --immutable-tip
+                                                        ]
+                                                        --genesis FILEPATH
+                                                        ( --stake-pool-verification-key STRING
+                                                        | --stake-pool-verification-extended-key STRING
+                                                        | --cold-verification-key-file FILEPATH
+                                                        | --stake-pool-id STAKE_POOL_ID
+                                                        )
+                                                        --vrf-signing-key-file FILEPATH
+                                                        (--current | --next)
+                                                        [ --output-json
+                                                        | --output-text
+                                                        | --output-yaml
+                                                        ]
+                                                        [--out-file FILEPATH]
+                                                        
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --genesis FILEPATH       Shelley genesis filepath
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded).
+  --vrf-signing-key-file FILEPATH
+                           Input filepath of the VRF signing key.
+  --current                Get the leadership schedule for the current epoch.
+  --next                   Get the leadership schedule for the following epoch.
+  --output-json            Format leadership-schedule query output to JSON
+                           (default).
+  --output-text            Format leadership-schedule query output to TEXT.
+  --output-yaml            Format leadership-schedule query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_ledger-peer-snapshot.cli
@@ -1,0 +1,43 @@
+Usage: cardano-cli dijkstra query ledger-peer-snapshot 
+                                                         [--cardano-mode
+                                                           [--epoch-slots SLOTS]]
+                                                         ( --mainnet
+                                                         | --testnet-magic NATURAL
+                                                         )
+                                                         --socket-path SOCKET_PATH
+                                                         [ --volatile-tip
+                                                         | --immutable-tip
+                                                         ]
+                                                         [--all-ledger-peers]
+                                                         [ --output-json
+                                                         | --output-yaml
+                                                         ]
+                                                         [--out-file FILEPATH]
+                                                         
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --all-ledger-peers       Query all ledger peers instead of big ones
+  --output-json            Format ledger-peer-snapshot query output to JSON
+                           (default).
+  --output-yaml            Format ledger-peer-snapshot query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_ledger-state.cli
@@ -1,0 +1,42 @@
+Usage: cardano-cli dijkstra query ledger-state 
+                                                 [--cardano-mode
+                                                   [--epoch-slots SLOTS]]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 --socket-path SOCKET_PATH
+                                                 [ --volatile-tip
+                                                 | --immutable-tip
+                                                 ]
+                                                 [ --output-json
+                                                 | --output-text
+                                                 | --output-yaml
+                                                 ]
+                                                 [--out-file FILEPATH]
+                                                 
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format ledger-state query output to JSON (default).
+  --output-text            Format ledger-state query output to TEXT.
+  --output-yaml            Format ledger-state query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_pool-params.cli
@@ -1,0 +1,46 @@
+Usage: cardano-cli dijkstra query pool-params 
+                                                [--cardano-mode
+                                                  [--epoch-slots SLOTS]]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --socket-path SOCKET_PATH
+                                                [ --volatile-tip
+                                                | --immutable-tip
+                                                ]
+                                                ( --all-stake-pools
+                                                | (--stake-pool-id STAKE_POOL_ID)
+                                                )
+                                                [--output-json | --output-yaml]
+                                                [--out-file FILEPATH]
+                                                
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --all-stake-pools        Query for all stake pools
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded).
+  --output-json            Format pool-state query output to JSON (default).
+  --output-yaml            Format pool-state query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_pool-state.cli
@@ -1,0 +1,44 @@
+Usage: cardano-cli dijkstra query pool-state 
+                                               [--cardano-mode
+                                                 [--epoch-slots SLOTS]]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               --socket-path SOCKET_PATH
+                                               [ --volatile-tip
+                                               | --immutable-tip
+                                               ]
+                                               ( --all-stake-pools
+                                               | (--stake-pool-id STAKE_POOL_ID)
+                                               )
+                                               [--output-json | --output-yaml]
+                                               [--out-file FILEPATH]
+                                               
+
+  Dump the pool state
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --all-stake-pools        Query for all stake pools
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded).
+  --output-json            Format pool-state query output to JSON (default).
+  --output-yaml            Format pool-state query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_proposals.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_proposals.cli
@@ -1,0 +1,46 @@
+Usage: cardano-cli dijkstra query proposals 
+                                              [--cardano-mode
+                                                [--epoch-slots SLOTS]]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              --socket-path SOCKET_PATH
+                                              [--volatile-tip | --immutable-tip]
+                                              ( --all-proposals
+                                              | (--governance-action-tx-id TXID
+                                                --governance-action-index WORD16)
+                                              )
+                                              [--output-json | --output-yaml]
+                                              [--out-file FILEPATH]
+                                              
+
+  Get the governance proposals that are eligible for ratification. Proposals
+  submitted during the current epoch are excluded, as they cannot be ratified
+  until the next epoch.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --all-proposals          Query for all governance proposals.
+  --governance-action-tx-id TXID
+                           Txid of the governance action.
+  --governance-action-index WORD16
+                           Tx's governance action index.
+  --output-json            Format proposals query output to JSON (default).
+  --output-yaml            Format proposals query output to YAML.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_protocol-parameters.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli dijkstra query protocol-parameters 
+                                                        [--cardano-mode
+                                                          [--epoch-slots SLOTS]]
+                                                        ( --mainnet
+                                                        | --testnet-magic NATURAL
+                                                        )
+                                                        --socket-path SOCKET_PATH
+                                                        [ --output-json
+                                                        | --output-yaml
+                                                        ]
+                                                        [--out-file FILEPATH]
+                                                        
+
+  Get the node's current protocol parameters
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --output-json            Format protocol-parameters query output to JSON
+                           (default).
+  --output-yaml            Format protocol-parameters query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_protocol-state.cli
@@ -1,0 +1,44 @@
+Usage: cardano-cli dijkstra query protocol-state 
+                                                   [--cardano-mode
+                                                     [--epoch-slots SLOTS]]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --socket-path SOCKET_PATH
+                                                   [ --volatile-tip
+                                                   | --immutable-tip
+                                                   ]
+                                                   [ --output-cbor-bin
+                                                   | --output-cbor-hex
+                                                   | --output-json
+                                                   | --output-yaml
+                                                   ]
+                                                   [--out-file FILEPATH]
+                                                   
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --output-cbor-bin        Format protocol-state query output to CBOR.
+  --output-cbor-hex        Format protocol-state query output to BASE16 CBOR.
+  --output-json            Format protocol-state query output to JSON (default).
+  --output-yaml            Format protocol-state query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_ratify-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_ratify-state.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli dijkstra query ratify-state 
+                                                 [--cardano-mode
+                                                   [--epoch-slots SLOTS]]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 --socket-path SOCKET_PATH
+                                                 [ --volatile-tip
+                                                 | --immutable-tip
+                                                 ]
+                                                 [--output-json | --output-yaml]
+                                                 [--out-file FILEPATH]
+                                                 
+
+  Get the ratification state
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format ratify-state query output to JSON (default).
+  --output-yaml            Format ratify-state query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_ref-script-size.cli
@@ -1,0 +1,45 @@
+Usage: cardano-cli dijkstra query ref-script-size 
+                                                    [--cardano-mode
+                                                      [--epoch-slots SLOTS]]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    --socket-path SOCKET_PATH
+                                                    [ --volatile-tip
+                                                    | --immutable-tip
+                                                    ]
+                                                    (--tx-in TX_IN)
+                                                    [ --output-json
+                                                    | --output-text
+                                                    | --output-yaml
+                                                    ]
+                                                    [--out-file FILEPATH]
+                                                    
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --tx-in TX_IN            Transaction input (TxId#TxIx).
+  --output-json            Format reference-script-size query output to JSON
+                           (default).
+  --output-text            Format reference-script-size query output to TEXT.
+  --output-yaml            Format reference-script-size query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_slot-number.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli dijkstra query slot-number 
+                                                [--cardano-mode
+                                                  [--epoch-slots SLOTS]]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --socket-path SOCKET_PATH
+                                                [ --volatile-tip
+                                                | --immutable-tip
+                                                ]
+                                                TIMESTAMP
+                                                
+
+  Query slot number for UTC timestamp
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  TIMESTAMP                UTC timestamp in YYYY-MM-DDThh:mm:ssZ format
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_spo-stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_spo-stake-distribution.cli
@@ -1,0 +1,54 @@
+Usage: cardano-cli dijkstra query spo-stake-distribution 
+                                                           [--cardano-mode
+                                                             [--epoch-slots SLOTS]]
+                                                           ( --mainnet
+                                                           | --testnet-magic NATURAL
+                                                           )
+                                                           --socket-path SOCKET_PATH
+                                                           [ --volatile-tip
+                                                           | --immutable-tip
+                                                           ]
+                                                           ( --all-spos
+                                                           | 
+                                                           ( --spo-verification-key STRING
+                                                           | --spo-verification-key-file FILEPATH
+                                                           | --spo-key-hash HASH
+                                                           )
+                                                           )
+                                                           [ --output-json
+                                                           | --output-yaml
+                                                           ]
+                                                           [--out-file FILEPATH]
+                                                           
+
+  Get the SPO stake distribution.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --all-spos               Query for all DReps.
+  --spo-verification-key STRING
+                           SPO verification key (Bech32 or hex-encoded).
+  --spo-verification-key-file FILEPATH
+                           Filepath of the SPO verification key.
+  --spo-key-hash HASH      SPO verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --output-json            Format spo-stake-distribution query output to JSON
+                           (default).
+  --output-yaml            Format spo-stake-distribution query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_stake-address-info.cli
@@ -1,0 +1,42 @@
+Usage: cardano-cli dijkstra query stake-address-info 
+                                                       [--cardano-mode
+                                                         [--epoch-slots SLOTS]]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       --socket-path SOCKET_PATH
+                                                       [ --volatile-tip
+                                                       | --immutable-tip
+                                                       ]
+                                                       --address ADDRESS
+                                                       [ --output-json
+                                                       | --output-yaml
+                                                       ]
+                                                       [--out-file FILEPATH]
+                                                       
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
+  --output-json            Format stake-address-info query output to JSON
+                           (default).
+  --output-yaml            Format stake-address-info query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_stake-distribution.cli
@@ -1,0 +1,42 @@
+Usage: cardano-cli dijkstra query stake-distribution 
+                                                       [--cardano-mode
+                                                         [--epoch-slots SLOTS]]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       --socket-path SOCKET_PATH
+                                                       [ --volatile-tip
+                                                       | --immutable-tip
+                                                       ]
+                                                       [ --output-json
+                                                       | --output-text
+                                                       | --output-yaml
+                                                       ]
+                                                       [--out-file FILEPATH]
+                                                       
+
+  Get the node's current aggregated stake distribution
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format stake-distribution query output to JSON
+                           (default).
+  --output-text            Format stake-distribution query output to TEXT.
+  --output-yaml            Format stake-distribution query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_stake-pool-default-vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_stake-pool-default-vote.cli
@@ -1,0 +1,50 @@
+Usage: cardano-cli dijkstra query stake-pool-default-vote 
+                                                            [--cardano-mode
+                                                              [--epoch-slots SLOTS]]
+                                                            ( --mainnet
+                                                            | --testnet-magic NATURAL
+                                                            )
+                                                            --socket-path SOCKET_PATH
+                                                            [ --volatile-tip
+                                                            | --immutable-tip
+                                                            ]
+                                                            ( --spo-verification-key STRING
+                                                            | --spo-verification-key-file FILEPATH
+                                                            | --spo-key-hash HASH
+                                                            )
+                                                            [ --output-json
+                                                            | --output-yaml
+                                                            ]
+                                                            [--out-file FILEPATH]
+                                                            
+
+  Get the stake pool default vote.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --spo-verification-key STRING
+                           SPO verification key (Bech32 or hex-encoded).
+  --spo-verification-key-file FILEPATH
+                           Filepath of the SPO verification key.
+  --spo-key-hash HASH      SPO verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --output-json            Format stake-pool-default-vote query output to JSON
+                           (default).
+  --output-yaml            Format stake-pool-default-vote query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_stake-pools.cli
@@ -1,0 +1,41 @@
+Usage: cardano-cli dijkstra query stake-pools 
+                                                [--cardano-mode
+                                                  [--epoch-slots SLOTS]]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --socket-path SOCKET_PATH
+                                                [ --volatile-tip
+                                                | --immutable-tip
+                                                ]
+                                                [ --output-json
+                                                | --output-text
+                                                | --output-yaml
+                                                ]
+                                                [--out-file FILEPATH]
+                                                
+
+  Get the node's current set of stake pool ids
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format stake-pools query output to JSON (default).
+  --output-text            Format stake-pools query output to TEXT.
+  --output-yaml            Format stake-pools query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_stake-snapshot.cli
@@ -1,0 +1,47 @@
+Usage: cardano-cli dijkstra query stake-snapshot 
+                                                   [--cardano-mode
+                                                     [--epoch-slots SLOTS]]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --socket-path SOCKET_PATH
+                                                   [ --volatile-tip
+                                                   | --immutable-tip
+                                                   ]
+                                                   ( --all-stake-pools
+                                                   | (--stake-pool-id STAKE_POOL_ID)
+                                                   )
+                                                   [ --output-json
+                                                   | --output-yaml
+                                                   ]
+                                                   [--out-file FILEPATH]
+                                                   
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --all-stake-pools        Query for all stake pools
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded).
+  --output-json            Format stake-snapshot query output to JSON (default).
+  --output-yaml            Format stake-snapshot query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_tip.cli
@@ -1,0 +1,31 @@
+Usage: cardano-cli dijkstra query tip [--cardano-mode [--epoch-slots SLOTS]]
+                                        (--mainnet | --testnet-magic NATURAL)
+                                        --socket-path SOCKET_PATH
+                                        [--volatile-tip | --immutable-tip]
+                                        [--output-json | --output-yaml]
+                                        [--out-file FILEPATH]
+                                        
+
+  Get the node's current tip (slot no, hash, block no)
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format tip query output to JSON (default).
+  --output-yaml            Format tip query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_treasury.cli
@@ -1,0 +1,32 @@
+Usage: cardano-cli dijkstra query treasury 
+                                             [--cardano-mode
+                                               [--epoch-slots SLOTS]]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             --socket-path SOCKET_PATH
+                                             [--volatile-tip | --immutable-tip]
+                                             [--out-file FILEPATH]
+                                             
+
+  Get the treasury value
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_tx-mempool.cli
@@ -1,0 +1,40 @@
+Usage: cardano-cli dijkstra query tx-mempool 
+                                               [--cardano-mode
+                                                 [--epoch-slots SLOTS]]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               --socket-path SOCKET_PATH
+                                               (info | next-tx | tx-exists)
+                                               [--output-json | --output-yaml]
+                                               [--out-file FILEPATH]
+                                               
+
+  Local Mempool info
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --output-json            Format tx-mempool query output to JSON (default).
+  --output-yaml            Format tx-mempool query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text
+
+Available commands:
+  info                     Ask the node about the current mempool's capacity and
+                           sizes
+  next-tx                  Requests the next transaction from the mempool's
+                           current list
+  tx-exists                Query if a particular transaction exists in the
+                           mempool

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_tx-mempool_info.cli
@@ -1,0 +1,6 @@
+Usage: cardano-cli dijkstra query tx-mempool info 
+
+  Ask the node about the current mempool's capacity and sizes
+
+Available options:
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_tx-mempool_next-tx.cli
@@ -1,0 +1,6 @@
+Usage: cardano-cli dijkstra query tx-mempool next-tx 
+
+  Requests the next transaction from the mempool's current list
+
+Available options:
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_tx-mempool_tx-exists.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_tx-mempool_tx-exists.cli
@@ -1,0 +1,6 @@
+Usage: cardano-cli dijkstra query tx-mempool tx-exists TX_ID 
+
+  Query if a particular transaction exists in the mempool
+
+Available options:
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_query_utxo.cli
@@ -1,0 +1,47 @@
+Usage: cardano-cli dijkstra query utxo [--cardano-mode [--epoch-slots SLOTS]]
+                                         (--mainnet | --testnet-magic NATURAL)
+                                         --socket-path SOCKET_PATH
+                                         [--volatile-tip | --immutable-tip]
+                                         ( --whole-utxo
+                                         | (--address ADDRESS)
+                                         | (--tx-in TX_IN)
+                                         )
+                                         [ --output-cbor-bin
+                                         | --output-cbor-hex
+                                         | --output-json
+                                         | --output-text
+                                         | --output-yaml
+                                         ]
+                                         [--out-file FILEPATH]
+                                         
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --whole-utxo             Return the whole UTxO (only appropriate on small
+                           testnets).
+  --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
+  --tx-in TX_IN            Filter by transaction input (TxId#TxIx).
+  --output-cbor-bin        Format utxo query output to CBOR.
+  --output-cbor-hex        Format utxo query output to BASE16 CBOR.
+  --output-json            Format utxo query output to JSON (default).
+  --output-text            Format utxo query output to TEXT.
+  --output-yaml            Format utxo query output to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address.cli
@@ -1,0 +1,55 @@
+Usage: cardano-cli dijkstra stake-address 
+                                            ( key-gen
+                                            | key-hash
+                                            | build
+                                            | registration-certificate
+                                            | deregistration-certificate
+                                            | stake-delegation-certificate
+                                            | stake-and-vote-delegation-certificate
+                                            | vote-delegation-certificate
+                                            | registration-and-delegation-certificate
+                                            | registration-and-vote-delegation-certificate
+                                            | registration-stake-and-vote-delegation-certificate
+                                            )
+                                            
+
+  Stake address commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a stake address key pair
+  key-hash                 Print the hash of a stake address key
+  build                    Build a stake address
+  registration-certificate Create a stake address registration certificate
+  deregistration-certificate
+                           Create a stake address deregistration certificate
+  stake-delegation-certificate
+                           Create a stake address stake delegation certificate,
+                           which when submitted in a transaction delegates stake
+                           to a stake pool.
+  stake-and-vote-delegation-certificate
+                           Create a stake address stake and vote delegation
+                           certificate, which when submitted in a transaction
+                           delegates stake to a stake pool and a DRep.
+  vote-delegation-certificate
+                           Create a stake address vote delegation certificate,
+                           which when submitted in a transaction delegates stake
+                           to a DRep.
+  registration-and-delegation-certificate
+                           Create a stake address registration and delegation
+                           certificate, which when submitted in a transaction
+                           registers a stake address and delegates stake to a
+                           stake pool.
+  registration-and-vote-delegation-certificate
+                           Create a stake address registration and vote
+                           delegation certificate, which when submitted in a
+                           transaction registers a stake address and delegates
+                           votes to a DRep or pre-defined voting option.
+  registration-stake-and-vote-delegation-certificate
+                           Create a stake address registration, stake delegation
+                           and vote delegation certificate, which when submitted
+                           in a transaction registers a stake address, delgates
+                           stake to a pool, and delegates votes to a DRep or
+                           pre-defined voting option.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_build.cli
@@ -1,0 +1,28 @@
+Usage: cardano-cli dijkstra stake-address build 
+                                                  ( --stake-verification-key STRING
+                                                  | --stake-verification-key-file FILEPATH
+                                                  | --stake-key-hash HASH
+                                                  | --stake-script-file FILEPATH
+                                                  )
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILEPATH]
+                                                  
+
+  Build a stake address
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_deregistration-certificate.cli
@@ -1,0 +1,26 @@
+Usage: cardano-cli dijkstra stake-address deregistration-certificate 
+                                                                       ( --stake-verification-key STRING
+                                                                       | --stake-verification-key-file FILEPATH
+                                                                       | --stake-key-hash HASH
+                                                                       | --stake-script-file FILEPATH
+                                                                       | --stake-address ADDRESS
+                                                                       )
+                                                                       --key-reg-deposit-amt NATURAL
+                                                                       --out-file FILEPATH
+                                                                       
+
+  Create a stake address deregistration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_key-gen.cli
@@ -1,0 +1,25 @@
+Usage: cardano-cli dijkstra stake-address key-gen 
+                                                    [ --key-output-bech32
+                                                    | --key-output-text-envelope
+                                                    | --key-output-format STRING
+                                                    ]
+                                                    --verification-key-file FILEPATH
+                                                    --signing-key-file FILEPATH
+                                                    
+
+  Create a stake address key pair
+
+Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
+  --verification-key-file FILEPATH
+                           Output filepath of the verification key.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_key-hash.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli dijkstra stake-address key-hash 
+                                                     ( --stake-verification-key STRING
+                                                     | --stake-verification-key-file FILEPATH
+                                                     )
+                                                     [--out-file FILEPATH]
+                                                     
+
+  Print the hash of a stake address key
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_registration-and-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_registration-and-delegation-certificate.cli
@@ -1,0 +1,43 @@
+Usage: cardano-cli dijkstra stake-address registration-and-delegation-certificate 
+                                                                                    ( --stake-verification-key STRING
+                                                                                    | --stake-verification-key-file FILEPATH
+                                                                                    | --stake-key-hash HASH
+                                                                                    | --stake-script-file FILEPATH
+                                                                                    | --stake-address ADDRESS
+                                                                                    )
+                                                                                    ( --stake-pool-verification-key STRING
+                                                                                    | --stake-pool-verification-extended-key STRING
+                                                                                    | --cold-verification-key-file FILEPATH
+                                                                                    | --stake-pool-id STAKE_POOL_ID
+                                                                                    )
+                                                                                    --key-reg-deposit-amt NATURAL
+                                                                                    --out-file FILEPATH
+                                                                                    
+
+  Create a stake address registration and delegation certificate, which when
+  submitted in a transaction registers a stake address and delegates stake to a
+  stake pool.
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_registration-and-vote-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_registration-and-vote-delegation-certificate.cli
@@ -1,0 +1,45 @@
+Usage: cardano-cli dijkstra stake-address registration-and-vote-delegation-certificate 
+                                                                                         ( --stake-verification-key STRING
+                                                                                         | --stake-verification-key-file FILEPATH
+                                                                                         | --stake-key-hash HASH
+                                                                                         | --stake-script-file FILEPATH
+                                                                                         | --stake-address ADDRESS
+                                                                                         )
+                                                                                         ( --drep-script-hash HASH
+                                                                                         | --drep-verification-key STRING
+                                                                                         | --drep-verification-key-file FILEPATH
+                                                                                         | --drep-key-hash HASH
+                                                                                         | --always-abstain
+                                                                                         | --always-no-confidence
+                                                                                         )
+                                                                                         --key-reg-deposit-amt NATURAL
+                                                                                         --out-file FILEPATH
+                                                                                         
+
+  Create a stake address registration and vote delegation certificate, which
+  when submitted in a transaction registers a stake address and delegates votes
+  to a DRep or pre-defined voting option.
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --drep-script-hash HASH  DRep script hash (hex-encoded). Obtain it with
+                           "cardano-cli hash script ...".
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --always-abstain         Abstain from voting on all proposals.
+  --always-no-confidence   Always vote no confidence
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_registration-certificate.cli
@@ -1,0 +1,26 @@
+Usage: cardano-cli dijkstra stake-address registration-certificate 
+                                                                     ( --stake-verification-key STRING
+                                                                     | --stake-verification-key-file FILEPATH
+                                                                     | --stake-key-hash HASH
+                                                                     | --stake-script-file FILEPATH
+                                                                     | --stake-address ADDRESS
+                                                                     )
+                                                                     --key-reg-deposit-amt NATURAL
+                                                                     --out-file FILEPATH
+                                                                     
+
+  Create a stake address registration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_registration-stake-and-vote-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_registration-stake-and-vote-delegation-certificate.cli
@@ -1,0 +1,61 @@
+Usage: cardano-cli dijkstra stake-address registration-stake-and-vote-delegation-certificate 
+                                                                                               ( --stake-verification-key STRING
+                                                                                               | --stake-verification-key-file FILEPATH
+                                                                                               | --stake-key-hash HASH
+                                                                                               | --stake-script-file FILEPATH
+                                                                                               | --stake-address ADDRESS
+                                                                                               )
+                                                                                               ( --stake-pool-verification-key STRING
+                                                                                               | --stake-pool-verification-extended-key STRING
+                                                                                               | --cold-verification-key-file FILEPATH
+                                                                                               | --stake-pool-id STAKE_POOL_ID
+                                                                                               )
+                                                                                               ( --drep-script-hash HASH
+                                                                                               | --drep-verification-key STRING
+                                                                                               | --drep-verification-key-file FILEPATH
+                                                                                               | --drep-key-hash HASH
+                                                                                               | --always-abstain
+                                                                                               | --always-no-confidence
+                                                                                               )
+                                                                                               --key-reg-deposit-amt NATURAL
+                                                                                               --out-file FILEPATH
+                                                                                               
+
+  Create a stake address registration, stake delegation and vote delegation
+  certificate, which when submitted in a transaction registers a stake address,
+  delgates stake to a pool, and delegates votes to a DRep or pre-defined voting
+  option.
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded).
+  --drep-script-hash HASH  DRep script hash (hex-encoded). Obtain it with
+                           "cardano-cli hash script ...".
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --always-abstain         Abstain from voting on all proposals.
+  --always-no-confidence   Always vote no confidence
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_stake-and-vote-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_stake-and-vote-delegation-certificate.cli
@@ -1,0 +1,56 @@
+Usage: cardano-cli dijkstra stake-address stake-and-vote-delegation-certificate 
+                                                                                  ( --stake-verification-key STRING
+                                                                                  | --stake-verification-key-file FILEPATH
+                                                                                  | --stake-key-hash HASH
+                                                                                  | --stake-script-file FILEPATH
+                                                                                  | --stake-address ADDRESS
+                                                                                  )
+                                                                                  ( --stake-pool-verification-key STRING
+                                                                                  | --stake-pool-verification-extended-key STRING
+                                                                                  | --cold-verification-key-file FILEPATH
+                                                                                  | --stake-pool-id STAKE_POOL_ID
+                                                                                  )
+                                                                                  ( --drep-script-hash HASH
+                                                                                  | --drep-verification-key STRING
+                                                                                  | --drep-verification-key-file FILEPATH
+                                                                                  | --drep-key-hash HASH
+                                                                                  | --always-abstain
+                                                                                  | --always-no-confidence
+                                                                                  )
+                                                                                  --out-file FILEPATH
+                                                                                  
+
+  Create a stake address stake and vote delegation certificate, which when
+  submitted in a transaction delegates stake to a stake pool and a DRep.
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded).
+  --drep-script-hash HASH  DRep script hash (hex-encoded). Obtain it with
+                           "cardano-cli hash script ...".
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --always-abstain         Abstain from voting on all proposals.
+  --always-no-confidence   Always vote no confidence
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_stake-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_stake-delegation-certificate.cli
@@ -1,0 +1,39 @@
+Usage: cardano-cli dijkstra stake-address stake-delegation-certificate 
+                                                                         ( --stake-verification-key STRING
+                                                                         | --stake-verification-key-file FILEPATH
+                                                                         | --stake-key-hash HASH
+                                                                         | --stake-script-file FILEPATH
+                                                                         | --stake-address ADDRESS
+                                                                         )
+                                                                         ( --stake-pool-verification-key STRING
+                                                                         | --stake-pool-verification-extended-key STRING
+                                                                         | --cold-verification-key-file FILEPATH
+                                                                         | --stake-pool-id STAKE_POOL_ID
+                                                                         )
+                                                                         --out-file FILEPATH
+                                                                         
+
+  Create a stake address stake delegation certificate, which when submitted in a
+  transaction delegates stake to a stake pool.
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded).
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_vote-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-address_vote-delegation-certificate.cli
@@ -1,0 +1,41 @@
+Usage: cardano-cli dijkstra stake-address vote-delegation-certificate 
+                                                                        ( --stake-verification-key STRING
+                                                                        | --stake-verification-key-file FILEPATH
+                                                                        | --stake-key-hash HASH
+                                                                        | --stake-script-file FILEPATH
+                                                                        | --stake-address ADDRESS
+                                                                        )
+                                                                        ( --drep-script-hash HASH
+                                                                        | --drep-verification-key STRING
+                                                                        | --drep-verification-key-file FILEPATH
+                                                                        | --drep-key-hash HASH
+                                                                        | --always-abstain
+                                                                        | --always-no-confidence
+                                                                        )
+                                                                        --out-file FILEPATH
+                                                                        
+
+  Create a stake address vote delegation certificate, which when submitted in a
+  transaction delegates stake to a DRep.
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --drep-script-hash HASH  DRep script hash (hex-encoded). Obtain it with
+                           "cardano-cli hash script ...".
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --always-abstain         Abstain from voting on all proposals.
+  --always-no-confidence   Always vote no confidence
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-pool.cli
@@ -1,0 +1,21 @@
+Usage: cardano-cli dijkstra stake-pool 
+                                         ( registration-certificate
+                                         | deregistration-certificate
+                                         | id
+                                         | metadata-hash
+                                         )
+                                         
+
+  Stake pool commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  registration-certificate Create a stake pool registration certificate
+  deregistration-certificate
+                           Create a stake pool deregistration certificate
+  id                       Build pool id from the offline key
+  metadata-hash            Calculate the hash of a stake pool metadata file,
+                           optionally checking the obtained hash against an
+                           expected value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-pool_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-pool_deregistration-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli dijkstra stake-pool deregistration-certificate 
+                                                                    ( --stake-pool-verification-key STRING
+                                                                    | --stake-pool-verification-extended-key STRING
+                                                                    | --cold-verification-key-file FILEPATH
+                                                                    )
+                                                                    --epoch NATURAL
+                                                                    --out-file FILEPATH
+                                                                    
+
+  Create a stake pool deregistration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the stake pool verification key.
+  --epoch NATURAL          The epoch number.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-pool_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-pool_id.cli
@@ -1,0 +1,27 @@
+Usage: cardano-cli dijkstra stake-pool id 
+                                            ( --stake-pool-verification-key STRING
+                                            | --stake-pool-verification-extended-key STRING
+                                            | --cold-verification-key-file FILEPATH
+                                            )
+                                            [--output-bech32 | --output-hex]
+                                            [--out-file FILEPATH]
+                                            
+
+  Build pool id from the offline key
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the stake pool verification key.
+  --output-bech32          Format pool-id output to BECH32 (default).
+  --output-hex             Format pool-id output to BASE16.
+  --output-format STRING   Optional pool id output format. Accepted output
+                           formats are "hex" and "bech32" (default is "bech32").
+                           The --output-format flag is deprecated and will be
+                           removed in a future version.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-pool_metadata-hash.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli dijkstra stake-pool metadata-hash 
+                                                       ( --pool-metadata-file FILEPATH
+                                                       | --pool-metadata-url TEXT
+                                                       )
+                                                       [ --expected-hash HASH
+                                                       | --out-file FILEPATH
+                                                       ]
+                                                       
+
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
+
+Available options:
+  --pool-metadata-file FILEPATH
+                           Filepath of the pool metadata.
+  --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
+                           Supported schemes are: file, http, https, ipfs.
+  --expected-hash HASH     Expected hash for the stake pool metadata, for
+                           verification purposes. If provided, the hash of the
+                           stake pool metadata will be compared to this value.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_stake-pool_registration-certificate.cli
@@ -1,0 +1,88 @@
+Usage: cardano-cli dijkstra stake-pool registration-certificate 
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --stake-pool-verification-extended-key STRING
+                                                                  | --cold-verification-key-file FILEPATH
+                                                                  )
+                                                                  ( --vrf-verification-key STRING
+                                                                  | --vrf-verification-key-file FILEPATH
+                                                                  )
+                                                                  --pool-pledge LOVELACE
+                                                                  --pool-cost LOVELACE
+                                                                  --pool-margin RATIONAL
+                                                                  ( --pool-reward-account-verification-key STRING
+                                                                  | --pool-reward-account-verification-key-file FILEPATH
+                                                                  )
+                                                                  ( --pool-owner-verification-key STRING
+                                                                  | --pool-owner-stake-verification-key-file FILEPATH
+                                                                  )
+                                                                  [ [--pool-relay-ipv4 STRING]
+                                                                    [--pool-relay-ipv6 STRING]
+                                                                    --pool-relay-port INT
+                                                                  | --single-host-pool-relay STRING
+                                                                    --pool-relay-port INT
+                                                                  | --multi-host-pool-relay STRING
+                                                                  ]
+                                                                  [--validate-relays]
+                                                                  [--metadata-url URL
+                                                                    --metadata-hash HASH
+                                                                    [--check-metadata-hash]]
+                                                                  ( --mainnet
+                                                                  | --testnet-magic NATURAL
+                                                                  )
+                                                                  --out-file FILEPATH
+                                                                  
+
+  Create a stake pool registration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the stake pool verification key.
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILEPATH
+                           Filepath of the VRF verification key.
+  --pool-pledge LOVELACE   The stake pool's pledge.
+  --pool-cost LOVELACE     The stake pool's cost.
+  --pool-margin RATIONAL   The stake pool's margin.
+  --pool-reward-account-verification-key STRING
+                           Reward account stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-reward-account-verification-key-file FILEPATH
+                           Filepath of the reward account stake verification
+                           key.
+  --pool-owner-verification-key STRING
+                           Pool owner stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-owner-stake-verification-key-file FILEPATH
+                           Filepath of the pool owner stake verification key.
+  --pool-relay-ipv4 STRING The stake pool relay's IPv4 address
+  --pool-relay-ipv6 STRING The stake pool relay's IPv6 address
+  --pool-relay-port INT    The stake pool relay's port
+  --single-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an A or AAAA DNS record
+  --pool-relay-port INT    The stake pool relay's port
+  --multi-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an SRV DNS record
+  --validate-relays        Validate the relays given on the command line by
+                           connecting to each one (this parameter requires
+                           network access to the relays)
+  --metadata-url URL       Pool metadata URL (maximum length of 128 characters).
+  --metadata-hash HASH     Pool metadata hash.
+  --check-metadata-hash    Verify that the expected stake pool metadata hash
+                           provided in --metadata-hash matches the hash of the
+                           file downloaded from the URL provided in
+                           --metadata-url (this parameter will download the file
+                           from the URL)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_text-view_decode-cbor.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_text-view_decode-cbor.cli
@@ -1,0 +1,20 @@
+Usage: cardano-cli dijkstra text-view decode-cbor --in-file FILEPATH
+                                                    [ --output-cbor-hex
+                                                    | --output-json
+                                                    | --output-text
+                                                    | --output-yaml
+                                                    ]
+                                                    [--out-file FILEPATH]
+                                                    
+
+  Print a TextView file as decoded CBOR.
+
+Available options:
+  --in-file FILEPATH       CBOR input file.
+  --output-cbor-hex        Format text view info output format to BASE16 CBOR.
+  --output-json            Format text view info output format to JSON.
+  --output-text            Format text view info output format to TEXT
+                           (default).
+  --output-yaml            Format text view info output format to YAML.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction.cli
@@ -1,0 +1,50 @@
+Usage: cardano-cli dijkstra transaction 
+                                          ( build-raw
+                                          | build
+                                          | build-estimate
+                                          | sign
+                                          | witness
+                                          | assemble
+                                          | submit
+                                          | policyid
+                                          | calculate-min-fee
+                                          | calculate-min-required-utxo
+                                          | calculate-plutus-script-cost
+                                          | hash-script-data
+                                          | txid
+                                          )
+                                          
+
+  Transaction commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  build-raw                Build a transaction (low-level, inconvenient)
+
+                           Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  build                    Build a balanced transaction (automatically calculates fees)
+
+                           Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  build-estimate           Build a balanced transaction without access to a live node (automatically estimates fees)
+
+                           Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  sign                     Sign a transaction
+  witness                  Create a transaction witness
+  assemble                 Assemble a tx body and witness(es) to form a
+                           transaction
+  submit                   Submit a transaction to the local node whose Unix
+                           domain socket is obtained from the
+                           CARDANO_NODE_SOCKET_PATH environment variable.
+  policyid                 Calculate the PolicyId from the monetary policy
+                           script.
+  calculate-min-fee        Calculate the minimum fee for a transaction.
+  calculate-min-required-utxo
+                           Calculate the minimum required UTxO for a transaction
+                           output.
+  calculate-plutus-script-cost
+                           Calculate the costs of the Plutus scripts of a given
+                           transaction.
+  hash-script-data         Calculate the hash of script data.
+  txid                     Print a transaction identifier.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_assemble.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_assemble.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli dijkstra transaction assemble --tx-body-file FILEPATH
+                                                   [--witness-file FILEPATH]
+                                                   [--out-canonical-cbor]
+                                                   --out-file FILEPATH
+                                                   
+
+  Assemble a tx body and witness(es) to form a transaction
+
+Available options:
+  --tx-body-file FILEPATH  Input filepath of the JSON TxBody.
+  --witness-file FILEPATH  Filepath of the witness
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_build-estimate.cli
@@ -1,0 +1,519 @@
+Usage: cardano-cli dijkstra transaction build-estimate 
+                                                         [ --script-valid
+                                                         | --script-invalid
+                                                         ]
+                                                         --shelley-key-witnesses INT
+                                                         [--byron-key-witnesses Int]
+                                                         --protocol-params-file FILEPATH
+                                                         --total-utxo-value VALUE
+                                                         (--tx-in TX_IN
+                                                           [ --spending-tx-in-reference TX_IN
+                                                             ( --spending-plutus-script-v2
+                                                             | --spending-plutus-script-v3
+                                                             )
+                                                             [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                             | --spending-reference-tx-in-datum-file JSON_FILE
+                                                             | --spending-reference-tx-in-datum-value JSON_VALUE
+                                                             | --spending-reference-tx-in-inline-datum-present
+                                                             ]
+                                                             ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                             | --spending-reference-tx-in-redeemer-value JSON_VALUE
+                                                             )
+                                                             --spending-reference-tx-in-execution-units (INT, INT)
+                                                           | --simple-script-tx-in-reference TX_IN
+                                                           | --tx-in-script-file FILEPATH
+                                                             [
+                                                               [ --tx-in-datum-cbor-file CBOR_FILE
+                                                               | --tx-in-datum-file JSON_FILE
+                                                               | --tx-in-datum-value JSON_VALUE
+                                                               | --tx-in-inline-datum-present
+                                                               ]
+                                                               ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                               | --tx-in-redeemer-file JSON_FILE
+                                                               | --tx-in-redeemer-value JSON_VALUE
+                                                               )
+                                                               --tx-in-execution-units (INT, INT)]
+                                                           ])
+                                                         [--read-only-tx-in-reference TX_IN]
+                                                         [ --required-signer FILEPATH
+                                                         | --required-signer-hash HASH
+                                                         ]
+                                                         [--tx-in-collateral TX_IN]
+                                                         [--tx-out-return-collateral ADDRESS VALUE]
+                                                         [--tx-out ADDRESS VALUE
+                                                           [ --tx-out-datum-hash HASH
+                                                           | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                           | --tx-out-datum-hash-file JSON_FILE
+                                                           | --tx-out-datum-hash-value JSON_VALUE
+                                                           | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                           | --tx-out-datum-embed-file JSON_FILE
+                                                           | --tx-out-datum-embed-value JSON_VALUE
+                                                           | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                           | --tx-out-inline-datum-file JSON_FILE
+                                                           | --tx-out-inline-datum-value JSON_VALUE
+                                                           ]
+                                                           [--tx-out-reference-script-file FILEPATH]]
+                                                         --change-address ADDRESS
+                                                         [--mint VALUE
+                                                           ( --mint-script-file FILEPATH
+                                                             [
+                                                               ( --mint-redeemer-cbor-file CBOR_FILE
+                                                               | --mint-redeemer-file JSON_FILE
+                                                               | --mint-redeemer-value JSON_VALUE
+                                                               )
+                                                               --mint-execution-units (INT, INT)]
+                                                           | --simple-minting-script-tx-in-reference TX_IN
+                                                             --policy-id HASH
+                                                           | --mint-tx-in-reference TX_IN
+                                                             ( --mint-plutus-script-v2
+                                                             | --mint-plutus-script-v3
+                                                             )
+                                                             ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                             | --mint-reference-tx-in-redeemer-value JSON_VALUE
+                                                             )
+                                                             --mint-reference-tx-in-execution-units (INT, INT)
+                                                             --policy-id HASH
+                                                           )]
+                                                         [--invalid-before SLOT]
+                                                         [--invalid-hereafter SLOT]
+                                                         [
+                                                           --certificate-file FILEPATH
+                                                           [ --certificate-script-file FILEPATH
+                                                             [
+                                                               ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                               | --certificate-redeemer-file JSON_FILE
+                                                               | --certificate-redeemer-value JSON_VALUE
+                                                               )
+                                                               --certificate-execution-units (INT, INT)]
+                                                           | --certificate-tx-in-reference TX_IN
+                                                             ( --certificate-plutus-script-v2
+                                                             | --certificate-plutus-script-v3
+                                                             )
+                                                             ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                             | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                             )
+                                                             --certificate-reference-tx-in-execution-units (INT, INT)
+                                                           ]]
+                                                         [--withdrawal WITHDRAWAL
+                                                           [ --withdrawal-script-file FILEPATH
+                                                             [
+                                                               ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                               | --withdrawal-redeemer-file JSON_FILE
+                                                               | --withdrawal-redeemer-value JSON_VALUE
+                                                               )
+                                                               --withdrawal-execution-units (INT, INT)]
+                                                           | --withdrawal-tx-in-reference TX_IN
+                                                             ( --withdrawal-plutus-script-v2
+                                                             | --withdrawal-plutus-script-v3
+                                                             )
+                                                             ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                             | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                                                             )
+                                                             --withdrawal-reference-tx-in-execution-units (INT, INT)
+                                                           ]]
+                                                         [--tx-total-collateral INTEGER]
+                                                         [--reference-script-size NATURAL]
+                                                         [ --json-metadata-no-schema
+                                                         | --json-metadata-detailed-schema
+                                                         ]
+                                                         [--auxiliary-script-file FILEPATH]
+                                                         [ --metadata-json-file FILEPATH
+                                                         | --metadata-cbor-file FILEPATH
+                                                         ]
+                                                         [--vote-file FILEPATH
+                                                           [ --vote-script-file FILEPATH
+                                                             [
+                                                               ( --vote-redeemer-cbor-file CBOR_FILE
+                                                               | --vote-redeemer-file JSON_FILE
+                                                               | --vote-redeemer-value JSON_VALUE
+                                                               )
+                                                               --vote-execution-units (INT, INT)]
+                                                           | --vote-tx-in-reference TX_IN
+                                                             --vote-plutus-script-v3
+                                                             ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                             | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                             )
+                                                             --vote-reference-tx-in-execution-units (INT, INT)
+                                                           ]]
+                                                         [--proposal-file FILEPATH
+                                                           [ --proposal-script-file FILEPATH
+                                                             [
+                                                               ( --proposal-redeemer-cbor-file CBOR_FILE
+                                                               | --proposal-redeemer-file JSON_FILE
+                                                               | --proposal-redeemer-value JSON_VALUE
+                                                               )
+                                                               --proposal-execution-units (INT, INT)]
+                                                           | --proposal-tx-in-reference TX_IN
+                                                             --proposal-plutus-script-v3
+                                                             ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                             | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                             )
+                                                             --proposal-reference-tx-in-execution-units (INT, INT)
+                                                           ]]
+                                                         [--current-treasury-value LOVELACE]
+                                                         [--treasury-donation LOVELACE]
+                                                         [--out-canonical-cbor]
+                                                         --out-file FILEPATH
+                                                         
+
+  Build a balanced transaction without access to a live node (automatically estimates fees)
+
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+
+Available options:
+  --script-valid           Assertion that the script is valid. (default)
+  --script-invalid         Assertion that the script is invalid. If a
+                           transaction is submitted with such a script, the
+                           script will fail and the collateral will be taken.
+  --shelley-key-witnesses INT
+                           Specify the number of Shelley key witnesses the
+                           transaction requires.
+  --byron-key-witnesses Int
+                           Specify the number of Byron key witnesses the
+                           transaction requires.
+  --protocol-params-file FILEPATH
+                           Filepath of the JSON-encoded protocol parameters file
+  --total-utxo-value VALUE The total value of the UTxO that exists at the tx
+                           inputs being spent.
+  --tx-in TX_IN            TxId#TxIx
+  --spending-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --spending-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --spending-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
+  --spending-reference-tx-in-inline-datum-present
+                           Inline datum present at transaction input.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --spending-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --simple-script-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a simple reference script attached.
+  --tx-in-script-file FILEPATH
+                           The file containing the script to witness the
+                           spending of the transaction input.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
+  --tx-in-inline-datum-present
+                           Inline datum present at transaction input.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --read-only-tx-in-reference TX_IN
+                           Specify a read only reference input. This reference
+                           input is not witnessing anything it is simply
+                           provided in the plutus script context.
+  --required-signer FILEPATH
+                           Input filepath of the signing key (zero or more)
+                           whose signature is required.
+  --required-signer-hash HASH
+                           Hash of the verification key (zero or more) whose
+                           signature is required.
+  --tx-in-collateral TX_IN TxId#TxIx
+  --tx-out-return-collateral ADDRESS VALUE
+                           The transaction output as ADDRESS VALUE where ADDRESS
+                           is the Bech32-encoded address followed by the value
+                           in Lovelace. In the situation where your collateral
+                           txin over collateralizes the transaction, you can
+                           optionally specify a tx out of your choosing to
+                           return the excess Lovelace.
+  --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
+                           is the Bech32-encoded address followed by the value
+                           in the multi-asset syntax (including simply
+                           Lovelace).
+  --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
+                           datum hash (in hex).
+  --tx-out-datum-hash-cbor-file CBOR_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
+                           The script datum hash for this tx output, by hashing
+                           the script datum given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
+                           The script datum to embed in the tx output as an
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
+                           The script datum to embed in the tx output as an
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
+                           The script datum to embed in the tx output as an
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-out-reference-script-file FILEPATH
+                           Reference script input file.
+  --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
+  --mint VALUE             Mint multi-asset value(s) with the multi-asset cli
+                           syntax. You must specify a script witness.
+  --mint-script-file FILEPATH
+                           The file containing the script to witness the minting
+                           of assets for a particular policy Id.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --mint-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --simple-minting-script-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a simple reference script attached.
+  --policy-id HASH         Policy id of minting script.
+  --mint-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --mint-plutus-script-v2  Specify a plutus script v2 reference script.
+  --mint-plutus-script-v3  Specify a plutus script v3 reference script.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --mint-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --policy-id HASH         Policy id of minting script.
+  --invalid-before SLOT    Time that transaction is valid from (in slots).
+  --invalid-hereafter SLOT Time that transaction is valid until (in slots).
+  --certificate-file FILEPATH
+                           Filepath of the certificate. This encompasses all
+                           types of certificates (stake pool certificates, stake
+                           key certificates etc). Optionally specify a script
+                           witness.
+  --certificate-script-file FILEPATH
+                           The file containing the script to witness the use of
+                           the certificate.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --certificate-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --certificate-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --certificate-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
+                           StakeAddress is the Bech32-encoded stake address
+                           followed by the amount in Lovelace. Optionally
+                           specify a script witness.
+  --withdrawal-script-file FILEPATH
+                           The file containing the script to witness the
+                           withdrawal of rewards.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --withdrawal-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --withdrawal-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --withdrawal-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --withdrawal-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --withdrawal-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --tx-total-collateral INTEGER
+                           The total amount of collateral that will be collected
+                           as fees in the event of a Plutus script failure. Must
+                           be used in conjuction with
+                           "--tx-out-return-collateral".
+  --reference-script-size NATURAL
+                           Total size in bytes of transaction reference scripts
+                           (default is 0).
+  --json-metadata-no-schema
+                           Use the "no schema" conversion from JSON to tx
+                           metadata (default).
+  --json-metadata-detailed-schema
+                           Use the "detailed schema" conversion from JSON to tx
+                           metadata.
+  --auxiliary-script-file FILEPATH
+                           Filepath of auxiliary script(s)
+  --metadata-json-file FILEPATH
+                           Filepath of the metadata file, in JSON format.
+  --metadata-cbor-file FILEPATH
+                           Filepath of the metadata, in raw CBOR format.
+  --vote-file FILEPATH     Filepath of the vote.
+  --vote-script-file FILEPATH
+                           The file containing the script to witness a vote
+  --vote-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --vote-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --vote-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --vote-plutus-script-v3  Specify a plutus script v3 reference script.
+  --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --vote-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --proposal-file FILEPATH Filepath of the proposal.
+  --proposal-script-file FILEPATH
+                           The file containing the script to witness a proposal
+  --proposal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --proposal-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --proposal-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --proposal-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --proposal-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --current-treasury-value LOVELACE
+                           The current treasury value.
+  --treasury-donation LOVELACE
+                           The donation to the treasury to perform.
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
+  --out-file FILEPATH      Output filepath of the JSON TxBody.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_build-raw.cli
@@ -1,0 +1,503 @@
+Usage: cardano-cli dijkstra transaction build-raw 
+                                                    [ --script-valid
+                                                    | --script-invalid
+                                                    ]
+                                                    (--tx-in TX_IN
+                                                      [ --spending-tx-in-reference TX_IN
+                                                        ( --spending-plutus-script-v2
+                                                        | --spending-plutus-script-v3
+                                                        )
+                                                        [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                        | --spending-reference-tx-in-datum-file JSON_FILE
+                                                        | --spending-reference-tx-in-datum-value JSON_VALUE
+                                                        | --spending-reference-tx-in-inline-datum-present
+                                                        ]
+                                                        ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                        | --spending-reference-tx-in-redeemer-value JSON_VALUE
+                                                        )
+                                                        --spending-reference-tx-in-execution-units (INT, INT)
+                                                      | --simple-script-tx-in-reference TX_IN
+                                                      | --tx-in-script-file FILEPATH
+                                                        [
+                                                          [ --tx-in-datum-cbor-file CBOR_FILE
+                                                          | --tx-in-datum-file JSON_FILE
+                                                          | --tx-in-datum-value JSON_VALUE
+                                                          | --tx-in-inline-datum-present
+                                                          ]
+                                                          ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                          | --tx-in-redeemer-file JSON_FILE
+                                                          | --tx-in-redeemer-value JSON_VALUE
+                                                          )
+                                                          --tx-in-execution-units (INT, INT)]
+                                                      ])
+                                                    [--read-only-tx-in-reference TX_IN]
+                                                    [--tx-in-collateral TX_IN]
+                                                    [--tx-out-return-collateral ADDRESS VALUE]
+                                                    [--tx-total-collateral INTEGER]
+                                                    [ --required-signer FILEPATH
+                                                    | --required-signer-hash HASH
+                                                    ]
+                                                    [--tx-out ADDRESS VALUE
+                                                      [ --tx-out-datum-hash HASH
+                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                      | --tx-out-datum-hash-file JSON_FILE
+                                                      | --tx-out-datum-hash-value JSON_VALUE
+                                                      | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                      | --tx-out-datum-embed-file JSON_FILE
+                                                      | --tx-out-datum-embed-value JSON_VALUE
+                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                      | --tx-out-inline-datum-file JSON_FILE
+                                                      | --tx-out-inline-datum-value JSON_VALUE
+                                                      ]
+                                                      [--tx-out-reference-script-file FILEPATH]]
+                                                    [--mint VALUE
+                                                      ( --mint-script-file FILEPATH
+                                                        [
+                                                          ( --mint-redeemer-cbor-file CBOR_FILE
+                                                          | --mint-redeemer-file JSON_FILE
+                                                          | --mint-redeemer-value JSON_VALUE
+                                                          )
+                                                          --mint-execution-units (INT, INT)]
+                                                      | --simple-minting-script-tx-in-reference TX_IN
+                                                        --policy-id HASH
+                                                      | --mint-tx-in-reference TX_IN
+                                                        ( --mint-plutus-script-v2
+                                                        | --mint-plutus-script-v3
+                                                        )
+                                                        ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                        | --mint-reference-tx-in-redeemer-value JSON_VALUE
+                                                        )
+                                                        --mint-reference-tx-in-execution-units (INT, INT)
+                                                        --policy-id HASH
+                                                      )]
+                                                    [--invalid-before SLOT]
+                                                    [--invalid-hereafter SLOT]
+                                                    --fee LOVELACE
+                                                    [--certificate-file FILEPATH
+                                                      [ --certificate-script-file FILEPATH
+                                                        [
+                                                          ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                          | --certificate-redeemer-file JSON_FILE
+                                                          | --certificate-redeemer-value JSON_VALUE
+                                                          )
+                                                          --certificate-execution-units (INT, INT)]
+                                                      | --certificate-tx-in-reference TX_IN
+                                                        ( --certificate-plutus-script-v2
+                                                        | --certificate-plutus-script-v3
+                                                        )
+                                                        ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                        | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                        )
+                                                        --certificate-reference-tx-in-execution-units (INT, INT)
+                                                      ]]
+                                                    [--withdrawal WITHDRAWAL
+                                                      [ --withdrawal-script-file FILEPATH
+                                                        [
+                                                          ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                          | --withdrawal-redeemer-file JSON_FILE
+                                                          | --withdrawal-redeemer-value JSON_VALUE
+                                                          )
+                                                          --withdrawal-execution-units (INT, INT)]
+                                                      | --withdrawal-tx-in-reference TX_IN
+                                                        ( --withdrawal-plutus-script-v2
+                                                        | --withdrawal-plutus-script-v3
+                                                        )
+                                                        ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                        | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                                                        )
+                                                        --withdrawal-reference-tx-in-execution-units (INT, INT)
+                                                      ]]
+                                                    [ --json-metadata-no-schema
+                                                    | --json-metadata-detailed-schema
+                                                    ]
+                                                    [--auxiliary-script-file FILEPATH]
+                                                    [ --metadata-json-file FILEPATH
+                                                    | --metadata-cbor-file FILEPATH
+                                                    ]
+                                                    [--protocol-params-file FILEPATH]
+                                                    [--vote-file FILEPATH
+                                                      [ --vote-script-file FILEPATH
+                                                        [
+                                                          ( --vote-redeemer-cbor-file CBOR_FILE
+                                                          | --vote-redeemer-file JSON_FILE
+                                                          | --vote-redeemer-value JSON_VALUE
+                                                          )
+                                                          --vote-execution-units (INT, INT)]
+                                                      | --vote-tx-in-reference TX_IN
+                                                        --vote-plutus-script-v3
+                                                        ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                        | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                        )
+                                                        --vote-reference-tx-in-execution-units (INT, INT)
+                                                      ]]
+                                                    [--proposal-file FILEPATH
+                                                      [ --proposal-script-file FILEPATH
+                                                        [
+                                                          ( --proposal-redeemer-cbor-file CBOR_FILE
+                                                          | --proposal-redeemer-file JSON_FILE
+                                                          | --proposal-redeemer-value JSON_VALUE
+                                                          )
+                                                          --proposal-execution-units (INT, INT)]
+                                                      | --proposal-tx-in-reference TX_IN
+                                                        --proposal-plutus-script-v3
+                                                        ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                        | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                        )
+                                                        --proposal-reference-tx-in-execution-units (INT, INT)
+                                                      ]]
+                                                    [--current-treasury-value LOVELACE]
+                                                    [--treasury-donation LOVELACE]
+                                                    [--out-canonical-cbor]
+                                                    --out-file FILEPATH
+                                                    
+
+  Build a transaction (low-level, inconvenient)
+
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+
+Available options:
+  --script-valid           Assertion that the script is valid. (default)
+  --script-invalid         Assertion that the script is invalid. If a
+                           transaction is submitted with such a script, the
+                           script will fail and the collateral will be taken.
+  --tx-in TX_IN            TxId#TxIx
+  --spending-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --spending-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --spending-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
+  --spending-reference-tx-in-inline-datum-present
+                           Inline datum present at transaction input.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --spending-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --simple-script-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a simple reference script attached.
+  --tx-in-script-file FILEPATH
+                           The file containing the script to witness the
+                           spending of the transaction input.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
+  --tx-in-inline-datum-present
+                           Inline datum present at transaction input.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --read-only-tx-in-reference TX_IN
+                           Specify a read only reference input. This reference
+                           input is not witnessing anything it is simply
+                           provided in the plutus script context.
+  --tx-in-collateral TX_IN TxId#TxIx
+  --tx-out-return-collateral ADDRESS VALUE
+                           The transaction output as ADDRESS VALUE where ADDRESS
+                           is the Bech32-encoded address followed by the value
+                           in Lovelace. In the situation where your collateral
+                           txin over collateralizes the transaction, you can
+                           optionally specify a tx out of your choosing to
+                           return the excess Lovelace.
+  --tx-total-collateral INTEGER
+                           The total amount of collateral that will be collected
+                           as fees in the event of a Plutus script failure. Must
+                           be used in conjuction with
+                           "--tx-out-return-collateral".
+  --required-signer FILEPATH
+                           Input filepath of the signing key (zero or more)
+                           whose signature is required.
+  --required-signer-hash HASH
+                           Hash of the verification key (zero or more) whose
+                           signature is required.
+  --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
+                           is the Bech32-encoded address followed by the value
+                           in the multi-asset syntax (including simply
+                           Lovelace).
+  --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
+                           datum hash (in hex).
+  --tx-out-datum-hash-cbor-file CBOR_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
+                           The script datum hash for this tx output, by hashing
+                           the script datum given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
+                           The script datum to embed in the tx output as an
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
+                           The script datum to embed in the tx output as an
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
+                           The script datum to embed in the tx output as an
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-out-reference-script-file FILEPATH
+                           Reference script input file.
+  --mint VALUE             Mint multi-asset value(s) with the multi-asset cli
+                           syntax. You must specify a script witness.
+  --mint-script-file FILEPATH
+                           The file containing the script to witness the minting
+                           of assets for a particular policy Id.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --mint-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --simple-minting-script-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a simple reference script attached.
+  --policy-id HASH         Policy id of minting script.
+  --mint-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --mint-plutus-script-v2  Specify a plutus script v2 reference script.
+  --mint-plutus-script-v3  Specify a plutus script v3 reference script.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --mint-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --policy-id HASH         Policy id of minting script.
+  --invalid-before SLOT    Time that transaction is valid from (in slots).
+  --invalid-hereafter SLOT Time that transaction is valid until (in slots).
+  --fee LOVELACE           The fee amount in Lovelace.
+  --certificate-file FILEPATH
+                           Filepath of the certificate. This encompasses all
+                           types of certificates (stake pool certificates, stake
+                           key certificates etc). Optionally specify a script
+                           witness.
+  --certificate-script-file FILEPATH
+                           The file containing the script to witness the use of
+                           the certificate.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --certificate-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --certificate-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --certificate-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
+                           StakeAddress is the Bech32-encoded stake address
+                           followed by the amount in Lovelace. Optionally
+                           specify a script witness.
+  --withdrawal-script-file FILEPATH
+                           The file containing the script to witness the
+                           withdrawal of rewards.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --withdrawal-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --withdrawal-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --withdrawal-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --withdrawal-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --withdrawal-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --json-metadata-no-schema
+                           Use the "no schema" conversion from JSON to tx
+                           metadata (default).
+  --json-metadata-detailed-schema
+                           Use the "detailed schema" conversion from JSON to tx
+                           metadata.
+  --auxiliary-script-file FILEPATH
+                           Filepath of auxiliary script(s)
+  --metadata-json-file FILEPATH
+                           Filepath of the metadata file, in JSON format.
+  --metadata-cbor-file FILEPATH
+                           Filepath of the metadata, in raw CBOR format.
+  --protocol-params-file FILEPATH
+                           Filepath of the JSON-encoded protocol parameters file
+  --vote-file FILEPATH     Filepath of the vote.
+  --vote-script-file FILEPATH
+                           The file containing the script to witness a vote
+  --vote-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --vote-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --vote-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --vote-plutus-script-v3  Specify a plutus script v3 reference script.
+  --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --vote-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --proposal-file FILEPATH Filepath of the proposal.
+  --proposal-script-file FILEPATH
+                           The file containing the script to witness a proposal
+  --proposal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --proposal-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --proposal-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --proposal-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --proposal-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --current-treasury-value LOVELACE
+                           The current treasury value.
+  --treasury-donation LOVELACE
+                           The donation to the treasury to perform.
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
+  --out-file FILEPATH      Output filepath of the JSON TxBody.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_build.cli
@@ -1,0 +1,488 @@
+Usage: cardano-cli dijkstra transaction build 
+                                                [--cardano-mode
+                                                  [--epoch-slots SLOTS]]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --socket-path SOCKET_PATH
+                                                [ --script-valid
+                                                | --script-invalid
+                                                ]
+                                                [--witness-override WORD]
+                                                (--tx-in TX_IN
+                                                  [ --spending-tx-in-reference TX_IN
+                                                    ( --spending-plutus-script-v2
+                                                    | --spending-plutus-script-v3
+                                                    )
+                                                    [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                    | --spending-reference-tx-in-datum-file JSON_FILE
+                                                    | --spending-reference-tx-in-datum-value JSON_VALUE
+                                                    | --spending-reference-tx-in-inline-datum-present
+                                                    ]
+                                                    ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --spending-reference-tx-in-redeemer-value JSON_VALUE
+                                                    )
+                                                  | --simple-script-tx-in-reference TX_IN
+                                                  | --tx-in-script-file FILEPATH
+                                                    [
+                                                      [ --tx-in-datum-cbor-file CBOR_FILE
+                                                      | --tx-in-datum-file JSON_FILE
+                                                      | --tx-in-datum-value JSON_VALUE
+                                                      | --tx-in-inline-datum-present
+                                                      ]
+                                                      ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --tx-in-redeemer-file JSON_FILE
+                                                      | --tx-in-redeemer-value JSON_VALUE
+                                                      )]
+                                                  ])
+                                                [--read-only-tx-in-reference TX_IN]
+                                                [ --required-signer FILEPATH
+                                                | --required-signer-hash HASH
+                                                ]
+                                                [--tx-in-collateral TX_IN]
+                                                [--tx-out-return-collateral ADDRESS VALUE]
+                                                [--tx-total-collateral INTEGER]
+                                                [--tx-out ADDRESS VALUE
+                                                  [ --tx-out-datum-hash HASH
+                                                  | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                  | --tx-out-datum-hash-file JSON_FILE
+                                                  | --tx-out-datum-hash-value JSON_VALUE
+                                                  | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                  | --tx-out-datum-embed-file JSON_FILE
+                                                  | --tx-out-datum-embed-value JSON_VALUE
+                                                  | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                  | --tx-out-inline-datum-file JSON_FILE
+                                                  | --tx-out-inline-datum-value JSON_VALUE
+                                                  ]
+                                                  [--tx-out-reference-script-file FILEPATH]]
+                                                --change-address ADDRESS
+                                                [--mint VALUE
+                                                  ( --mint-script-file FILEPATH
+                                                    [ --mint-redeemer-cbor-file CBOR_FILE
+                                                    | --mint-redeemer-file JSON_FILE
+                                                    | --mint-redeemer-value JSON_VALUE
+                                                    ]
+                                                  | --simple-minting-script-tx-in-reference TX_IN
+                                                    --policy-id HASH
+                                                  | --mint-tx-in-reference TX_IN
+                                                    ( --mint-plutus-script-v2
+                                                    | --mint-plutus-script-v3
+                                                    )
+                                                    ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --mint-reference-tx-in-redeemer-value JSON_VALUE
+                                                    )
+                                                    --policy-id HASH
+                                                  )]
+                                                [--invalid-before SLOT]
+                                                [--invalid-hereafter SLOT]
+                                                [--certificate-file FILEPATH
+                                                  [ --certificate-script-file FILEPATH
+                                                    [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                    | --certificate-redeemer-file JSON_FILE
+                                                    | --certificate-redeemer-value JSON_VALUE
+                                                    ]
+                                                  | --certificate-tx-in-reference TX_IN
+                                                    ( --certificate-plutus-script-v2
+                                                    | --certificate-plutus-script-v3
+                                                    )
+                                                    ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                    )
+                                                  ]]
+                                                [--withdrawal WITHDRAWAL
+                                                  [ --withdrawal-script-file FILEPATH
+                                                    [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                    | --withdrawal-redeemer-file JSON_FILE
+                                                    | --withdrawal-redeemer-value JSON_VALUE
+                                                    ]
+                                                  | --withdrawal-tx-in-reference TX_IN
+                                                    ( --withdrawal-plutus-script-v2
+                                                    | --withdrawal-plutus-script-v3
+                                                    )
+                                                    ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                                                    )
+                                                  ]]
+                                                [ --json-metadata-no-schema
+                                                | --json-metadata-detailed-schema
+                                                ]
+                                                [--auxiliary-script-file FILEPATH]
+                                                [ --metadata-json-file FILEPATH
+                                                | --metadata-cbor-file FILEPATH
+                                                ]
+                                                [--vote-file FILEPATH
+                                                  [ --vote-script-file FILEPATH
+                                                    [ --vote-redeemer-cbor-file CBOR_FILE
+                                                    | --vote-redeemer-file JSON_FILE
+                                                    | --vote-redeemer-value JSON_VALUE
+                                                    ]
+                                                  | --vote-tx-in-reference TX_IN
+                                                    --vote-plutus-script-v3
+                                                    ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                    )
+                                                  ]]
+                                                [--proposal-file FILEPATH
+                                                  [ --proposal-script-file FILEPATH
+                                                    [ --proposal-redeemer-cbor-file CBOR_FILE
+                                                    | --proposal-redeemer-file JSON_FILE
+                                                    | --proposal-redeemer-value JSON_VALUE
+                                                    ]
+                                                  | --proposal-tx-in-reference TX_IN
+                                                    --proposal-plutus-script-v3
+                                                    ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                    )
+                                                  ]]
+                                                [--current-treasury-value]
+                                                [--treasury-donation LOVELACE]
+                                                [--out-canonical-cbor]
+                                                ( --out-file FILEPATH
+                                                | --calculate-plutus-script-cost FILEPATH
+                                                )
+                                                
+
+  Build a balanced transaction (automatically calculates fees)
+
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --script-valid           Assertion that the script is valid. (default)
+  --script-invalid         Assertion that the script is invalid. If a
+                           transaction is submitted with such a script, the
+                           script will fail and the collateral will be taken.
+  --witness-override WORD  Specify and override the number of witnesses the
+                           transaction requires.
+  --tx-in TX_IN            TxId#TxIx
+  --spending-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --spending-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --spending-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
+  --spending-reference-tx-in-inline-datum-present
+                           Inline datum present at transaction input.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --simple-script-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a simple reference script attached.
+  --tx-in-script-file FILEPATH
+                           The file containing the script to witness the
+                           spending of the transaction input.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
+  --tx-in-inline-datum-present
+                           Inline datum present at transaction input.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --read-only-tx-in-reference TX_IN
+                           Specify a read only reference input. This reference
+                           input is not witnessing anything it is simply
+                           provided in the plutus script context.
+  --required-signer FILEPATH
+                           Input filepath of the signing key (zero or more)
+                           whose signature is required.
+  --required-signer-hash HASH
+                           Hash of the verification key (zero or more) whose
+                           signature is required.
+  --tx-in-collateral TX_IN TxId#TxIx
+  --tx-out-return-collateral ADDRESS VALUE
+                           The transaction output as ADDRESS VALUE where ADDRESS
+                           is the Bech32-encoded address followed by the value
+                           in Lovelace. In the situation where your collateral
+                           txin over collateralizes the transaction, you can
+                           optionally specify a tx out of your choosing to
+                           return the excess Lovelace.
+  --tx-total-collateral INTEGER
+                           The total amount of collateral that will be collected
+                           as fees in the event of a Plutus script failure. Must
+                           be used in conjuction with
+                           "--tx-out-return-collateral".
+  --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
+                           is the Bech32-encoded address followed by the value
+                           in the multi-asset syntax (including simply
+                           Lovelace).
+  --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
+                           datum hash (in hex).
+  --tx-out-datum-hash-cbor-file CBOR_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
+                           The script datum hash for this tx output, by hashing
+                           the script datum given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
+                           The script datum to embed in the tx output as an
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
+                           The script datum to embed in the tx output as an
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
+                           The script datum to embed in the tx output as an
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-out-reference-script-file FILEPATH
+                           Reference script input file.
+  --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
+  --mint VALUE             Mint multi-asset value(s) with the multi-asset cli
+                           syntax. You must specify a script witness.
+  --mint-script-file FILEPATH
+                           The file containing the script to witness the minting
+                           of assets for a particular policy Id.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --simple-minting-script-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a simple reference script attached.
+  --policy-id HASH         Policy id of minting script.
+  --mint-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --mint-plutus-script-v2  Specify a plutus script v2 reference script.
+  --mint-plutus-script-v3  Specify a plutus script v3 reference script.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --policy-id HASH         Policy id of minting script.
+  --invalid-before SLOT    Time that transaction is valid from (in slots).
+  --invalid-hereafter SLOT Time that transaction is valid until (in slots).
+  --certificate-file FILEPATH
+                           Filepath of the certificate. This encompasses all
+                           types of certificates (stake pool certificates, stake
+                           key certificates etc). Optionally specify a script
+                           witness.
+  --certificate-script-file FILEPATH
+                           The file containing the script to witness the use of
+                           the certificate.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --certificate-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --certificate-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
+                           StakeAddress is the Bech32-encoded stake address
+                           followed by the amount in Lovelace. Optionally
+                           specify a script witness.
+  --withdrawal-script-file FILEPATH
+                           The file containing the script to witness the
+                           withdrawal of rewards.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --withdrawal-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --withdrawal-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --withdrawal-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --json-metadata-no-schema
+                           Use the "no schema" conversion from JSON to tx
+                           metadata (default).
+  --json-metadata-detailed-schema
+                           Use the "detailed schema" conversion from JSON to tx
+                           metadata.
+  --auxiliary-script-file FILEPATH
+                           Filepath of auxiliary script(s)
+  --metadata-json-file FILEPATH
+                           Filepath of the metadata file, in JSON format.
+  --metadata-cbor-file FILEPATH
+                           Filepath of the metadata, in raw CBOR format.
+  --vote-file FILEPATH     Filepath of the vote.
+  --vote-script-file FILEPATH
+                           The file containing the script to witness a vote
+  --vote-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --vote-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --vote-plutus-script-v3  Specify a plutus script v3 reference script.
+  --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --proposal-file FILEPATH Filepath of the proposal.
+  --proposal-script-file FILEPATH
+                           The file containing the script to witness a proposal
+  --proposal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --proposal-tx-in-reference TX_IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --proposal-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --current-treasury-value Include the current treasury value in the
+                           transaction. The value is obtained from the node.
+  --treasury-donation LOVELACE
+                           The donation to the treasury to perform.
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
+  --out-file FILEPATH      Output filepath of the JSON TxBody.
+  --calculate-plutus-script-cost FILEPATH
+                           Where to write the script cost information.
+                           (Deprecated: this flag is deprecated and will be
+                           removed in a future version. Please, use
+                           calculate-plutus-script-cost command instead.)
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_calculate-min-fee.cli
@@ -1,0 +1,39 @@
+Usage: cardano-cli dijkstra transaction calculate-min-fee --tx-body-file FILEPATH
+                                                            --protocol-params-file FILEPATH
+                                                            --witness-count NATURAL
+                                                            [--byron-witness-count NATURAL]
+                                                            [--reference-script-size NATURAL]
+                                                            [ --output-json
+                                                            | --output-text
+                                                            | --output-yaml
+                                                            ]
+                                                            [--out-file FILEPATH]
+                                                            [ --mainnet
+                                                            | --testnet-magic NATURAL
+                                                            ]
+                                                            [--tx-in-count NATURAL]
+                                                            [--tx-out-count NATURAL]
+                                                            
+
+  Calculate the minimum fee for a transaction.
+
+Available options:
+  --tx-body-file FILEPATH  Input filepath of the JSON TxBody.
+  --protocol-params-file FILEPATH
+                           Filepath of the JSON-encoded protocol parameters file
+  --witness-count NATURAL  The number of Shelley key witnesses.
+  --byron-witness-count NATURAL
+                           The number of Byron key witnesses (default is 0).
+  --reference-script-size NATURAL
+                           Total size in bytes of transaction reference scripts
+                           (default is 0).
+  --output-json            Format calculate-min-fee query output to JSON
+                           (default).
+  --output-text            Format calculate-min-fee query output to TEXT.
+  --output-yaml            Format calculate-min-fee query output to YAML.
+  --out-file FILEPATH      The output file.
+  --mainnet                DEPRECATED. This argument has no effect.
+  --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
+  --tx-in-count NATURAL    DEPRECATED. This argument has no effect.
+  --tx-out-count NATURAL   DEPRECATED. This argument has no effect.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_calculate-min-required-utxo.cli
@@ -1,0 +1,68 @@
+Usage: cardano-cli dijkstra transaction calculate-min-required-utxo --protocol-params-file FILEPATH
+                                                                      --tx-out ADDRESS VALUE
+                                                                      [ --tx-out-datum-hash HASH
+                                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                      | --tx-out-datum-hash-file JSON_FILE
+                                                                      | --tx-out-datum-hash-value JSON_VALUE
+                                                                      | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                      | --tx-out-datum-embed-file JSON_FILE
+                                                                      | --tx-out-datum-embed-value JSON_VALUE
+                                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                      | --tx-out-inline-datum-file JSON_FILE
+                                                                      | --tx-out-inline-datum-value JSON_VALUE
+                                                                      ]
+                                                                      [--tx-out-reference-script-file FILEPATH]
+                                                                      
+
+  Calculate the minimum required UTxO for a transaction output.
+
+Available options:
+  --protocol-params-file FILEPATH
+                           Filepath of the JSON-encoded protocol parameters file
+  --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
+                           is the Bech32-encoded address followed by the value
+                           in the multi-asset syntax (including simply
+                           Lovelace).
+  --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
+                           datum hash (in hex).
+  --tx-out-datum-hash-cbor-file CBOR_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
+                           The script datum hash for this tx output, by hashing
+                           the script datum given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
+                           The script datum to embed in the tx output as an
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
+                           The script datum to embed in the tx output as an
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
+                           The script datum to embed in the tx output as an
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-out-reference-script-file FILEPATH
+                           Reference script input file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_calculate-min-value.cli
@@ -1,0 +1,68 @@
+Usage: cardano-cli dijkstra transaction calculate-min-value --protocol-params-file FILEPATH
+                                                              --tx-out ADDRESS VALUE
+                                                              [ --tx-out-datum-hash HASH
+                                                              | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                              | --tx-out-datum-hash-file JSON_FILE
+                                                              | --tx-out-datum-hash-value JSON_VALUE
+                                                              | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                              | --tx-out-datum-embed-file JSON_FILE
+                                                              | --tx-out-datum-embed-value JSON_VALUE
+                                                              | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                              | --tx-out-inline-datum-file JSON_FILE
+                                                              | --tx-out-inline-datum-value JSON_VALUE
+                                                              ]
+                                                              [--tx-out-reference-script-file FILEPATH]
+                                                              
+
+  DEPRECATED: Use 'calculate-min-required-utxo' instead.
+
+Available options:
+  --protocol-params-file FILEPATH
+                           Filepath of the JSON-encoded protocol parameters file
+  --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
+                           is the Bech32-encoded address followed by the value
+                           in the multi-asset syntax (including simply
+                           Lovelace).
+  --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
+                           datum hash (in hex).
+  --tx-out-datum-hash-cbor-file CBOR_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
+                           The script datum hash for this tx output, by hashing
+                           the script datum given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
+                           The script datum to embed in the tx output as an
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
+                           The script datum to embed in the tx output as an
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
+                           The script datum to embed in the tx output as an
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-out-reference-script-file FILEPATH
+                           Reference script input file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_calculate-plutus-script-cost.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_calculate-plutus-script-cost.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli dijkstra transaction calculate-plutus-script-cost 
+                                                                       ( online
+                                                                       | offline
+                                                                       )
+                                                                       
+
+  Calculate the costs of the Plutus scripts of a given transaction.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  online                   Connect to a running node to get context info and
+                           calculate the costs of the Plutus scripts of a given
+                           transaction.
+  offline                  Manually provide get context info and calculate the
+                           costs of the Plutus scripts of a given transaction.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_calculate-plutus-script-cost_offline.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_calculate-plutus-script-cost_offline.cli
@@ -1,0 +1,54 @@
+Usage: cardano-cli dijkstra transaction calculate-plutus-script-cost offline 
+                                                                               ( --start-time-utc UTC_TIME
+                                                                               | --start-time-posix POSIX_TIME
+                                                                               | --genesis-file FILEPATH
+                                                                               )
+                                                                               [--unsafe-extend-safe-zone]
+                                                                               --era-history-file FILEPATH
+                                                                               --utxo-file FILEPATH
+                                                                               --protocol-params-file FILEPATH
+                                                                               --tx-file FILEPATH
+                                                                               [--out-file FILEPATH]
+                                                                               
+
+  Manually provide get context info and calculate the costs of the Plutus
+  scripts of a given transaction.
+
+Available options:
+  --start-time-utc UTC_TIME
+                           The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format.
+  --start-time-posix POSIX_TIME
+                           The genesis start time as POSIX seconds.
+  --genesis-file FILEPATH  Path to the Byron genesis file from which to get the
+                           start time.
+  --unsafe-extend-safe-zone
+                           Allow overriding the validity of the era history past
+                           the safe zone. The safe zone is a period of time
+                           during which we are sure there won't be any era
+                           transition (hard fork), and we are confident that the
+                           slot duration will not change, thus the conversion
+                           from slot numbers to POSIX times using the era
+                           history will be correct. This safe zone is
+                           conservative. Even if we are past the safe zone, if
+                           there hasn't been any era transition (hard fork)
+                           since we obtained it, we can continue safely using
+                           the era history. This flag essentially disables the
+                           safe zone check. This allows the user to use the era
+                           history past the safe zone, at the user's discretion.
+  --era-history-file FILEPATH
+                           Filepath of the era history file as produced by the
+                           'query era-history' command. The era history contains
+                           information about when era transitions happened and
+                           can be used together with the start time to convert
+                           slot numbers to POSIX times.
+  --utxo-file FILEPATH     Filepath to a JSON-encoded UTxO file as produced by
+                           the 'query utxo' command. Only UTxOs referenced by
+                           the transaction are needed, not the whole UTxO, but
+                           unnecessary info will be ignored.
+  --protocol-params-file FILEPATH
+                           Filepath of the JSON-encoded protocol parameters file
+  --tx-file FILEPATH       Filepath of the transaction whose Plutus scripts to
+                           calculate the cost.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_calculate-plutus-script-cost_online.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_calculate-plutus-script-cost_online.cli
@@ -1,0 +1,32 @@
+Usage: cardano-cli dijkstra transaction calculate-plutus-script-cost online 
+                                                                              [--cardano-mode
+                                                                                [--epoch-slots SLOTS]]
+                                                                              ( --mainnet
+                                                                              | --testnet-magic NATURAL
+                                                                              )
+                                                                              --socket-path SOCKET_PATH
+                                                                              --tx-file FILEPATH
+                                                                              [--out-file FILEPATH]
+                                                                              
+
+  Connect to a running node to get context info and calculate the costs of the
+  Plutus scripts of a given transaction.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --tx-file FILEPATH       Filepath of the transaction whose Plutus scripts to
+                           calculate the cost.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_hash-script-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_hash-script-data.cli
@@ -1,0 +1,21 @@
+Usage: cardano-cli dijkstra transaction hash-script-data 
+                                                           ( --script-data-cbor-file CBOR_FILE
+                                                           | --script-data-file JSON_FILE
+                                                           | --script-data-value JSON_VALUE
+                                                           )
+                                                           
+
+  Calculate the hash of script data.
+
+Available options:
+  --script-data-cbor-file CBOR_FILE
+                           The script data file. The file has to be in CBOR
+                           format.
+  --script-data-file JSON_FILE
+                           The script data file. The file must follow the
+                           detailed JSON schema for script data.
+  --script-data-value JSON_VALUE
+                           The script data. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_policyid.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_policyid.cli
@@ -1,0 +1,7 @@
+Usage: cardano-cli dijkstra transaction policyid --script-file FILEPATH 
+
+  Calculate the PolicyId from the monetary policy script.
+
+Available options:
+  --script-file FILEPATH   Filepath of the script.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_sign-witness.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_sign-witness.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli dijkstra transaction sign-witness --tx-body-file FILEPATH
+                                                       [--witness-file FILEPATH]
+                                                       [--out-canonical-cbor]
+                                                       --out-file FILEPATH
+                                                       
+
+  Assemble a tx body and witness(es) to form a transaction
+
+Available options:
+  --tx-body-file FILEPATH  Input filepath of the JSON TxBody.
+  --witness-file FILEPATH  Filepath of the witness
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_sign.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_sign.cli
@@ -1,0 +1,29 @@
+Usage: cardano-cli dijkstra transaction sign 
+                                               ( --tx-body-file FILEPATH
+                                               | --tx-file FILEPATH
+                                               )
+                                               [--signing-key-file FILEPATH
+                                                 [--address STRING]]
+                                               [ --mainnet
+                                               | --testnet-magic NATURAL
+                                               ]
+                                               [--out-canonical-cbor]
+                                               --out-file FILEPATH
+                                               
+
+  Sign a transaction
+
+Available options:
+  --tx-body-file FILEPATH  Input filepath of the JSON TxBody.
+  --tx-file FILEPATH       Input filepath of the JSON Tx.
+  --signing-key-file FILEPATH
+                           Input filepath of the signing key (one or more).
+  --address STRING         Byron address (Base58-encoded).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
+  --out-file FILEPATH      Output filepath of the JSON Tx.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_submit.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_submit.cli
@@ -1,0 +1,29 @@
+Usage: cardano-cli dijkstra transaction submit 
+                                                 [--cardano-mode
+                                                   [--epoch-slots SLOTS]]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 --socket-path SOCKET_PATH
+                                                 --tx-file FILEPATH
+                                                 
+
+  Submit a transaction to the local node whose Unix domain socket is obtained
+  from the CARDANO_NODE_SOCKET_PATH environment variable.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --tx-file FILEPATH       Filepath of the transaction you intend to submit.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_txid.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_txid.cli
@@ -1,0 +1,19 @@
+Usage: cardano-cli dijkstra transaction txid 
+                                               ( --tx-body-file FILEPATH
+                                               | --tx-file FILEPATH
+                                               )
+                                               [ --output-json
+                                               | --output-text
+                                               | --output-yaml
+                                               ]
+                                               
+
+  Print a transaction identifier.
+
+Available options:
+  --tx-body-file FILEPATH  Input filepath of the JSON TxBody.
+  --tx-file FILEPATH       Input filepath of the JSON Tx.
+  --output-json            Format output to JSON (default).
+  --output-text            Format output to TEXT.
+  --output-yaml            Format output to YAML.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_witness.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/dijkstra_transaction_witness.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli dijkstra transaction witness --tx-body-file FILEPATH
+                                                  --signing-key-file FILEPATH
+                                                  [--address STRING]
+                                                  [ --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  ]
+                                                  --out-file FILEPATH
+                                                  
+
+  Create a transaction witness
+
+Available options:
+  --tx-body-file FILEPATH  Input filepath of the JSON TxBody.
+  --signing-key-file FILEPATH
+                           Input filepath of the signing key (one or more).
+  --address STRING         Byron address (Base58-encoded).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text


### PR DESCRIPTION
# Context

Until now, only some commands were enabled for Dikjstra. This PR enables all of them.

# How to trust this PR

It is just really one line of code, the rest is all generated golden files. And the line of code matches the one for `Conway`. There is the question of when we set `latest` to Dijkstra, but I am guessing when it stops being experimental.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
