### PR TITLE
Integrate cardano-api 11.7.0.0

### DIFF
--- a/.changes/20260904_074500_cardano-cli_mgalazyn_integrate_cardano_api_11_7_0_0.yml
+++ b/.changes/20260904_074500_cardano-cli_mgalazyn_integrate_cardano_api_11_7_0_0.yml
@@ -1,0 +1,6 @@
+description: |
+  Update cardano-api to 11.7.0.0, fixing plutus redeemer pointer indexing in transaction building: proposal pointers now follow the transaction's insertion order and certificate pointers count unwitnessed certificates.
+kind:
+- bugfix
+pr: 1440
+project: cardano-cli

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2026-07-30T07:30:12Z
-  , cardano-haskell-packages 2026-09-02T08:49:12Z
+  , cardano-haskell-packages 2026-09-04T06:57:08Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -246,7 +246,7 @@ library
     binary,
     bytestring,
     canonical-json,
-    cardano-api ^>=11.6,
+    cardano-api ^>=11.7,
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class ^>=2.5,

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
@@ -194,8 +194,8 @@ readCertificateScriptWitnessSbe sbe (AnyNonAssetScriptPlutus plutusReq) =
               redeemer
               execUnits
 
--- | Create 'TxCertificates'. Note that 'Certificate era' will be deduplicated. Only Certificates with a
--- stake credential will be in the result.
+-- | Create 'TxCertificates'. Note that 'Certificate era' will be deduplicated. A witness is attached
+-- only to certificates which require one.
 --
 -- Note that, when building a transaction in Conway era, a witness is not required for staking credential
 -- registration, but this is only the case during the transitional period of Conway era and only for staking
@@ -206,15 +206,15 @@ mkTxCertificatesSbe
    . ShelleyBasedEra era
   -> [(Exp.Certificate (ShelleyLedgerEra era), Exp.AnyWitness (ShelleyLedgerEra era))]
   -> Exp.TxCertificates (ShelleyLedgerEra era)
-mkTxCertificatesSbe era certs = Exp.TxCertificates . OMap.fromList $ map getStakeCred certs
+mkTxCertificatesSbe era certs = Exp.TxCertificates . OMap.fromList $ map attachWitness certs
  where
-  getStakeCred
+  attachWitness
     :: (Exp.Certificate (ShelleyLedgerEra era), Exp.AnyWitness (ShelleyLedgerEra era))
     -> ( Exp.Certificate (ShelleyLedgerEra era)
-       , Maybe (StakeCredential, Exp.AnyWitness (ShelleyLedgerEra era))
+       , Maybe (Exp.AnyWitness (ShelleyLedgerEra era))
        )
-  getStakeCred (c@(Exp.Certificate cert), wit) =
-    (c, (,wit) <$> Compatible.getTxCertWitness (convert era) cert)
+  attachWitness (c@(Exp.Certificate cert), wit) =
+    (c, wit <$ Compatible.getTxCertWitness (convert era) cert)
 
 readUpdateProposalFile
   :: Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1788340302,
-        "narHash": "sha256-4xBiG33FSaLyIWGf3uzA1YWPvwBFcJ7zd1QgXxtkDm0=",
+        "lastModified": 1788506871,
+        "narHash": "sha256-hHaUZtnMc5eZpBhK+DSps14UYjgZ4Q+Ax2hjntKZQWA=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "097b28f32f34294b6f01e682683ab375e3ca0e5e",
+        "rev": "5fe1c08b9ee30ccf90eff55cb7a014999a7b7367",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Context

Integrates the cardano-api 11.7.0.0 release.

Picks up the plutus redeemer pointer indexing fix ([cardano-api#1288](https://github.com/IntersectMBO/cardano-api/pull/1288)): proposal pointers now follow the transaction's insertion order and certificate pointers count unwitnessed certificates.

- Bumps the `cardano-api` bound to `^>=11.7` and refreshes the CHaP pin (`cabal.project` index-state and `flake.lock`).
- Adapts `mkTxCertificatesSbe` to the new `TxCertificates` shape, which no longer pairs each certificate witness with a stake credential (the credential is derived from the certificate).

# How to trust this PR

The only code change is in `Cardano.CLI.Compatible.Transaction.Run.mkTxCertificatesSbe`, following the upstream API change. The rest is dependency pinning. CI builds and tests cover it.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
