### PR TITLE
Replace caseShelleyToBabbageOrConwayEraOnwards with inEonForShelleyBasedEra

### DIFF
--- a/.changes/replace-era-case-combinators.yml
+++ b/.changes/replace-era-case-combinators.yml
@@ -1,0 +1,6 @@
+project: cardano-cli
+pr: 1438
+kind:
+  - refactoring
+description: |
+  Replaced uses of cardano-api's `caseShelleyToBabbageOrConwayEraOnwards` with `inEonForShelleyBasedEra`, and dropped the unused `ShelleyToBabbageEra` witness from `UpdateProtocolParametersPreConway` so the pre-Conway protocol parameters update parser no longer needs an era case split.

--- a/cardano-cli/src/Cardano/CLI/Compatible/Governance/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Governance/Option.hs
@@ -1,10 +1,11 @@
+{-# LANGUAGE GADTs #-}
+
 module Cardano.CLI.Compatible.Governance.Option
   ( pCompatibleGovernanceCmds
   )
 where
 
 import Cardano.Api
-import Cardano.Api.Experimental qualified as Exp
 
 import Cardano.CLI.Compatible.Governance.Command
 import Cardano.CLI.Compatible.Governance.Types
@@ -29,23 +30,29 @@ pCompatibleGovernanceCmds
 pCompatibleGovernanceCmds sbe =
   asum $
     catMaybes
-      [ inEonForShelleyBasedEra
-          ( subInfoParser
-              "governance"
-              ( Opt.progDesc $
-                  mconcat
-                    [ "Governance commands."
-                    ]
-              )
-              [ pCreateMirCertificatesCmds sbe
-              , pGovernanceGenesisKeyDelegationCertificate
-              , fmap CreateCompatibleProtocolParametersUpdateCmd <$> pGovernanceActionCmds sbe
-              ]
-          )
-          ( \w ->
-              fmap LatestCompatibleGovernanceCmds <$> Exp.obtainCommonConstraints w Latest.pGovernanceCmds
-          )
-          sbe
+      [ case sbe of
+          ShelleyBasedEraShelley -> preConway
+          ShelleyBasedEraAllegra -> preConway
+          ShelleyBasedEraMary -> preConway
+          ShelleyBasedEraAlonzo -> preConway
+          ShelleyBasedEraBabbage -> preConway
+          ShelleyBasedEraConway ->
+            fmap LatestCompatibleGovernanceCmds <$> Latest.pGovernanceCmds
+          ShelleyBasedEraDijkstra ->
+            fmap LatestCompatibleGovernanceCmds <$> Latest.pGovernanceCmds
+      ]
+ where
+  preConway =
+    subInfoParser
+      "governance"
+      ( Opt.progDesc $
+          mconcat
+            [ "Governance commands."
+            ]
+      )
+      [ pCreateMirCertificatesCmds sbe
+      , pGovernanceGenesisKeyDelegationCertificate
+      , fmap CreateCompatibleProtocolParametersUpdateCmd <$> pGovernanceActionCmds sbe
       ]
 
 pGovernanceActionCmds
@@ -64,7 +71,16 @@ pGovernanceActionCmds sbe =
 pUpdateProtocolParametersCmd
   :: ShelleyBasedEra era -> Parser (GovernanceActionProtocolParametersUpdateCmdArgs era)
 pUpdateProtocolParametersCmd sbe =
-  inEonForShelleyBasedEra (preConway sbe) postConway sbe
+  case sbe of
+    ShelleyBasedEraShelley -> preConway
+    ShelleyBasedEraAllegra -> preConway
+    ShelleyBasedEraMary -> preConway
+    ShelleyBasedEraAlonzo -> preConway
+    ShelleyBasedEraBabbage -> preConway
+    ShelleyBasedEraConway ->
+      mkCmd sbe (pure Nothing) (Just <$> pUpdateProtocolParametersPostConway)
+    ShelleyBasedEraDijkstra ->
+      mkCmd sbe (pure Nothing) (Just <$> pUpdateProtocolParametersPostConway)
  where
   -- The two branches build the same command and differ only in which of the two
   -- optional payloads they populate.
@@ -86,22 +102,8 @@ pUpdateProtocolParametersCmd sbe =
         )
       $ Opt.progDesc "Create a protocol parameters update."
 
-  preConway
-    :: ShelleyBasedEra era'
-    -> Parser (GovernanceActionProtocolParametersUpdateCmdArgs era')
-  preConway sbe' =
-    mkCmd sbe' (Just <$> pUpdateProtocolParametersPreConway) (pure Nothing)
-
-  postConway
-    :: ConwayEraOnwards era'
-    -> Parser (GovernanceActionProtocolParametersUpdateCmdArgs era')
-  postConway conwayOnwards =
-    mkCmd
-      (convert conwayOnwards)
-      (pure Nothing)
-      ( Just
-          <$> Exp.obtainCommonConstraints (convert conwayOnwards) pUpdateProtocolParametersPostConway
-      )
+  preConway =
+    mkCmd sbe (Just <$> pUpdateProtocolParametersPreConway) (pure Nothing)
 
 pUpdateProtocolParametersPreConway
   :: Parser (UpdateProtocolParametersPreConway era)

--- a/cardano-cli/src/Cardano/CLI/Compatible/Governance/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Governance/Option.hs
@@ -72,38 +72,52 @@ pUpdateProtocolParametersCmd
   :: ShelleyBasedEra era -> Parser (GovernanceActionProtocolParametersUpdateCmdArgs era)
 pUpdateProtocolParametersCmd sbe =
   case sbe of
-    ShelleyBasedEraShelley -> preConway
-    ShelleyBasedEraAllegra -> preConway
-    ShelleyBasedEraMary -> preConway
-    ShelleyBasedEraAlonzo -> preConway
-    ShelleyBasedEraBabbage -> preConway
-    ShelleyBasedEraConway ->
-      mkCmd sbe (pure Nothing) (Just <$> pUpdateProtocolParametersPostConway)
-    ShelleyBasedEraDijkstra ->
-      mkCmd sbe (pure Nothing) (Just <$> pUpdateProtocolParametersPostConway)
- where
-  -- The two branches build the same command and differ only in which of the two
-  -- optional payloads they populate.
-  mkCmd
-    :: ShelleyBasedEra era'
-    -> Parser (Maybe (UpdateProtocolParametersPreConway era'))
-    -> Parser (Maybe (UpdateProtocolParametersConwayOnwards era'))
-    -> Parser (GovernanceActionProtocolParametersUpdateCmdArgs era')
-  mkCmd sbe' pPreConway pConwayOnwards =
-    Opt.hsubparser
-      $ commandWithMetavar "create-protocol-parameters-update"
-      $ Opt.info
-        ( GovernanceActionProtocolParametersUpdateCmdArgs sbe'
-            <$> pPreConway
-            <*> pConwayOnwards
-            <*> pGovActionProtocolParametersUpdate sbe'
-            <*> pCostModelsFile sbe'
-            <*> pOutputFile
-        )
-      $ Opt.progDesc "Create a protocol parameters update."
+    ShelleyBasedEraShelley -> pPreConwayUpdateProtocolParametersCmd sbe
+    ShelleyBasedEraAllegra -> pPreConwayUpdateProtocolParametersCmd sbe
+    ShelleyBasedEraMary -> pPreConwayUpdateProtocolParametersCmd sbe
+    ShelleyBasedEraAlonzo -> pPreConwayUpdateProtocolParametersCmd sbe
+    ShelleyBasedEraBabbage -> pPreConwayUpdateProtocolParametersCmd sbe
+    ShelleyBasedEraConway -> pPostConwayUpdateProtocolParametersCmd sbe
+    ShelleyBasedEraDijkstra -> pPostConwayUpdateProtocolParametersCmd sbe
 
-  preConway =
-    mkCmd sbe (Just <$> pUpdateProtocolParametersPreConway) (pure Nothing)
+pPreConwayUpdateProtocolParametersCmd
+  :: ShelleyBasedEra era -> Parser (GovernanceActionProtocolParametersUpdateCmdArgs era)
+pPreConwayUpdateProtocolParametersCmd sbe =
+  Opt.hsubparser
+    $ commandWithMetavar "create-protocol-parameters-update"
+    $ Opt.info
+      ( GovernanceActionProtocolParametersUpdateCmdArgs sbe
+          <$> fmap Just pUpdateProtocolParametersPreConway
+          <*> pure Nothing
+          <*> pGovActionProtocolParametersUpdate sbe
+          <*> pCostModelsFile sbe
+          <*> pOutputFile
+      )
+    $ Opt.progDesc "Create a protocol parameters update."
+
+pPostConwayUpdateProtocolParametersCmd
+  :: ShelleyBasedEra era -> Parser (GovernanceActionProtocolParametersUpdateCmdArgs era)
+pPostConwayUpdateProtocolParametersCmd sbe =
+  Opt.hsubparser
+    $ commandWithMetavar "create-protocol-parameters-update"
+    $ Opt.info
+      ( GovernanceActionProtocolParametersUpdateCmdArgs sbe Nothing
+          <$> pConwayOnwards
+          <*> pGovActionProtocolParametersUpdate sbe
+          <*> pCostModelsFile sbe
+          <*> pOutputFile
+      )
+    $ Opt.progDesc "Create a protocol parameters update."
+ where
+  pConwayOnwards =
+    case sbe of
+      ShelleyBasedEraShelley -> pure Nothing
+      ShelleyBasedEraAllegra -> pure Nothing
+      ShelleyBasedEraMary -> pure Nothing
+      ShelleyBasedEraAlonzo -> pure Nothing
+      ShelleyBasedEraBabbage -> pure Nothing
+      ShelleyBasedEraConway -> Just <$> pUpdateProtocolParametersPostConway
+      ShelleyBasedEraDijkstra -> Just <$> pUpdateProtocolParametersPostConway
 
 pUpdateProtocolParametersPreConway
   :: Parser (UpdateProtocolParametersPreConway era)

--- a/cardano-cli/src/Cardano/CLI/Compatible/Governance/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Governance/Option.hs
@@ -1,14 +1,10 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Cardano.CLI.Compatible.Governance.Option
   ( pCompatibleGovernanceCmds
   )
 where
 
 import Cardano.Api
-import Cardano.Api.Experimental (obtainCommonConstraints)
+import Cardano.Api.Experimental qualified as Exp
 
 import Cardano.CLI.Compatible.Governance.Command
 import Cardano.CLI.Compatible.Governance.Types
@@ -33,22 +29,21 @@ pCompatibleGovernanceCmds
 pCompatibleGovernanceCmds sbe =
   asum $
     catMaybes
-      [ caseShelleyToBabbageOrConwayEraOnwards
-          ( const $
-              subInfoParser
-                "governance"
-                ( Opt.progDesc $
-                    mconcat
-                      [ "Governance commands."
-                      ]
-                )
-                [ pCreateMirCertificatesCmds sbe
-                , pGovernanceGenesisKeyDelegationCertificate
-                , fmap CreateCompatibleProtocolParametersUpdateCmd <$> pGovernanceActionCmds sbe
-                ]
+      [ inEonForShelleyBasedEra
+          ( subInfoParser
+              "governance"
+              ( Opt.progDesc $
+                  mconcat
+                    [ "Governance commands."
+                    ]
+              )
+              [ pCreateMirCertificatesCmds sbe
+              , pGovernanceGenesisKeyDelegationCertificate
+              , fmap CreateCompatibleProtocolParametersUpdateCmd <$> pGovernanceActionCmds sbe
+              ]
           )
           ( \w ->
-              fmap LatestCompatibleGovernanceCmds <$> obtainCommonConstraints (convert w) Latest.pGovernanceCmds
+              fmap LatestCompatibleGovernanceCmds <$> Exp.obtainCommonConstraints w Latest.pGovernanceCmds
           )
           sbe
       ]
@@ -63,58 +58,55 @@ pGovernanceActionCmds sbe =
           [ "Governance action commands."
           ]
     )
-    [ pGovernanceActionProtocolParametersUpdateCmd sbe
+    [ Just $ pUpdateProtocolParametersCmd sbe
     ]
-
-pGovernanceActionProtocolParametersUpdateCmd
-  :: ()
-  => ShelleyBasedEra era
-  -> Maybe (Parser (GovernanceActionProtocolParametersUpdateCmdArgs era))
-pGovernanceActionProtocolParametersUpdateCmd sbe = do
-  w <- forShelleyBasedEraMaybeEon sbe
-  pure $
-    pUpdateProtocolParametersCmd w
 
 pUpdateProtocolParametersCmd
   :: ShelleyBasedEra era -> Parser (GovernanceActionProtocolParametersUpdateCmdArgs era)
-pUpdateProtocolParametersCmd =
-  caseShelleyToBabbageOrConwayEraOnwards
-    ( \shelleyToBab ->
-        let sbe = convert shelleyToBab
-         in Opt.hsubparser
-              $ commandWithMetavar "create-protocol-parameters-update"
-              $ Opt.info
-                ( GovernanceActionProtocolParametersUpdateCmdArgs
-                    (convert shelleyToBab)
-                    <$> fmap Just (pUpdateProtocolParametersPreConway shelleyToBab)
-                    <*> pure Nothing
-                    <*> pGovActionProtocolParametersUpdate sbe
-                    <*> pCostModelsFile sbe
-                    <*> pOutputFile
-                )
-              $ Opt.progDesc "Create a protocol parameters update."
-    )
-    ( \conwayOnwards ->
-        let sbe = convert conwayOnwards
-            ppup = fmap Just (obtainCommonConstraints (convert conwayOnwards) pUpdateProtocolParametersPostConway)
-         in Opt.hsubparser
-              $ commandWithMetavar "create-protocol-parameters-update"
-              $ Opt.info
-                ( GovernanceActionProtocolParametersUpdateCmdArgs
-                    (convert conwayOnwards)
-                    Nothing
-                    <$> ppup
-                    <*> pGovActionProtocolParametersUpdate sbe
-                    <*> pCostModelsFile sbe
-                    <*> pOutputFile
-                )
-              $ Opt.progDesc "Create a protocol parameters update."
-    )
+pUpdateProtocolParametersCmd sbe =
+  inEonForShelleyBasedEra (preConway sbe) postConway sbe
+ where
+  -- The two branches build the same command and differ only in which of the two
+  -- optional payloads they populate.
+  mkCmd
+    :: ShelleyBasedEra era'
+    -> Parser (Maybe (UpdateProtocolParametersPreConway era'))
+    -> Parser (Maybe (UpdateProtocolParametersConwayOnwards era'))
+    -> Parser (GovernanceActionProtocolParametersUpdateCmdArgs era')
+  mkCmd sbe' pPreConway pConwayOnwards =
+    Opt.hsubparser
+      $ commandWithMetavar "create-protocol-parameters-update"
+      $ Opt.info
+        ( GovernanceActionProtocolParametersUpdateCmdArgs sbe'
+            <$> pPreConway
+            <*> pConwayOnwards
+            <*> pGovActionProtocolParametersUpdate sbe'
+            <*> pCostModelsFile sbe'
+            <*> pOutputFile
+        )
+      $ Opt.progDesc "Create a protocol parameters update."
+
+  preConway
+    :: ShelleyBasedEra era'
+    -> Parser (GovernanceActionProtocolParametersUpdateCmdArgs era')
+  preConway sbe' =
+    mkCmd sbe' (Just <$> pUpdateProtocolParametersPreConway) (pure Nothing)
+
+  postConway
+    :: ConwayEraOnwards era'
+    -> Parser (GovernanceActionProtocolParametersUpdateCmdArgs era')
+  postConway conwayOnwards =
+    mkCmd
+      (convert conwayOnwards)
+      (pure Nothing)
+      ( Just
+          <$> Exp.obtainCommonConstraints (convert conwayOnwards) pUpdateProtocolParametersPostConway
+      )
 
 pUpdateProtocolParametersPreConway
-  :: ShelleyToBabbageEra era -> Parser (UpdateProtocolParametersPreConway era)
-pUpdateProtocolParametersPreConway shelleyToBab =
-  UpdateProtocolParametersPreConway shelleyToBab
+  :: Parser (UpdateProtocolParametersPreConway era)
+pUpdateProtocolParametersPreConway =
+  UpdateProtocolParametersPreConway
     <$> pEpochNoUpdateProp
     <*> pProtocolParametersUpdateGenesisKeys
 

--- a/cardano-cli/src/Cardano/CLI/Compatible/Governance/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Governance/Run.hs
@@ -132,7 +132,7 @@ shelleyToBabbageProtocolParametersUpdate
 shelleyToBabbageProtocolParametersUpdate sbe args = do
   let oFp = uppFilePath args
       anyEra = AnyShelleyBasedEra sbe
-  UpdateProtocolParametersPreConway _stB expEpoch genesisVerKeys <-
+  UpdateProtocolParametersPreConway expEpoch genesisVerKeys <-
     fromExceptTCli $
       hoistMaybe (GovernanceActionsValueUpdateProtocolParametersNotFound anyEra) $
         uppPreConway args

--- a/cardano-cli/src/Cardano/CLI/Compatible/Governance/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Governance/Types.hs
@@ -38,8 +38,7 @@ data GovernanceActionProtocolParametersUpdateCmdArgs era
 
 data UpdateProtocolParametersPreConway era
   = UpdateProtocolParametersPreConway
-  { eon :: !(ShelleyToBabbageEra era)
-  , expiryEpoch :: !EpochNo
+  { expiryEpoch :: !EpochNo
   , genesisVerificationKeys :: ![VerificationKeyFile In]
   }
 

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Option.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.CLI.Compatible.Transaction.Option
   ( pAllCompatibleTransactionCommands
@@ -150,8 +151,8 @@ pTxOutDatum sbe =
 
 pRefScriptFp :: ShelleyBasedEra era -> Parser ReferenceScriptAnyEra
 pRefScriptFp =
-  caseShelleyToBabbageOrConwayEraOnwards
-    (const $ pure ReferenceScriptAnyEraNone)
+  inEonForShelleyBasedEra @ConwayEraOnwards
+    (pure ReferenceScriptAnyEraNone)
     ( const $
         ReferenceScriptAnyEra
           <$> parseFilePath "tx-out-reference-script-file" "Reference script input file."
@@ -163,7 +164,7 @@ pVoteFiles
   -> BalanceTxExecUnits
   -> Parser [(VoteFile In, Maybe AnyNonAssetScript)]
 pVoteFiles sbe bExUnits =
-  caseShelleyToBabbageOrConwayEraOnwards
-    (const $ pure [])
+  inEonForShelleyBasedEra @ConwayEraOnwards
+    (pure [])
     (const . many $ pVoteFile bExUnits)
     sbe

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
@@ -78,13 +78,12 @@ runCompatibleTransactionCmd
           ]
 
     (protocolUpdates, votes) :: (AnyProtocolUpdate era, AnyVote era) <-
-      caseShelleyToBabbageOrConwayEraOnwards
-        ( const $ do
-            case mUpdateProposal of
-              Nothing -> return (NoPParamsUpdate sbe, NoVotes)
-              Just p -> do
-                pparamUpdate <- readUpdateProposalFile p
-                return (pparamUpdate, NoVotes)
+      inEonForShelleyBasedEra
+        ( case mUpdateProposal of
+            Nothing -> return (NoPParamsUpdate sbe, NoVotes)
+            Just p -> do
+              pparamUpdate <- readUpdateProposalFile p
+              return (pparamUpdate, NoVotes)
         )
         ( \w ->
             case mProposalProcedure of


### PR DESCRIPTION
# Context

[IntersectMBO/cardano-api#1326](https://github.com/IntersectMBO/cardano-api/pull/1326) removes the era case combinators, including `caseShelleyToBabbageOrConwayEraOnwards`. This migrates the call sites here ahead of that.

Most sites ignored one or both of the witnesses that combinator hands out, so they become `inEonForShelleyBasedEra`.

`pUpdateProtocolParametersCmd` was the awkward one: it matched on all seven `ShelleyBasedEra` constructors, but only to build a `ShelleyToBabbageEra` for the `eon` field of `UpdateProtocolParametersPreConway` — a field nothing ever read. Dropping the field removes the match. Its two branches then differ only in which optional payload they fill, so the shared scaffolding moves into `mkCmd`.

`inEonForShelleyBasedEra` is already in the released cardano-api, so this can merge before or after the cardano-api PR.

# How to trust this PR

No change to the CLI's interface — same commands, same help output, which the golden tests cover.

```bash
cabal build cardano-cli -j4
cabal test cardano-cli-golden cardano-cli-test -j4
```

Locally: clean build, `cardano-cli-golden` 815/815, `cardano-cli-test` 73/73, no new `hlint` hints.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
