### PR TITLE
Replace getLocalChainTip with in-session queries in runQueryKesPeriodInfoCmd

### DIFF
--- a/.changes/20260901_fix_kes_period_info_hang.yml
+++ b/.changes/20260901_fix_kes_period_info_hang.yml
@@ -1,5 +1,5 @@
 project: cardano-cli
 pr: 1435
 kind:
-  - bugfix
-description: Fix `query kes-period-info` hanging indefinitely by replacing `getLocalChainTip` (which opens a second node connection) with `queryChainBlockNo`/`queryChainPoint` state queries within the existing connection.
+  - optimisation
+description: Replace `getLocalChainTip` with `queryChainBlockNo`/`queryChainPoint` in `runQueryKesPeriodInfoCmd` to avoid opening a redundant node connection.

--- a/.changes/20260901_fix_kes_period_info_hang.yml
+++ b/.changes/20260901_fix_kes_period_info_hang.yml
@@ -1,0 +1,5 @@
+project: cardano-cli
+pr: 1435
+kind:
+  - bugfix
+description: Fix `query kes-period-info` hanging indefinitely by replacing `getLocalChainTip` (which opens a second node connection) with `queryChainBlockNo`/`queryChainPoint` state queries within the existing connection.

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -381,7 +381,9 @@ runQueryKesPeriodInfoCmd
             -- it is equivalent to what we have on disk.
             ptclState <- easyRunQuery (queryProtocolState sbe)
 
-            chainTip <- liftIO $ getLocalChainTip nodeConnInfo
+            mChainBlockNo <- lift queryChainBlockNo & onLeft (left . QueryCmdUnsupportedNtcVersion)
+            mChainPoint <- lift queryChainPoint & onLeft (left . QueryCmdUnsupportedNtcVersion)
+            let chainTip = makeChainTip mChainBlockNo mChainPoint
 
             let curKesPeriod = currentKesPeriod chainTip gParams
                 oCertStartKesPeriod = opCertStartingKesPeriod opCert


### PR DESCRIPTION
`runQueryKesPeriodInfoCmd` called `getLocalChainTip` to get the chain tip, which opens a fresh connection to the node. This replaces it with `queryChainBlockNo`/`queryChainPoint`, which retrieve the same information through the already-open state query session — one fewer connection per invocation.

## Changelog

```yaml
- description: |
    Replace getLocalChainTip with queryChainBlockNo/queryChainPoint in runQueryKesPeriodInfoCmd to avoid opening a redundant node connection
  type:
    - optimisation
```