### PR TITLE
Pin the cardano-keys extraction PRs and adapt to them

### DIFF
--- a/.changes/pin-cardano-keys-extraction.yml
+++ b/.changes/pin-cardano-keys-extraction.yml
@@ -1,0 +1,6 @@
+project: cardano-cli
+pr: 1444
+kind:
+  - maintenance
+description: |
+  Pinned the cardano-keys extraction (IntersectMBO/cardano-keys#4) and its cardano-api adoption (IntersectMBO/cardano-api#1332) as temporary source-repository-packages, and adapted to the two API changes: `getKesPeriod` returns `KESPeriod` instead of `Word`, and `textEnvelopeType` is a free function rather than a class method.

--- a/.github/master-check-exceptions.list
+++ b/.github/master-check-exceptions.list
@@ -1,0 +1,2 @@
+https://github.com/IntersectMBO/cardano-keys
+https://github.com/IntersectMBO/cardano-api

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -89,6 +89,15 @@ jobs:
 
     - uses: actions/checkout@v6
 
+    # Git for Windows refuses paths longer than 260 characters unless
+    # core.longpaths is set; cabal clones source-repository-packages into
+    # dist-newstyle/src/<name>-<hash>/, deep enough for the pinned
+    # cardano-api's golden files to exceed the limit. Drop once
+    # input-output-hk/actions#44 ships this in the base action.
+    - name: Enable long file paths for Git on Windows
+      if: ${{ matrix.sys.os == 'windows-latest' }}
+      run: git config --system core.longpaths true
+
     - name: Cache and install Cabal dependencies
       uses: input-output-hk/cardano-dev/actions/cabal-cache@cabal-cache-0.0.1.0
       with:

--- a/cabal.project
+++ b/cabal.project
@@ -66,6 +66,28 @@ semaphore: True
 -- Always write GHC env files, because they are needed for ghci.
 write-ghc-environment-files: always
 
+-- Temporary, until the cardano-keys extraction lands in CHaP: the key layer
+-- extracted from cardano-api (IntersectMBO/cardano-keys#4) and the cardano-api
+-- change that adopts it (IntersectMBO/cardano-api#1332).
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/cardano-keys
+  tag: df20ae67e89920fdc65cd3c30a720dbcbf9e5344
+  subdir: cardano-keys
+  --sha256: sha256-TILlrhcfUOgVkrG5vi6QL8sjTaFvBKJIrnPvURG94A4=
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/cardano-api
+  tag: a6fec2be2c931a8ebaeeb4ee934cc67c144eb29c
+  subdir: cardano-api
+  --sha256: sha256-Ox31/CCDgmHjLQDhJR9wG3DpRncZ331yp5v2pb7p/9k=
+
+constraints:
+  -- cardano-crypto-class caps crypton below 1.1; without this the GHC 9.14
+  -- solver greedily picks crypton 1.1.4 and cannot resolve the plan.
+  , crypton < 1.1
+
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -79,6 +79,7 @@ import Cardano.Ledger.Address qualified as L
 import Cardano.Ledger.Api.State.Query qualified as L
 import Cardano.Ledger.Api.Tx qualified as L
 import Cardano.Ledger.Conway.State (ChainAccountState (..))
+import Cardano.Protocol.TPraos.OCert (unKESPeriod)
 import Cardano.Slotting.EpochInfo (EpochInfo (..), epochInfoSlotToUTCTime, hoistEpochInfo)
 import Cardano.Slotting.Time (RelativeTime (..), toRelativeTime)
 
@@ -427,7 +428,7 @@ runQueryKesPeriodInfoCmd
        in CurrentKesPeriod $ unSlotNo currSlot `div` slotsPerKesPeriod
 
     opCertStartingKesPeriod :: OperationalCertificate -> OpCertStartingKesPeriod
-    opCertStartingKesPeriod = OpCertStartingKesPeriod . fromIntegral . getKesPeriod
+    opCertStartingKesPeriod = OpCertStartingKesPeriod . fromIntegral . unKESPeriod . getKesPeriod
 
     opCertEndKesPeriod :: GenesisParameters era -> OperationalCertificate -> OpCertEndingKesPeriod
     opCertEndKesPeriod gParams oCert =

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/Operational.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/Operational.hs
@@ -2,7 +2,7 @@
 
 module Test.Golden.Shelley.TextEnvelope.Certificates.Operational where
 
-import Cardano.Api (HasTextEnvelope (..))
+import Cardano.Api (textEnvelopeType)
 import Cardano.Api.Experimental.Certificate (AsType (AsOperationalCertificate))
 
 import Control.Monad (void)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
@@ -3,7 +3,7 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.ExtendedPaymentKeys where
 
-import Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), textEnvelopeType)
 
 import Control.Monad (void)
 import Text.Regex.TDFA ((=~))

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
@@ -2,7 +2,7 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.GenesisDelegateKeys where
 
-import Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), textEnvelopeType)
 import Cardano.Api.Experimental.Certificate (AsType (AsOperationalCertificateIssueCounter))
 
 import Control.Monad (void)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
@@ -2,7 +2,7 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.GenesisKeys where
 
-import Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), textEnvelopeType)
 
 import Control.Monad (void)
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
@@ -2,7 +2,7 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.GenesisUTxOKeys where
 
-import Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), textEnvelopeType)
 
 import Control.Monad (void)
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
@@ -3,7 +3,7 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.KESKeys where
 
-import Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), textEnvelopeType)
 
 import Control.Monad (void)
 import Text.Regex.TDFA ((=~))

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
@@ -3,7 +3,7 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.PaymentKeys where
 
-import Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), textEnvelopeType)
 
 import Control.Monad (void)
 import Text.Regex.TDFA ((=~))

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
@@ -3,7 +3,7 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys where
 
-import Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), textEnvelopeType)
 
 import Control.Monad (void)
 import Text.Regex.TDFA ((=~))

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
@@ -3,7 +3,7 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys where
 
-import Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), textEnvelopeType)
 
 import Control.Monad (void)
 import Text.Regex.TDFA ((=~))


### PR DESCRIPTION
#  **DO NOT MERGE: work in progress and contains SRPs** 

# Context

In https://github.com/IntersectMBO/cardano-keys/pull/4, we move cardano key machinery to a separate repo with fewer dependencies than `cardano-api`, so that they can be used by testing projects in the consensus repos, among others, without having to depend in the full stack that `cardano-api` requires.

This PR pins `cardano-keys` https://github.com/IntersectMBO/cardano-keys/pull/4 and https://github.com/IntersectMBO/cardano-api/pull/1332 with SRPs to ensure the integration will work once releases start.

# How to trust this PR

Really small changes and just test that CI works. But make sure there are no SRPs or master exceptions before merging.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
